### PR TITLE
feat: add search within book

### DIFF
--- a/apps/main/src-tauri/migrations/2026-04-19-000000_create_fts_index/down.sql
+++ b/apps/main/src-tauri/migrations/2026-04-19-000000_create_fts_index/down.sql
@@ -1,0 +1,4 @@
+DROP TRIGGER IF EXISTS chunk_data_ai;
+DROP TRIGGER IF EXISTS chunk_data_ad;
+DROP TRIGGER IF EXISTS chunk_data_au;
+DROP TABLE IF EXISTS chunk_data_fts;

--- a/apps/main/src-tauri/migrations/2026-04-19-000000_create_fts_index/up.sql
+++ b/apps/main/src-tauri/migrations/2026-04-19-000000_create_fts_index/up.sql
@@ -1,0 +1,23 @@
+-- FTS5 content-sync table mirroring chunk_data.data
+CREATE VIRTUAL TABLE chunk_data_fts USING fts5(
+  data,
+  content='chunk_data',
+  content_rowid='id'
+);
+
+-- Keep FTS index in sync with chunk_data
+CREATE TRIGGER chunk_data_ai AFTER INSERT ON chunk_data BEGIN
+  INSERT INTO chunk_data_fts(rowid, data) VALUES (new.id, new.data);
+END;
+
+CREATE TRIGGER chunk_data_ad AFTER DELETE ON chunk_data BEGIN
+  INSERT INTO chunk_data_fts(chunk_data_fts, rowid, data) VALUES('delete', old.id, old.data);
+END;
+
+CREATE TRIGGER chunk_data_au AFTER UPDATE ON chunk_data BEGIN
+  INSERT INTO chunk_data_fts(chunk_data_fts, rowid, data) VALUES('delete', old.id, old.data);
+  INSERT INTO chunk_data_fts(rowid, data) VALUES (new.id, new.data);
+END;
+
+-- Backfill FTS index with existing chunk_data rows
+INSERT INTO chunk_data_fts(rowid, data) SELECT id, data FROM chunk_data;

--- a/apps/main/src-tauri/src/lib.rs
+++ b/apps/main/src-tauri/src/lib.rs
@@ -148,6 +148,7 @@ pub fn run() {
             sql::has_saved_epub_data,
             sql::update_book_location,
             sql::get_text_from_vector_id,
+            sql::search_book_text,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/main/src-tauri/src/sql.rs
+++ b/apps/main/src-tauri/src/sql.rs
@@ -61,6 +61,16 @@ pub struct PageData {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+pub struct TextSearchResult {
+    pub id: i64,
+    pub page_number: i32,
+    pub book_id: i32,
+    pub data: String,
+    pub snippet: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Book {
     pub id: i32,
     pub kind: String,
@@ -458,6 +468,54 @@ pub fn get_text_from_vector_id(vector_id: i64) -> Result<String, String> {
     Ok(result.unwrap_or_default())
 }
 
+#[tauri::command]
+pub fn search_book_text(query: String, book_id: i32) -> Result<Vec<TextSearchResult>, String> {
+    let pool = DB_POOL.get().ok_or("Database pool not initialized")?;
+    let mut conn = pool
+        .get()
+        .map_err(|e| format!("Failed to get connection: {}", e))?;
+
+    // FTS5 MATCH query with snippet generation, filtered by bookId
+    #[derive(diesel::QueryableByName)]
+    struct RawSearchResult {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        id: i64,
+        #[diesel(sql_type = diesel::sql_types::Integer, column_name = "pageNumber")]
+        page_number: i32,
+        #[diesel(sql_type = diesel::sql_types::Integer, column_name = "bookId")]
+        book_id: i32,
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        data: String,
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        snippet: String,
+    }
+
+    let results: Vec<RawSearchResult> = diesel::sql_query(
+        "SELECT chunk_data.id, chunk_data.pageNumber, chunk_data.bookId, chunk_data.data, \
+         snippet(chunk_data_fts, 0, '<mark>', '</mark>', '...', 40) as snippet \
+         FROM chunk_data_fts \
+         JOIN chunk_data ON chunk_data.id = chunk_data_fts.rowid \
+         WHERE chunk_data.bookId = ?1 AND chunk_data_fts MATCH ?2 \
+         ORDER BY rank \
+         LIMIT 50"
+    )
+    .bind::<diesel::sql_types::Integer, _>(&book_id)
+    .bind::<diesel::sql_types::Text, _>(&query)
+    .load(&mut conn)
+    .map_err(|e| format!("FTS search failed: {}", e))?;
+
+    Ok(results
+        .into_iter()
+        .map(|r| TextSearchResult {
+            id: r.id,
+            page_number: r.page_number,
+            book_id: r.book_id,
+            data: r.data,
+            snippet: r.snippet,
+        })
+        .collect())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::test_fixtures;
@@ -467,7 +525,7 @@ mod tests {
 
     use super::{
         delete_book, get_all_page_data_by_book_id, get_book, save_book, save_page_data_many,
-        update_book_cover, BookInsertable, ChunkDataInsertable,
+        search_book_text, update_book_cover, BookInsertable, ChunkDataInsertable,
     };
 
     #[test]
@@ -501,6 +559,58 @@ mod tests {
         expect!(result[1].data.as_str()).to(be_equal_to("test2"));
         Ok(())
     }
+
+    #[test]
+    fn test_search_book_text() -> Result<(), String> {
+        let _setup = init_test_database_setup()?;
+        let book_id = 1;
+
+        let page_data = vec![
+            ChunkDataInsertable {
+                id: Some(100),
+                page_number: 1,
+                book_id,
+                data: "The philosophy of consciousness has been debated for centuries.".to_string(),
+            },
+            ChunkDataInsertable {
+                id: Some(101),
+                page_number: 2,
+                book_id,
+                data: "Quantum mechanics describes the behavior of particles at atomic scales.".to_string(),
+            },
+            ChunkDataInsertable {
+                id: Some(102),
+                page_number: 3,
+                book_id,
+                data: "Neural networks in the brain give rise to consciousness and awareness.".to_string(),
+            },
+        ];
+        save_page_data_many(page_data)?;
+
+        // Search for "consciousness" — should find chunks on pages 1 and 3
+        let results = search_book_text("consciousness".to_string(), book_id)?;
+        expect!(results.len()).to(be_equal_to(2));
+        // Results should be from pages 1 and 3 (order by FTS rank)
+        let page_numbers: Vec<i32> = results.iter().map(|r| r.page_number).collect();
+        expect!(page_numbers.contains(&1)).to(be_equal_to(true));
+        expect!(page_numbers.contains(&3)).to(be_equal_to(true));
+        // Snippets should contain <mark> tags
+        for result in &results {
+            expect!(result.snippet.contains("<mark>")).to(be_equal_to(true));
+        }
+
+        // Search for "quantum" — should find only page 2
+        let results2 = search_book_text("quantum".to_string(), book_id)?;
+        expect!(results2.len()).to(be_equal_to(1));
+        expect!(results2[0].page_number).to(be_equal_to(2));
+
+        // Search for a term that doesn't exist
+        let results3 = search_book_text("nonexistentterm".to_string(), book_id)?;
+        expect!(results3.is_empty()).to(be_equal_to(true));
+
+        Ok(())
+    }
+
     // embed data , save vectors and query the text from the vector id and fetch the text from the vector id to confirm
     #[tokio::test]
     async fn test_embed_data_and_save_vectors() -> Result<(), String> {

--- a/apps/main/src-tauri/src/sql.rs
+++ b/apps/main/src-tauri/src/sql.rs
@@ -563,23 +563,25 @@ mod tests {
     #[test]
     fn test_search_book_text() -> Result<(), String> {
         let _setup = init_test_database_setup()?;
-        let book_id = 1;
+        // Use a unique book_id to avoid collisions with other tests
+        // (DB_POOL is shared via OnceLock across all tests)
+        let book_id = 999;
 
         let page_data = vec![
             ChunkDataInsertable {
-                id: Some(100),
+                id: Some(999100),
                 page_number: 1,
                 book_id,
                 data: "The philosophy of consciousness has been debated for centuries.".to_string(),
             },
             ChunkDataInsertable {
-                id: Some(101),
+                id: Some(999101),
                 page_number: 2,
                 book_id,
                 data: "Quantum mechanics describes the behavior of particles at atomic scales.".to_string(),
             },
             ChunkDataInsertable {
-                id: Some(102),
+                id: Some(999102),
                 page_number: 3,
                 book_id,
                 data: "Neural networks in the brain give rise to consciousness and awareness.".to_string(),

--- a/apps/main/src/components/djvu/DjvuView.tsx
+++ b/apps/main/src/components/djvu/DjvuView.tsx
@@ -11,13 +11,15 @@ import type { Book } from "@/generated";
 import { BackButton } from "@components/BackButton";
 import TTSControls from "@components/TTSControls";
 import { IconButton } from "@components/ui/IconButton";
-import { ChevronLeft, ChevronRight, MessageSquare, ZoomIn, ZoomOut } from "lucide-react";
+import { ChevronLeft, ChevronRight, MessageSquare, ZoomIn, ZoomOut, Search } from "lucide-react";
 import { bookIdAtom } from "@/stores/epub_atoms";
 import { eventBus, EventBusEvent } from "@/utils/bus";
 import type { ParagraphWithIndex } from "@/utils/bus";
 import { processEpubJob } from "@/modules/process_epub";
 import type { PageDataInsertable } from "@/modules/kysley";
 import { ChatPanel } from "@/components/chat/ChatPanel";
+import { SearchPanel } from "@/components/search/SearchPanel";
+import type { BookSearchResult } from "@/hooks/useBookSearch";
 import { useRequireAuth } from "@/hooks/useRequireAuth";
 import { db } from "@/modules/kysley";
 import { stringToNumberID } from "@components/lib/utils";
@@ -48,7 +50,26 @@ export function DjvuView({ book }: { book: Book }) {
   const mountedRef = useRef(true);
   const embeddingsProcessedRef = useRef(false);
   const [chatPanelOpen, setChatPanelOpen] = useState(false);
+  const [searchPanelOpen, setSearchPanelOpen] = useState(false);
   const { requireAuth, AuthDialog } = useRequireAuth();
+
+  const handleSearchNavigate = useCallback((result: BookSearchResult) => {
+    if (result.pageNumber !== undefined) {
+      setCurrentPage(result.pageNumber);
+    }
+  }, []);
+
+  // Cmd+F / Ctrl+F keyboard shortcut
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        e.preventDefault();
+        setSearchPanelOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
   const bookSyncIdRef = useRef<string | null>(null);
 
   // Set bookIdAtom for voice chat
@@ -344,6 +365,13 @@ export function DjvuView({ book }: { book: Book }) {
           >
             <MessageSquare size={20} />
           </button>
+          <IconButton
+            onClick={() => setSearchPanelOpen(true)}
+            className="hover:bg-black/10 dark:hover:bg-white/10 border-none"
+            aria-label="Search in book"
+          >
+            <Search size={20} />
+          </IconButton>
           <BackButton />
         </div>
       </div>
@@ -445,6 +473,15 @@ export function DjvuView({ book }: { book: Book }) {
         rendition={null}
         open={chatPanelOpen}
         onOpenChange={setChatPanelOpen}
+      />
+
+      {/* Search Panel */}
+      <SearchPanel
+        bookId={book.id}
+        bookFormat="djvu"
+        open={searchPanelOpen}
+        onOpenChange={setSearchPanelOpen}
+        onNavigate={handleSearchNavigate}
       />
     </div>
   );

--- a/apps/main/src/components/epub.tsx
+++ b/apps/main/src/components/epub.tsx
@@ -10,7 +10,7 @@ import { Radio, RadioGroup } from "@components/ui/Radio";
 import { ThemeType } from "@/themes/common";
 import { themes } from "@/themes/themes";
 import createIReactReaderTheme from "@/themes/readerThemes";
-import { Palette, Highlighter, MessageSquare } from "lucide-react";
+import { Palette, Highlighter, MessageSquare, Search } from "lucide-react";
 import TTSControls from "@components/TTSControls";
 import { Rendition } from "epubjs/types";
 import { convertFileSrc } from "@tauri-apps/api/core";
@@ -45,6 +45,8 @@ import { SelectionPopover } from "@/components/highlights/SelectionPopover";
 import { HighlightsPanel } from "@/components/highlights/HighlightsPanel";
 import { ReaderSettings } from "@/components/reader/ReaderSettings";
 import { ChatPanel } from "@/components/chat/ChatPanel";
+import { SearchPanel } from "@/components/search/SearchPanel";
+import type { BookSearchResult } from "@/hooks/useBookSearch";
 import { useRequireAuth } from "@/hooks/useRequireAuth";
 
 function cn(...classes: string[]) {
@@ -75,7 +77,28 @@ export function EpubView({ book }: { book: Book }): React.JSX.Element {
   } | null>(null);
   const [highlightsPanelOpen, setHighlightsPanelOpen] = useState(false);
   const [chatPanelOpen, setChatPanelOpen] = useState(false);
+  const [searchPanelOpen, setSearchPanelOpen] = useState(false);
   const { requireAuth, AuthDialog } = useRequireAuth();
+
+  const handleSearchNavigate = useCallback((result: BookSearchResult) => {
+    if (result.cfi && rendition) {
+      void rendition.display(result.cfi);
+    } else if (result.pageNumber && rendition) {
+      void rendition.display(result.pageNumber);
+    }
+  }, [rendition]);
+
+  // Cmd+F / Ctrl+F keyboard shortcut
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        e.preventDefault();
+        setSearchPanelOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   // Look up the book's sync_id for highlight storage
   useEffect(() => {
@@ -268,6 +291,13 @@ export function EpubView({ book }: { book: Book }): React.JSX.Element {
         <BackButton />
 
         <button
+          onClick={() => setSearchPanelOpen(true)}
+          className={cn("p-2 rounded-md", getTextColor())}
+          aria-label="Search in book"
+        >
+          <Search size={20} />
+        </button>
+        <button
           onClick={() => setHighlightsPanelOpen(true)}
           className={cn("p-2 rounded-md", getTextColor())}
           aria-label="Open highlights panel"
@@ -437,6 +467,15 @@ export function EpubView({ book }: { book: Book }): React.JSX.Element {
       />
 
       {AuthDialog}
+
+      {/* Search Panel */}
+      <SearchPanel
+        bookId={book.id}
+        bookFormat="epub"
+        open={searchPanelOpen}
+        onOpenChange={setSearchPanelOpen}
+        onNavigate={handleSearchNavigate}
+      />
 
       {/* Chat Panel */}
       <ChatPanel

--- a/apps/main/src/components/mobi/MobiView.tsx
+++ b/apps/main/src/components/mobi/MobiView.tsx
@@ -17,7 +17,7 @@ import TTSControls from "@components/TTSControls";
 import { IconButton } from "@components/ui/IconButton";
 import { Menu } from "@components/ui/Menu";
 import { Radio, RadioGroup } from "@components/ui/Radio";
-import { ChevronLeft, ChevronRight, MessageSquare, Palette } from "lucide-react";
+import { ChevronLeft, ChevronRight, MessageSquare, Palette, Search } from "lucide-react";
 import { bookIdAtom, themeAtom } from "@/stores/epub_atoms";
 import { themes } from "@/themes/themes";
 import { ThemeType } from "@/themes/common";
@@ -26,6 +26,8 @@ import type { ParagraphWithIndex } from "@/utils/bus";
 import { processEpubJob } from "@/modules/process_epub";
 import type { PageDataInsertable } from "@/modules/kysley";
 import { ChatPanel } from "@/components/chat/ChatPanel";
+import { SearchPanel } from "@/components/search/SearchPanel";
+import type { BookSearchResult } from "@/hooks/useBookSearch";
 import { useRequireAuth } from "@/hooks/useRequireAuth";
 import { db } from "@/modules/kysley";
 import { stringToNumberID } from "@components/lib/utils";
@@ -43,6 +45,7 @@ export function MobiView({ book }: { book: Book }): React.JSX.Element {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const embeddingsProcessedRef = useRef(false);
   const [chatPanelOpen, setChatPanelOpen] = useState(false);
+  const [searchPanelOpen, setSearchPanelOpen] = useState(false);
   const { requireAuth, AuthDialog } = useRequireAuth();
   const bookSyncIdRef = useRef<string | null>(null);
 
@@ -127,6 +130,25 @@ export function MobiView({ book }: { book: Book }): React.JSX.Element {
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [goNext, goPrev]);
+
+  const handleSearchNavigate = useCallback((result: BookSearchResult) => {
+    if (result.pageNumber !== undefined) {
+      // MOBI uses chapter index as page number
+      setChapterIndex(result.pageNumber);
+    }
+  }, []);
+
+  // Cmd+F / Ctrl+F keyboard shortcut
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        e.preventDefault();
+        setSearchPanelOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   // Publish paragraphs to event bus for TTS
   useEffect(() => {
@@ -275,6 +297,13 @@ export function MobiView({ book }: { book: Book }): React.JSX.Element {
       {/* Top bar */}
       <div className="absolute right-2 top-2 z-10 flex items-center gap-2">
         <button
+          onClick={() => setSearchPanelOpen(true)}
+          className={`p-2 rounded-md ${getTextColor()}`}
+          aria-label="Search in book"
+        >
+          <Search size={20} />
+        </button>
+        <button
           onClick={() => requireAuth("chat", () => setChatPanelOpen(true))}
           className={`p-2 rounded-md ${getTextColor()}`}
           aria-label="Open chat panel"
@@ -376,6 +405,15 @@ export function MobiView({ book }: { book: Book }): React.JSX.Element {
         rendition={null}
         open={chatPanelOpen}
         onOpenChange={setChatPanelOpen}
+      />
+
+      {/* Search Panel */}
+      <SearchPanel
+        bookId={book.id}
+        bookFormat="mobi"
+        open={searchPanelOpen}
+        onOpenChange={setSearchPanelOpen}
+        onNavigate={handleSearchNavigate}
       />
     </div>
   );

--- a/apps/main/src/components/pdf/components/pdf.tsx
+++ b/apps/main/src/components/pdf/components/pdf.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useState, useMemo, useRef } from "react";
 import { IconButton } from "@components/ui/IconButton";
 import { ThemeType } from "@/themes/common";
-import { Loader2, Menu as MenuIcon, LayoutGrid } from "lucide-react";
+import { Loader2, Menu as MenuIcon, LayoutGrid, Search } from "lucide-react";
 import { Document, Outline, pdfjs } from "react-pdf";
 import type { DocumentInitParameters } from "pdfjs-dist/types/src/display/api";
 import "../subscriptions/bus.ts";
@@ -46,6 +46,8 @@ import { eventBusLogsAtom } from "@/utils/bus";
 import { TextExtractor } from "./text-extractor.tsx";
 import { updateBookLocation, Book } from "@/generated";
 import { BackButton } from "@components/BackButton.tsx";
+import { SearchPanel } from "@/components/search/SearchPanel";
+import type { BookSearchResult } from "@/hooks/useBookSearch";
 
 // Configure PDF.js worker
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
@@ -66,6 +68,7 @@ export function PdfView({
   const setPdfDocProxy = useSetAtom(pdfDocumentProxyAtom);
   const setBookNavState = useSetAtom(bookNavigationStateAtom);
   useAtomValue(eventBusLogsAtom);
+  const [searchPanelOpen, setSearchPanelOpen] = useState(false);
 
   const setPageNumber = useSetAtom(setPageNumberAtom);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -171,6 +174,29 @@ export function PdfView({
     });
   }
 
+  const handleSearchNavigate = useCallback((result: BookSearchResult) => {
+    if (result.pageNumber) {
+      setBookNavState(BookNavigationState.Idle);
+      virtualizer.scrollToIndex(result.pageNumber - 1, {
+        align: "start",
+        behavior: "smooth",
+      });
+      setPageNumber(result.pageNumber);
+    }
+  }, [virtualizer, setBookNavState, setPageNumber]);
+
+  // Cmd+F / Ctrl+F keyboard shortcut
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        e.preventDefault();
+        setSearchPanelOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
   function onThumbnailNavigate(pageNumber: number) {
     // Reset navigation state to Idle so setPageNumber is not a no-op
     // (setPageNumberAtom skips if BookNavigationState is Navigating)
@@ -230,6 +256,16 @@ export function PdfView({
             aria-label="Open page thumbnails"
           >
             <LayoutGrid size={20} />
+          </IconButton>
+          <IconButton
+            onClick={() => setSearchPanelOpen(true)}
+            className={cn(
+              "hover:bg-black/10 dark:hover:bg-white/10 border-none",
+              getTextColor()
+            )}
+            aria-label="Search in book"
+          >
+            <Search size={20} />
           </IconButton>
 
           <div className="flex items-center gap-2 bg-white">
@@ -405,6 +441,14 @@ export function PdfView({
           </div>
         </SheetContent>
       </Sheet>
+      {/* Search Panel */}
+      <SearchPanel
+        bookId={book.id}
+        bookFormat="pdf"
+        open={searchPanelOpen}
+        onOpenChange={setSearchPanelOpen}
+        onNavigate={handleSearchNavigate}
+      />
     </div>
   );
 }

--- a/apps/main/src/components/search/SearchPanel.tsx
+++ b/apps/main/src/components/search/SearchPanel.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useRef } from 'react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetFooter,
+} from '@components/components/ui/sheet';
+import { ScrollArea } from '@components/components/ui/scroll-area';
+import { Search, Loader2 } from 'lucide-react';
+import { useBookSearch, type BookSearchResult } from '@/hooks/useBookSearch';
+
+interface SearchPanelProps {
+  bookId: number;
+  bookFormat: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onNavigate: (result: BookSearchResult) => void;
+  epubSearchFn?: (query: string) => Promise<{ cfi: string; excerpt: string }[]>;
+}
+
+/**
+ * Sanitizes a snippet string, allowing only <mark> tags and stripping all
+ * other HTML. This is safe because highlightedSnippet comes from either
+ * FTS5's snippet() function (which only wraps matched terms in <mark> tags)
+ * or from highlightText() in the hook (which regex-escapes the query before
+ * wrapping in <mark>). No user-controlled HTML is injected.
+ */
+function sanitizeSnippet(html: string): string {
+  return html
+    .replace(/<(?!\/?mark\b)[^>]+>/gi, '') // strip all tags except <mark> and </mark>
+    .replace(/&(?!amp;|lt;|gt;|quot;|#\d+;|#x[\da-f]+;)/gi, '&amp;'); // encode stray ampersands
+}
+
+export function SearchPanel({
+  bookId,
+  bookFormat,
+  open,
+  onOpenChange,
+  onNavigate,
+  epubSearchFn,
+}: SearchPanelProps) {
+  const {
+    query,
+    results,
+    isSearching,
+    activeMode,
+    handleQueryChange,
+    handleSubmit,
+  } = useBookSearch({ bookId, bookFormat, epubSearchFn });
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus input when panel opens
+  useEffect(() => {
+    if (open) {
+      setTimeout(() => inputRef.current?.focus(), 100);
+    }
+  }, [open]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-[400px] flex flex-col">
+        <SheetHeader>
+          <SheetTitle className="text-lg font-semibold">Search</SheetTitle>
+        </SheetHeader>
+
+        {/* Search input */}
+        <div className="px-4 pb-2">
+          <div className="flex items-center gap-2 rounded-md border border-input bg-muted/50 px-3 py-2">
+            <Search size={14} className="text-muted-foreground shrink-0" />
+            <input
+              ref={inputRef}
+              type="text"
+              className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+              placeholder='Search or "exact phrase"'
+              value={query}
+              onChange={(e) => handleQueryChange(e.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+            {isSearching && <Loader2 size={14} className="animate-spin text-muted-foreground" />}
+          </div>
+
+          {/* Result count */}
+          {query.trim() && (
+            <p className="text-xs text-muted-foreground mt-2">
+              {results.length} result{results.length !== 1 ? 's' : ''}
+            </p>
+          )}
+        </div>
+
+        {/* Results list */}
+        <ScrollArea className="flex-1 px-4">
+          {!query.trim() ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <h3 className="text-base font-semibold mb-1">Search this book</h3>
+              <p className="text-sm text-muted-foreground">
+                Type to find text, or press Enter for smart search.
+              </p>
+            </div>
+          ) : results.length === 0 && !isSearching ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <h3 className="text-base font-semibold mb-1">No results found</h3>
+              <p className="text-sm text-muted-foreground">
+                {activeMode === 'exact'
+                  ? 'Try pressing Enter for a smart search.'
+                  : 'No related passages found.'}
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {results.map((result) => (
+                <SearchResultItem
+                  key={result.id}
+                  result={result}
+                  onNavigate={onNavigate}
+                />
+              ))}
+            </div>
+          )}
+        </ScrollArea>
+
+        <SheetFooter>
+          <p className="text-xs text-muted-foreground">
+            {activeMode === 'semantic' && results.length > 0
+              ? 'Showing semantically related passages'
+              : 'Press Enter for smart search'}
+          </p>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function SearchResultItem({
+  result,
+  onNavigate,
+}: {
+  result: BookSearchResult;
+  onNavigate: (result: BookSearchResult) => void;
+}) {
+  return (
+    <button
+      className="cursor-pointer rounded-md p-3 hover:bg-accent/50 transition-colors text-left"
+      style={{ borderLeft: '3px solid hsl(var(--muted-foreground) / 0.4)' }}
+      onClick={() => onNavigate(result)}
+    >
+      {result.highlightedSnippet ? (
+        <p
+          className="text-sm line-clamp-3 [&_mark]:bg-yellow-500/30 [&_mark]:text-yellow-200 [&_mark]:rounded-sm"
+          // sanitizeSnippet strips all HTML tags except <mark>/<mark> before rendering.
+          // highlightedSnippet only ever contains <mark>-wrapped text from FTS5 or
+          // the highlightText() utility (which regex-escapes user input).
+          dangerouslySetInnerHTML={{ __html: sanitizeSnippet(result.highlightedSnippet) }}
+        />
+      ) : (
+        <p className="text-sm line-clamp-3">{result.snippet}</p>
+      )}
+      {(result.pageNumber || result.chapter) && (
+        <p className="text-xs text-muted-foreground mt-1">
+          {[result.chapter, result.pageNumber ? `Page ${result.pageNumber}` : null]
+            .filter(Boolean)
+            .join(' · ')}
+        </p>
+      )}
+    </button>
+  );
+}

--- a/apps/main/src/generated/commands.ts
+++ b/apps/main/src/generated/commands.ts
@@ -157,3 +157,6 @@ export async function unzip(params: types.UnzipParams): Promise<types.PathBuf> {
   return invoke('unzip', params);
 }
 
+export async function searchBookText(params: types.SearchBookTextParams): Promise<types.TextSearchResult[]> {
+  return invoke('search_book_text', params);
+}

--- a/apps/main/src/generated/types.ts
+++ b/apps/main/src/generated/types.ts
@@ -289,3 +289,17 @@ export interface ChunkDataInsertable {
   data: string;
 }
 
+export interface TextSearchResult {
+  id: number;
+  pageNumber: number;
+  bookId: number;
+  data: string;
+  snippet: string;
+}
+
+export interface SearchBookTextParams {
+  query: string;
+  bookId: number;
+  [key: string]: unknown;
+}
+

--- a/apps/main/src/hooks/useBookSearch.ts
+++ b/apps/main/src/hooks/useBookSearch.ts
@@ -1,0 +1,196 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { searchBookText } from '@/generated/commands';
+import { getContextForQuery } from '@/generated/commands';
+import { db } from '@/modules/kysley';
+
+export type SearchMode = 'exact' | 'semantic';
+
+export interface BookSearchResult {
+  id: string;
+  snippet: string;
+  highlightedSnippet?: string;
+  pageNumber?: number;
+  chapter?: string;
+  cfi?: string;
+  mode: SearchMode;
+}
+
+interface UseBookSearchOptions {
+  bookId: number;
+  bookFormat: string;
+  epubSearchFn?: (query: string) => Promise<{ cfi: string; excerpt: string }[]>;
+}
+
+export function useBookSearch({ bookId, bookFormat, epubSearchFn }: UseBookSearchOptions) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<BookSearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [activeMode, setActiveMode] = useState<SearchMode>('exact');
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const queryRef = useRef('');
+
+  // Keep ref in sync
+  useEffect(() => {
+    queryRef.current = query;
+  }, [query]);
+
+  // Detect if query is quoted
+  const isQuotedQuery = useCallback((q: string) => {
+    const trimmed = q.trim();
+    return trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length > 2;
+  }, []);
+
+  // Strip quotes from query
+  const stripQuotes = useCallback((q: string) => {
+    const trimmed = q.trim();
+    if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+      return trimmed.slice(1, -1);
+    }
+    return trimmed;
+  }, []);
+
+  // Exact search (FTS5 or epub.js spine search)
+  const runExactSearch = useCallback(async (searchQuery: string) => {
+    const cleanQuery = stripQuotes(searchQuery);
+    if (!cleanQuery || cleanQuery.length < 2) {
+      setResults([]);
+      return;
+    }
+
+    setIsSearching(true);
+    setActiveMode('exact');
+
+    try {
+      if (bookFormat === 'epub' && epubSearchFn) {
+        // Use epub.js spine-based search for EPUBs
+        const epubResults = await epubSearchFn(cleanQuery);
+        if (queryRef.current !== searchQuery) return; // stale
+        setResults(
+          epubResults.map((r, i) => ({
+            id: `epub-${i}`,
+            snippet: r.excerpt,
+            highlightedSnippet: highlightText(r.excerpt, cleanQuery),
+            cfi: r.cfi,
+            mode: 'exact' as SearchMode,
+          }))
+        );
+      } else {
+        // Use FTS5 for PDF/MOBI/DjVu (and EPUB without epubSearchFn)
+        const ftsResults = await searchBookText({ query: cleanQuery, bookId });
+        if (queryRef.current !== searchQuery) return; // stale
+        setResults(
+          ftsResults.map((r) => ({
+            id: `fts-${r.id}`,
+            snippet: r.data,
+            highlightedSnippet: r.snippet, // FTS5 snippet with <mark> tags
+            pageNumber: r.pageNumber,
+            mode: 'exact' as SearchMode,
+          }))
+        );
+      }
+    } catch (err) {
+      console.error('[useBookSearch] exact search failed:', err);
+      setResults([]);
+    } finally {
+      setIsSearching(false);
+    }
+  }, [bookId, bookFormat, epubSearchFn, stripQuotes]);
+
+  // Semantic search (vector)
+  const runSemanticSearch = useCallback(async (searchQuery: string) => {
+    const cleanQuery = stripQuotes(searchQuery);
+    if (!cleanQuery || cleanQuery.length < 2) return;
+
+    setIsSearching(true);
+    setActiveMode('semantic');
+
+    try {
+      const contextTexts = await getContextForQuery({ queryText: cleanQuery, bookId, k: 10 });
+      if (queryRef.current !== searchQuery) return; // stale
+
+      // Resolve page numbers from chunk_data
+      const resultsWithPages: BookSearchResult[] = await Promise.all(
+        contextTexts.map(async (text, i) => {
+          const chunk = await db
+            .selectFrom('chunk_data')
+            .select(['pageNumber'])
+            .where('bookId', '=', bookId)
+            .where('data', '=', text)
+            .executeTakeFirst();
+
+          return {
+            id: `semantic-${i}`,
+            snippet: text.length > 200 ? text.slice(0, 200) + '...' : text,
+            pageNumber: chunk?.pageNumber,
+            mode: 'semantic' as SearchMode,
+          };
+        })
+      );
+
+      setResults(resultsWithPages);
+    } catch (err) {
+      console.error('[useBookSearch] semantic search failed:', err);
+    } finally {
+      setIsSearching(false);
+    }
+  }, [bookId, stripQuotes]);
+
+  // Handle query changes — debounced exact search
+  const handleQueryChange = useCallback((newQuery: string) => {
+    setQuery(newQuery);
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    if (!newQuery.trim()) {
+      setResults([]);
+      return;
+    }
+
+    debounceRef.current = setTimeout(() => {
+      void runExactSearch(newQuery);
+    }, 300);
+  }, [runExactSearch]);
+
+  // Handle Enter — run semantic search
+  const handleSubmit = useCallback(() => {
+    if (!query.trim()) return;
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    // If query is quoted, run exact search immediately
+    if (isQuotedQuery(query)) {
+      void runExactSearch(query);
+    } else {
+      void runSemanticSearch(query);
+    }
+  }, [query, isQuotedQuery, runExactSearch, runSemanticSearch]);
+
+  // Cleanup debounce on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    query,
+    results,
+    isSearching,
+    activeMode,
+    handleQueryChange,
+    handleSubmit,
+  };
+}
+
+/** Wrap matched terms in <mark> tags for display */
+function highlightText(text: string, query: string): string {
+  if (!query) return text;
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return text.replace(new RegExp(`(${escaped})`, 'gi'), '<mark>$1</mark>');
+}

--- a/docs/superpowers/plans/2026-04-19-search-within-book.md
+++ b/docs/superpowers/plans/2026-04-19-search-within-book.md
@@ -1,0 +1,1102 @@
+# Search Within Book — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add in-book search with two modes — exact text search (as-you-type with debounce) and semantic search (on Enter) — via a slide-out panel in the reader toolbar.
+
+**Architecture:** FTS5 virtual table for exact text search on `chunk_data`, existing HNSW vector search for semantic. New `SearchPanel` component using the same `Sheet` pattern as `HighlightsPanel`/`ChatPanel`. New `useBookSearch` hook orchestrates both pipelines. EPUB exact search uses the existing `ReactReader.searchInBook()` method; PDF/MOBI/DjVu use the FTS5 Tauri command.
+
+**Tech Stack:** Rust/Diesel (SQLite FTS5), Tauri commands, React, Zustand/Jotai, Radix Sheet, lucide-react icons
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/main/src-tauri/migrations/2026-04-19-000000_create_fts_index/up.sql` — FTS5 virtual table + sync triggers + backfill
+- `apps/main/src-tauri/migrations/2026-04-19-000000_create_fts_index/down.sql` — Drop FTS table and triggers
+- `apps/main/src/components/search/SearchPanel.tsx` — Search slide-out panel UI
+- `apps/main/src/hooks/useBookSearch.ts` — Search orchestration hook
+
+**Modify:**
+- `apps/main/src-tauri/src/sql.rs` — Add `TextSearchResult` struct and `search_book_text` command
+- `apps/main/src-tauri/src/lib.rs` — Register `search_book_text` in `invoke_handler!`
+- `apps/main/src/generated/commands.ts` — Add `searchBookText` binding
+- `apps/main/src/generated/types.ts` — Add `TextSearchResult` and `SearchBookTextParams` types
+- `apps/main/src/components/epub.tsx` — Add search icon to toolbar, wire `SearchPanel`
+- `apps/main/src/components/pdf/components/pdf.tsx` — Add search icon to toolbar, wire `SearchPanel`
+- `apps/main/src/components/mobi/MobiView.tsx` — Add search icon to toolbar, wire `SearchPanel`
+- `apps/main/src/components/djvu/DjvuView.tsx` — Add search icon to toolbar, wire `SearchPanel`
+
+---
+
+### Task 1: FTS5 Migration
+
+**Files:**
+- Create: `apps/main/src-tauri/migrations/2026-04-19-000000_create_fts_index/up.sql`
+- Create: `apps/main/src-tauri/migrations/2026-04-19-000000_create_fts_index/down.sql`
+
+- [ ] **Step 1: Create the migration directory**
+
+```bash
+mkdir -p apps/main/src-tauri/migrations/2026-04-19-000000_create_fts_index
+```
+
+- [ ] **Step 2: Write the up migration**
+
+Create `apps/main/src-tauri/migrations/2026-04-19-000000_create_fts_index/up.sql`:
+
+```sql
+-- FTS5 content-sync table mirroring chunk_data.data
+CREATE VIRTUAL TABLE chunk_data_fts USING fts5(
+  data,
+  content='chunk_data',
+  content_rowid='id'
+);
+
+-- Keep FTS index in sync with chunk_data
+CREATE TRIGGER chunk_data_ai AFTER INSERT ON chunk_data BEGIN
+  INSERT INTO chunk_data_fts(rowid, data) VALUES (new.id, new.data);
+END;
+
+CREATE TRIGGER chunk_data_ad AFTER DELETE ON chunk_data BEGIN
+  INSERT INTO chunk_data_fts(chunk_data_fts, rowid, data) VALUES('delete', old.id, old.data);
+END;
+
+CREATE TRIGGER chunk_data_au AFTER UPDATE ON chunk_data BEGIN
+  INSERT INTO chunk_data_fts(chunk_data_fts, rowid, data) VALUES('delete', old.id, old.data);
+  INSERT INTO chunk_data_fts(rowid, data) VALUES (new.id, new.data);
+END;
+
+-- Backfill FTS index with existing chunk_data rows
+INSERT INTO chunk_data_fts(rowid, data) SELECT id, data FROM chunk_data;
+```
+
+- [ ] **Step 3: Write the down migration**
+
+Create `apps/main/src-tauri/migrations/2026-04-19-000000_create_fts_index/down.sql`:
+
+```sql
+DROP TRIGGER IF EXISTS chunk_data_ai;
+DROP TRIGGER IF EXISTS chunk_data_ad;
+DROP TRIGGER IF EXISTS chunk_data_au;
+DROP TABLE IF EXISTS chunk_data_fts;
+```
+
+- [ ] **Step 4: Verify the migration runs**
+
+```bash
+cd apps/main/src-tauri && cargo build 2>&1 | tail -20
+```
+
+Expected: Build succeeds. Diesel's `embed_migrations!()` in `db.rs` picks up the new migration automatically.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/main/src-tauri/migrations/2026-04-19-000000_create_fts_index/
+git commit -m "feat(search): add FTS5 migration for chunk_data full-text search"
+```
+
+---
+
+### Task 2: Rust `search_book_text` Command
+
+**Files:**
+- Modify: `apps/main/src-tauri/src/sql.rs`
+- Modify: `apps/main/src-tauri/src/lib.rs`
+
+- [ ] **Step 1: Add `TextSearchResult` struct and `search_book_text` function to `sql.rs`**
+
+Add this after the `PageData` struct (around line 60) in `apps/main/src-tauri/src/sql.rs`:
+
+```rust
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TextSearchResult {
+    pub id: i64,
+    pub page_number: i32,
+    pub book_id: i32,
+    pub data: String,
+    pub snippet: String,
+}
+```
+
+Add this function before the `#[cfg(test)]` block at the end of `sql.rs`:
+
+```rust
+#[tauri::command]
+pub fn search_book_text(query: String, book_id: i32) -> Result<Vec<TextSearchResult>, String> {
+    let pool = DB_POOL.get().ok_or("Database pool not initialized")?;
+    let mut conn = pool
+        .get()
+        .map_err(|e| format!("Failed to get connection: {}", e))?;
+
+    // FTS5 MATCH query with snippet generation, filtered by bookId
+    #[derive(diesel::QueryableByName)]
+    struct RawSearchResult {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        id: i64,
+        #[diesel(sql_type = diesel::sql_types::Integer, column_name = "pageNumber")]
+        page_number: i32,
+        #[diesel(sql_type = diesel::sql_types::Integer, column_name = "bookId")]
+        book_id: i32,
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        data: String,
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        snippet: String,
+    }
+
+    let results: Vec<RawSearchResult> = diesel::sql_query(
+        "SELECT chunk_data.id, chunk_data.pageNumber, chunk_data.bookId, chunk_data.data, \
+         snippet(chunk_data_fts, 0, '<mark>', '</mark>', '...', 40) as snippet \
+         FROM chunk_data_fts \
+         JOIN chunk_data ON chunk_data.id = chunk_data_fts.rowid \
+         WHERE chunk_data.bookId = ?1 AND chunk_data_fts MATCH ?2 \
+         ORDER BY rank \
+         LIMIT 50"
+    )
+    .bind::<diesel::sql_types::Integer, _>(&book_id)
+    .bind::<diesel::sql_types::Text, _>(&query)
+    .load(&mut conn)
+    .map_err(|e| format!("FTS search failed: {}", e))?;
+
+    Ok(results
+        .into_iter()
+        .map(|r| TextSearchResult {
+            id: r.id,
+            page_number: r.page_number,
+            book_id: r.book_id,
+            data: r.data,
+            snippet: r.snippet,
+        })
+        .collect())
+}
+```
+
+- [ ] **Step 2: Register the command in `lib.rs`**
+
+In `apps/main/src-tauri/src/lib.rs`, add `sql::search_book_text,` to the `invoke_handler!` macro, after the `sql::get_text_from_vector_id,` line:
+
+```rust
+            sql::get_text_from_vector_id,
+            sql::search_book_text,
+```
+
+- [ ] **Step 3: Add a test for `search_book_text`**
+
+Add this test inside the `mod tests` block in `sql.rs`, after the existing `test_save_page_data_many` test:
+
+```rust
+    #[test]
+    fn test_search_book_text() -> Result<(), String> {
+        let _setup = init_test_database_setup()?;
+        let book_id = 1;
+
+        let page_data = vec![
+            ChunkDataInsertable {
+                id: Some(100),
+                page_number: 1,
+                book_id,
+                data: "The philosophy of consciousness has been debated for centuries.".to_string(),
+            },
+            ChunkDataInsertable {
+                id: Some(101),
+                page_number: 2,
+                book_id,
+                data: "Quantum mechanics describes the behavior of particles at atomic scales.".to_string(),
+            },
+            ChunkDataInsertable {
+                id: Some(102),
+                page_number: 3,
+                book_id,
+                data: "Neural networks in the brain give rise to consciousness and awareness.".to_string(),
+            },
+        ];
+        save_page_data_many(page_data)?;
+
+        // Search for "consciousness" — should find chunks on pages 1 and 3
+        let results = search_book_text("consciousness".to_string(), book_id)?;
+        expect!(results.len()).to(be_equal_to(2));
+        // Results should be from pages 1 and 3 (order by FTS rank)
+        let page_numbers: Vec<i32> = results.iter().map(|r| r.page_number).collect();
+        expect!(page_numbers.contains(&1)).to(be_equal_to(true));
+        expect!(page_numbers.contains(&3)).to(be_equal_to(true));
+        // Snippets should contain <mark> tags
+        for result in &results {
+            expect!(result.snippet.contains("<mark>")).to(be_equal_to(true));
+        }
+
+        // Search for "quantum" — should find only page 2
+        let results2 = search_book_text("quantum".to_string(), book_id)?;
+        expect!(results2.len()).to(be_equal_to(1));
+        expect!(results2[0].page_number).to(be_equal_to(2));
+
+        // Search for a term that doesn't exist
+        let results3 = search_book_text("nonexistentterm".to_string(), book_id)?;
+        expect!(results3.is_empty()).to(be_equal_to(true));
+
+        Ok(())
+    }
+```
+
+Also add `search_book_text` to the test imports at the top of the `mod tests` block:
+
+```rust
+    use super::{
+        delete_book, get_all_page_data_by_book_id, get_book, save_book, save_page_data_many,
+        search_book_text, update_book_cover, BookInsertable, ChunkDataInsertable,
+    };
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+cd apps/main/src-tauri && cargo test test_search_book_text -- --nocapture
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/main/src-tauri/src/sql.rs apps/main/src-tauri/src/lib.rs
+git commit -m "feat(search): add search_book_text Tauri command with FTS5"
+```
+
+---
+
+### Task 3: TypeScript Bindings
+
+**Files:**
+- Modify: `apps/main/src/generated/types.ts`
+- Modify: `apps/main/src/generated/commands.ts`
+
+- [ ] **Step 1: Add `TextSearchResult` type and params to `types.ts`**
+
+Add at the end of `apps/main/src/generated/types.ts` (before the closing blank line):
+
+```typescript
+export interface TextSearchResult {
+  id: number;
+  pageNumber: number;
+  bookId: number;
+  data: string;
+  snippet: string;
+}
+
+export interface SearchBookTextParams {
+  query: string;
+  bookId: number;
+  [key: string]: unknown;
+}
+```
+
+- [ ] **Step 2: Add `searchBookText` command to `commands.ts`**
+
+Add at the end of `apps/main/src/generated/commands.ts`:
+
+```typescript
+export async function searchBookText(params: types.SearchBookTextParams): Promise<types.TextSearchResult[]> {
+  return invoke('search_book_text', params);
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/main/src/generated/types.ts apps/main/src/generated/commands.ts
+git commit -m "feat(search): add TypeScript bindings for search_book_text"
+```
+
+---
+
+### Task 4: `useBookSearch` Hook
+
+**Files:**
+- Create: `apps/main/src/hooks/useBookSearch.ts`
+
+- [ ] **Step 1: Create the hook**
+
+Create `apps/main/src/hooks/useBookSearch.ts`:
+
+```typescript
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { searchBookText } from '@/generated/commands';
+import { getContextForQuery } from '@/generated/commands';
+import { db } from '@/modules/kysley';
+
+export type SearchMode = 'exact' | 'semantic';
+
+export interface BookSearchResult {
+  id: string;
+  snippet: string;
+  highlightedSnippet?: string;
+  pageNumber?: number;
+  chapter?: string;
+  cfi?: string;
+  mode: SearchMode;
+}
+
+interface UseBookSearchOptions {
+  bookId: number;
+  bookFormat: string;
+  epubSearchFn?: (query: string) => Promise<{ cfi: string; excerpt: string }[]>;
+}
+
+export function useBookSearch({ bookId, bookFormat, epubSearchFn }: UseBookSearchOptions) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<BookSearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [activeMode, setActiveMode] = useState<SearchMode>('exact');
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const queryRef = useRef('');
+
+  // Keep ref in sync
+  useEffect(() => {
+    queryRef.current = query;
+  }, [query]);
+
+  // Detect if query is quoted
+  const isQuotedQuery = useCallback((q: string) => {
+    const trimmed = q.trim();
+    return trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length > 2;
+  }, []);
+
+  // Strip quotes from query
+  const stripQuotes = useCallback((q: string) => {
+    const trimmed = q.trim();
+    if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+      return trimmed.slice(1, -1);
+    }
+    return trimmed;
+  }, []);
+
+  // Exact search (FTS5 or epub.js spine search)
+  const runExactSearch = useCallback(async (searchQuery: string) => {
+    const cleanQuery = stripQuotes(searchQuery);
+    if (!cleanQuery || cleanQuery.length < 2) {
+      setResults([]);
+      return;
+    }
+
+    setIsSearching(true);
+    setActiveMode('exact');
+
+    try {
+      if (bookFormat === 'epub' && epubSearchFn) {
+        // Use epub.js spine-based search for EPUBs
+        const epubResults = await epubSearchFn(cleanQuery);
+        if (queryRef.current !== searchQuery) return; // stale
+        setResults(
+          epubResults.map((r, i) => ({
+            id: `epub-${i}`,
+            snippet: r.excerpt,
+            highlightedSnippet: highlightText(r.excerpt, cleanQuery),
+            cfi: r.cfi,
+            mode: 'exact' as SearchMode,
+          }))
+        );
+      } else {
+        // Use FTS5 for PDF/MOBI/DjVu (and EPUB without epubSearchFn)
+        const ftsResults = await searchBookText({ query: cleanQuery, bookId });
+        if (queryRef.current !== searchQuery) return; // stale
+        setResults(
+          ftsResults.map((r) => ({
+            id: `fts-${r.id}`,
+            snippet: r.data,
+            highlightedSnippet: r.snippet, // FTS5 snippet with <mark> tags
+            pageNumber: r.pageNumber,
+            mode: 'exact' as SearchMode,
+          }))
+        );
+      }
+    } catch (err) {
+      console.error('[useBookSearch] exact search failed:', err);
+      setResults([]);
+    } finally {
+      setIsSearching(false);
+    }
+  }, [bookId, bookFormat, epubSearchFn, stripQuotes]);
+
+  // Semantic search (vector)
+  const runSemanticSearch = useCallback(async (searchQuery: string) => {
+    const cleanQuery = stripQuotes(searchQuery);
+    if (!cleanQuery || cleanQuery.length < 2) return;
+
+    setIsSearching(true);
+    setActiveMode('semantic');
+
+    try {
+      const contextTexts = await getContextForQuery({ queryText: cleanQuery, bookId, k: 10 });
+      if (queryRef.current !== searchQuery) return; // stale
+
+      // Resolve page numbers from chunk_data
+      const resultsWithPages: BookSearchResult[] = await Promise.all(
+        contextTexts.map(async (text, i) => {
+          const chunk = await db
+            .selectFrom('chunk_data')
+            .select(['pageNumber'])
+            .where('bookId', '=', bookId)
+            .where('data', '=', text)
+            .executeTakeFirst();
+
+          return {
+            id: `semantic-${i}`,
+            snippet: text.length > 200 ? text.slice(0, 200) + '...' : text,
+            pageNumber: chunk?.pageNumber,
+            mode: 'semantic' as SearchMode,
+          };
+        })
+      );
+
+      setResults(resultsWithPages);
+    } catch (err) {
+      console.error('[useBookSearch] semantic search failed:', err);
+    } finally {
+      setIsSearching(false);
+    }
+  }, [bookId, stripQuotes]);
+
+  // Handle query changes — debounced exact search
+  const handleQueryChange = useCallback((newQuery: string) => {
+    setQuery(newQuery);
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    if (!newQuery.trim()) {
+      setResults([]);
+      return;
+    }
+
+    debounceRef.current = setTimeout(() => {
+      void runExactSearch(newQuery);
+    }, 300);
+  }, [runExactSearch]);
+
+  // Handle Enter — run semantic search
+  const handleSubmit = useCallback(() => {
+    if (!query.trim()) return;
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    // If query is quoted, run exact search immediately
+    if (isQuotedQuery(query)) {
+      void runExactSearch(query);
+    } else {
+      void runSemanticSearch(query);
+    }
+  }, [query, isQuotedQuery, runExactSearch, runSemanticSearch]);
+
+  // Cleanup debounce on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    query,
+    results,
+    isSearching,
+    activeMode,
+    handleQueryChange,
+    handleSubmit,
+  };
+}
+
+/** Wrap matched terms in <mark> tags for display */
+function highlightText(text: string, query: string): string {
+  if (!query) return text;
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return text.replace(new RegExp(`(${escaped})`, 'gi'), '<mark>$1</mark>');
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/main/src/hooks/useBookSearch.ts
+git commit -m "feat(search): add useBookSearch hook with exact and semantic modes"
+```
+
+---
+
+### Task 5: `SearchPanel` Component
+
+**Files:**
+- Create: `apps/main/src/components/search/SearchPanel.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `apps/main/src/components/search/SearchPanel.tsx`:
+
+Note: The `highlightedSnippet` field contains HTML from the FTS5 `snippet()` function which only produces `<mark>` tags — it does not accept user input and is safe to render. The `highlightText` utility in `useBookSearch` also only wraps matched terms in `<mark>` tags using a regex escape of the query.
+
+```tsx
+import { useEffect, useRef } from 'react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetFooter,
+} from '@components/components/ui/sheet';
+import { ScrollArea } from '@components/components/ui/scroll-area';
+import { Search, Loader2 } from 'lucide-react';
+import { useBookSearch, type BookSearchResult } from '@/hooks/useBookSearch';
+
+interface SearchPanelProps {
+  bookId: number;
+  bookFormat: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onNavigate: (result: BookSearchResult) => void;
+  epubSearchFn?: (query: string) => Promise<{ cfi: string; excerpt: string }[]>;
+}
+
+export function SearchPanel({
+  bookId,
+  bookFormat,
+  open,
+  onOpenChange,
+  onNavigate,
+  epubSearchFn,
+}: SearchPanelProps) {
+  const {
+    query,
+    results,
+    isSearching,
+    activeMode,
+    handleQueryChange,
+    handleSubmit,
+  } = useBookSearch({ bookId, bookFormat, epubSearchFn });
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus input when panel opens
+  useEffect(() => {
+    if (open) {
+      setTimeout(() => inputRef.current?.focus(), 100);
+    }
+  }, [open]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-[400px] flex flex-col">
+        <SheetHeader>
+          <SheetTitle className="text-lg font-semibold">Search</SheetTitle>
+        </SheetHeader>
+
+        {/* Search input */}
+        <div className="px-4 pb-2">
+          <div className="flex items-center gap-2 rounded-md border border-input bg-muted/50 px-3 py-2">
+            <Search size={14} className="text-muted-foreground shrink-0" />
+            <input
+              ref={inputRef}
+              type="text"
+              className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+              placeholder='Search or "exact phrase"'
+              value={query}
+              onChange={(e) => handleQueryChange(e.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+            {isSearching && <Loader2 size={14} className="animate-spin text-muted-foreground" />}
+          </div>
+
+          {/* Result count */}
+          {query.trim() && (
+            <p className="text-xs text-muted-foreground mt-2">
+              {results.length} result{results.length !== 1 ? 's' : ''}
+            </p>
+          )}
+        </div>
+
+        {/* Results list */}
+        <ScrollArea className="flex-1 px-4">
+          {!query.trim() ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <h3 className="text-base font-semibold mb-1">Search this book</h3>
+              <p className="text-sm text-muted-foreground">
+                Type to find text, or press Enter for smart search.
+              </p>
+            </div>
+          ) : results.length === 0 && !isSearching ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <h3 className="text-base font-semibold mb-1">No results found</h3>
+              <p className="text-sm text-muted-foreground">
+                {activeMode === 'exact'
+                  ? 'Try pressing Enter for a smart search.'
+                  : 'No related passages found.'}
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {results.map((result) => (
+                <SearchResultItem
+                  key={result.id}
+                  result={result}
+                  onNavigate={onNavigate}
+                />
+              ))}
+            </div>
+          )}
+        </ScrollArea>
+
+        <SheetFooter>
+          <p className="text-xs text-muted-foreground">
+            {activeMode === 'semantic' && results.length > 0
+              ? 'Showing semantically related passages'
+              : 'Press Enter for smart search'}
+          </p>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function SearchResultItem({
+  result,
+  onNavigate,
+}: {
+  result: BookSearchResult;
+  onNavigate: (result: BookSearchResult) => void;
+}) {
+  return (
+    <button
+      className="cursor-pointer rounded-md p-3 hover:bg-accent/50 transition-colors text-left"
+      style={{ borderLeft: '3px solid hsl(var(--muted-foreground) / 0.4)' }}
+      onClick={() => onNavigate(result)}
+    >
+      {result.highlightedSnippet ? (
+        <p
+          className="text-sm line-clamp-3 [&>mark]:bg-yellow-500/30 [&>mark]:text-yellow-200 [&>mark]:rounded-sm"
+          // Safe: highlightedSnippet is generated by FTS5 snippet() which only produces
+          // <mark> tags from indexed content, or by highlightText() which regex-escapes
+          // the query before wrapping in <mark>. No user-controlled HTML is injected.
+          dangerouslySetInnerHTML={{ __html: result.highlightedSnippet }}
+        />
+      ) : (
+        <p className="text-sm line-clamp-3">{result.snippet}</p>
+      )}
+      {(result.pageNumber || result.chapter) && (
+        <p className="text-xs text-muted-foreground mt-1">
+          {[result.chapter, result.pageNumber ? `Page ${result.pageNumber}` : null]
+            .filter(Boolean)
+            .join(' · ')}
+        </p>
+      )}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/main/src/components/search/SearchPanel.tsx
+git commit -m "feat(search): add SearchPanel slide-out component"
+```
+
+---
+
+### Task 6: Wire SearchPanel into EPUB Reader
+
+**Files:**
+- Modify: `apps/main/src/components/epub.tsx`
+
+- [ ] **Step 1: Add imports and state**
+
+At the top of `apps/main/src/components/epub.tsx`, add `Search` to the lucide-react import and import `SearchPanel`:
+
+```typescript
+import { Palette, Highlighter, MessageSquare, Search } from "lucide-react";
+```
+
+Add after the `ChatPanel` import:
+
+```typescript
+import { SearchPanel } from "@/components/search/SearchPanel";
+import type { BookSearchResult } from "@/hooks/useBookSearch";
+```
+
+Inside `EpubView`, add state after `const [chatPanelOpen, setChatPanelOpen] = useState(false);`:
+
+```typescript
+  const [searchPanelOpen, setSearchPanelOpen] = useState(false);
+```
+
+- [ ] **Step 2: Add navigation handler and keyboard shortcut**
+
+Add after the `searchPanelOpen` state declaration:
+
+```typescript
+  const handleSearchNavigate = useCallback((result: BookSearchResult) => {
+    if (result.cfi && rendition) {
+      void rendition.display(result.cfi);
+    } else if (result.pageNumber && rendition) {
+      void rendition.display(result.pageNumber);
+    }
+  }, [rendition]);
+
+  // Cmd+F / Ctrl+F keyboard shortcut
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        e.preventDefault();
+        setSearchPanelOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+```
+
+- [ ] **Step 3: Add search button to toolbar**
+
+In the toolbar `div` (the `<div className="absolute right-2 top-2 z-10 flex items-center gap-2">`), add a search button before the highlights button:
+
+```tsx
+        <button
+          onClick={() => setSearchPanelOpen(true)}
+          className={cn("p-2 rounded-md", getTextColor())}
+          aria-label="Search in book"
+        >
+          <Search size={20} />
+        </button>
+```
+
+- [ ] **Step 4: Add SearchPanel component**
+
+Add the `SearchPanel` component after the `ChatPanel` component (before the closing `</div>`):
+
+```tsx
+      {/* Search Panel */}
+      <SearchPanel
+        bookId={book.id}
+        bookFormat="epub"
+        open={searchPanelOpen}
+        onOpenChange={setSearchPanelOpen}
+        onNavigate={handleSearchNavigate}
+      />
+```
+
+Note: We skip `epubSearchFn` for now — the FTS5 backend works for all formats including EPUB. The epub.js spine search can be wired in later as an enhancement for CFI-precise navigation.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/main/src/components/epub.tsx
+git commit -m "feat(search): wire SearchPanel into EPUB reader with Cmd+F shortcut"
+```
+
+---
+
+### Task 7: Wire SearchPanel into PDF Reader
+
+**Files:**
+- Modify: `apps/main/src/components/pdf/components/pdf.tsx`
+
+- [ ] **Step 1: Add imports and state**
+
+At the top of `apps/main/src/components/pdf/components/pdf.tsx`, add `Search` to the lucide-react import:
+
+```typescript
+import { Loader2, Menu as MenuIcon, LayoutGrid, Search } from "lucide-react";
+```
+
+Add the SearchPanel import:
+
+```typescript
+import { SearchPanel } from "@/components/search/SearchPanel";
+import type { BookSearchResult } from "@/hooks/useBookSearch";
+```
+
+Inside `PdfView`, add state after the existing state declarations:
+
+```typescript
+  const [searchPanelOpen, setSearchPanelOpen] = useState(false);
+```
+
+- [ ] **Step 2: Add navigation handler and keyboard shortcut**
+
+Add after the state:
+
+```typescript
+  const handleSearchNavigate = useCallback((result: BookSearchResult) => {
+    if (result.pageNumber) {
+      setBookNavState(BookNavigationState.Idle);
+      virtualizer.scrollToIndex(result.pageNumber - 1, {
+        align: "start",
+        behavior: "smooth",
+      });
+      setPageNumber(result.pageNumber);
+    }
+  }, [virtualizer, setBookNavState, setPageNumber]);
+
+  // Cmd+F / Ctrl+F keyboard shortcut
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        e.preventDefault();
+        setSearchPanelOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+```
+
+- [ ] **Step 3: Add search button to the top bar**
+
+In the fixed top bar's flex container (around line 213), add a search button after the `LayoutGrid` button:
+
+```tsx
+          <IconButton
+            onClick={() => setSearchPanelOpen(true)}
+            className={cn(
+              "hover:bg-black/10 dark:hover:bg-white/10 border-none",
+              getTextColor()
+            )}
+            aria-label="Search in book"
+          >
+            <Search size={20} />
+          </IconButton>
+```
+
+- [ ] **Step 4: Add SearchPanel component**
+
+Add the `SearchPanel` component before the closing `</div>` of the root element, after the `ThumbnailSidebar`:
+
+```tsx
+      {/* Search Panel */}
+      <SearchPanel
+        bookId={book.id}
+        bookFormat="pdf"
+        open={searchPanelOpen}
+        onOpenChange={setSearchPanelOpen}
+        onNavigate={handleSearchNavigate}
+      />
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/main/src/components/pdf/components/pdf.tsx
+git commit -m "feat(search): wire SearchPanel into PDF reader"
+```
+
+---
+
+### Task 8: Wire SearchPanel into MOBI Reader
+
+**Files:**
+- Modify: `apps/main/src/components/mobi/MobiView.tsx`
+
+- [ ] **Step 1: Add imports and state**
+
+Add `Search` to the lucide-react import in `MobiView.tsx`:
+
+```typescript
+import { ChevronLeft, ChevronRight, MessageSquare, Palette, Search } from "lucide-react";
+```
+
+Add SearchPanel import:
+
+```typescript
+import { SearchPanel } from "@/components/search/SearchPanel";
+import type { BookSearchResult } from "@/hooks/useBookSearch";
+```
+
+Add state inside `MobiView`:
+
+```typescript
+  const [searchPanelOpen, setSearchPanelOpen] = useState(false);
+```
+
+- [ ] **Step 2: Add navigation handler and keyboard shortcut**
+
+```typescript
+  const handleSearchNavigate = useCallback((result: BookSearchResult) => {
+    if (result.pageNumber !== undefined) {
+      // MOBI uses chapter index as page number
+      setChapterIndex(result.pageNumber);
+    }
+  }, []);
+
+  // Cmd+F / Ctrl+F keyboard shortcut
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        e.preventDefault();
+        setSearchPanelOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+```
+
+- [ ] **Step 3: Add search button to toolbar**
+
+Find the toolbar area (where the `BackButton`, highlights, chat buttons are) and add a search button. Look for the area with the `MessageSquare` button and add before it:
+
+```tsx
+        <button
+          onClick={() => setSearchPanelOpen(true)}
+          className={cn("p-2 rounded-md", getTextColor())}
+          aria-label="Search in book"
+        >
+          <Search size={20} />
+        </button>
+```
+
+- [ ] **Step 4: Add SearchPanel component**
+
+Add before the closing `</div>` of the component, after `ChatPanel`:
+
+```tsx
+      {/* Search Panel */}
+      <SearchPanel
+        bookId={book.id}
+        bookFormat="mobi"
+        open={searchPanelOpen}
+        onOpenChange={setSearchPanelOpen}
+        onNavigate={handleSearchNavigate}
+      />
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/main/src/components/mobi/MobiView.tsx
+git commit -m "feat(search): wire SearchPanel into MOBI reader"
+```
+
+---
+
+### Task 9: Wire SearchPanel into DjVu Reader
+
+**Files:**
+- Modify: `apps/main/src/components/djvu/DjvuView.tsx`
+
+- [ ] **Step 1: Add imports and state**
+
+Add `Search` to the lucide-react import in `DjvuView.tsx`:
+
+```typescript
+import { ChevronLeft, ChevronRight, MessageSquare, ZoomIn, ZoomOut, Search } from "lucide-react";
+```
+
+Add SearchPanel import:
+
+```typescript
+import { SearchPanel } from "@/components/search/SearchPanel";
+import type { BookSearchResult } from "@/hooks/useBookSearch";
+```
+
+Add state inside `DjvuView`:
+
+```typescript
+  const [searchPanelOpen, setSearchPanelOpen] = useState(false);
+```
+
+- [ ] **Step 2: Add navigation handler and keyboard shortcut**
+
+```typescript
+  const handleSearchNavigate = useCallback((result: BookSearchResult) => {
+    if (result.pageNumber !== undefined) {
+      setCurrentPage(result.pageNumber);
+    }
+  }, []);
+
+  // Cmd+F / Ctrl+F keyboard shortcut
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        e.preventDefault();
+        setSearchPanelOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+```
+
+- [ ] **Step 3: Add search button to toolbar**
+
+Find the toolbar area and add a search button. Look for the area with `MessageSquare` and add before it:
+
+```tsx
+        <IconButton
+          onClick={() => setSearchPanelOpen(true)}
+          className="hover:bg-black/10 dark:hover:bg-white/10 border-none"
+          aria-label="Search in book"
+        >
+          <Search size={20} />
+        </IconButton>
+```
+
+- [ ] **Step 4: Add SearchPanel component**
+
+Add before the closing tag, after `ChatPanel`:
+
+```tsx
+      {/* Search Panel */}
+      <SearchPanel
+        bookId={book.id}
+        bookFormat="djvu"
+        open={searchPanelOpen}
+        onOpenChange={setSearchPanelOpen}
+        onNavigate={handleSearchNavigate}
+      />
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/main/src/components/djvu/DjvuView.tsx
+git commit -m "feat(search): wire SearchPanel into DjVu reader"
+```
+
+---
+
+### Task 10: Build Verification
+
+- [ ] **Step 1: Run Rust tests**
+
+```bash
+cd apps/main/src-tauri && cargo test 2>&1 | tail -30
+```
+
+Expected: All tests pass, including `test_search_book_text`.
+
+- [ ] **Step 2: Run TypeScript build**
+
+```bash
+cd apps/main && npx tsc --noEmit 2>&1 | tail -30
+```
+
+Expected: No new errors from the search feature files.
+
+- [ ] **Step 3: Commit any fixes if needed**
+
+If there are build errors, fix them and commit:
+
+```bash
+git add -A
+git commit -m "fix(search): resolve build errors"
+```

--- a/docs/superpowers/specs/2026-04-19-search-within-book-design.md
+++ b/docs/superpowers/specs/2026-04-19-search-within-book-design.md
@@ -1,0 +1,179 @@
+# Search Within Book — Design Spec
+
+## Overview
+
+Add in-book search to Rishi with two modes: **exact text search** (as-you-type with debounce) and **semantic search** (on Enter). The UI follows the Apple Books search UX pattern, implemented using the same Sheet-based slide-out panel design as the existing `HighlightsPanel` and `ChatPanel`.
+
+Quoting the query (e.g., `"exact phrase"`) forces exact matching; unquoted queries trigger exact search as-you-type and semantic search on Enter.
+
+## Search Modes
+
+### Exact Text Search
+- **Trigger:** As-you-type with 300ms debounce
+- **EPUB:** Uses the existing `ReactReader.searchInBook()` method which walks epub.js spine items, extracts text nodes, and returns `{ cfi, excerpt }` results
+- **PDF/MOBI/DjVu:** Uses a new `search_book_text` Tauri command backed by SQLite FTS5 on the `chunk_data` table
+- **Result display:** Snippet with matched terms highlighted in gold
+
+### Semantic Search
+- **Trigger:** On Enter key press
+- **All formats:** Uses the existing `getContextForQuery()` Tauri command which embeds the query via `all-MiniLM-L6-v2`, searches the HNSW vector index, and returns matching chunk texts
+- **Result display:** Snippet without term highlighting (matches by meaning, not literal text)
+
+## Backend Changes
+
+### New Migration — FTS5 Virtual Table
+
+A content-sync FTS5 virtual table mirroring `chunk_data.data`, with triggers to keep it in sync on insert/update/delete:
+
+```sql
+CREATE VIRTUAL TABLE chunk_data_fts USING fts5(
+  data,
+  content='chunk_data',
+  content_rowid='id'
+);
+
+CREATE TRIGGER chunk_data_ai AFTER INSERT ON chunk_data BEGIN
+  INSERT INTO chunk_data_fts(rowid, data) VALUES (new.id, new.data);
+END;
+
+CREATE TRIGGER chunk_data_ad AFTER DELETE ON chunk_data BEGIN
+  INSERT INTO chunk_data_fts(chunk_data_fts, rowid, data) VALUES('delete', old.id, old.data);
+END;
+
+CREATE TRIGGER chunk_data_au AFTER UPDATE ON chunk_data BEGIN
+  INSERT INTO chunk_data_fts(chunk_data_fts, rowid, data) VALUES('delete', old.id, old.data);
+  INSERT INTO chunk_data_fts(rowid, data) VALUES (new.id, new.data);
+END;
+```
+
+Note: Existing books that were indexed before this migration will need their FTS index rebuilt. The migration `up.sql` should include a one-time population:
+
+```sql
+INSERT INTO chunk_data_fts(rowid, data) SELECT id, data FROM chunk_data;
+```
+
+### New Tauri Command — `search_book_text`
+
+```rust
+#[tauri::command]
+pub fn search_book_text(query: String, book_id: i32) -> Result<Vec<TextSearchResult>, String>
+```
+
+- Runs a raw SQL query: `SELECT chunk_data.id, chunk_data.pageNumber, chunk_data.bookId, snippet(chunk_data_fts, 0, '<mark>', '</mark>', '...', 40) as snippet, chunk_data.data FROM chunk_data_fts JOIN chunk_data ON chunk_data.id = chunk_data_fts.rowid WHERE chunk_data.bookId = ? AND chunk_data_fts MATCH ?`
+- Returns `Vec<TextSearchResult>` with fields: `id: i64`, `page_number: i32`, `book_id: i32`, `data: String`, `snippet: String`
+- The `snippet()` function provides FTS5-generated excerpts with `<mark>` tags around matches
+
+### Existing Command Reused — `get_context_for_query`
+
+Already does end-to-end semantic search. The frontend calls it with `(queryText, bookId, k=10)` and gets back `Vec<String>` of matching chunk texts. Page numbers are resolved via a Kysely query on `chunk_data` (same pattern as `useChat.ts:131`).
+
+## Frontend Changes
+
+### New Component — `SearchPanel.tsx`
+
+Location: `apps/main/src/components/search/SearchPanel.tsx`
+
+Sheet-based slide-out panel matching `HighlightsPanel` pattern:
+- `Sheet` + `SheetContent side="right" className="w-[400px] flex flex-col"`
+- `SheetHeader` with title "Search"
+- Search input below header with placeholder `Search or "exact phrase"`
+- Result count below input (e.g., "5 results")
+- `ScrollArea` with result items
+- `SheetFooter` with contextual hint: "Press Enter for smart search" (during exact) or "Showing semantically related passages" (after semantic)
+
+**Props:**
+```typescript
+interface SearchPanelProps {
+  bookId: number;
+  bookFormat: 'epub' | 'pdf' | 'mobi' | 'djvu';
+  rendition: Rendition | null;  // for EPUB navigation
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onNavigate: (target: { cfi?: string; pageNumber?: number }) => void;
+}
+```
+
+### New Hook — `useBookSearch`
+
+Location: `apps/main/src/hooks/useBookSearch.ts`
+
+Manages search state and orchestrates both pipelines.
+
+**State:**
+- `query: string` — current search input
+- `results: SearchResult[]` — combined results list
+- `isSearching: boolean` — loading state
+- `searchMode: 'exact' | 'semantic'` — auto-detected from query format and trigger
+
+**Behavior:**
+- On keystroke (debounced 300ms): detect if query is quoted → exact search
+  - EPUB: call `searchInBook()` via ReactReader ref
+  - PDF/MOBI/DjVu: call `searchBookText()` Tauri command
+- On Enter: run semantic search via `getContextForQuery()`, replace results
+- Results are normalized into a common shape:
+
+```typescript
+interface SearchResult {
+  id: string;
+  snippet: string;           // text excerpt
+  highlightedSnippet?: string; // snippet with <mark> tags (exact only)
+  pageNumber?: number;
+  chapter?: string;
+  cfi?: string;              // EPUB only
+  mode: 'exact' | 'semantic';
+}
+```
+
+### Search Result Item
+
+Each result displays:
+- Snippet text — with matched terms highlighted via `<mark>` for exact search, plain text for semantic
+- Chapter name and/or page number in `text-xs text-muted-foreground`
+- `border-left: 3px solid` accent (same pattern as highlights)
+- Click navigates: EPUB calls `rendition.display(cfi)`, PDF/MOBI/DjVu updates page store
+- `hover:bg-accent/50 transition-colors` on hover (same as highlight items)
+
+### Toolbar Integration
+
+- Add a `Search` icon (lucide-react) to the reader toolbar alongside existing icons
+- Clicking toggles `SearchPanel` open/closed
+- `Cmd+F` / `Ctrl+F` keyboard shortcut toggles the panel
+- Auto-focus the search input when the panel opens
+
+### Empty States
+
+- **No query:** "Search for text in this book"
+- **No results (exact):** "No matches found"
+- **No results (semantic):** "No related passages found"
+- **Book not indexed:** "This book hasn't been indexed yet. Open it to start indexing."
+
+## Navigation on Result Click
+
+| Format | Exact Search Navigation | Semantic Search Navigation |
+|--------|------------------------|---------------------------|
+| EPUB   | `rendition.display(cfi)` — jumps to exact match location | `rendition.display(pageNumber)` — jumps to page containing the chunk |
+| PDF    | Update PDF page store to `pageNumber` | Same |
+| MOBI   | Navigate to `pageNumber` | Same |
+| DjVu   | Navigate to `pageNumber` | Same |
+
+## Files to Create
+
+1. `apps/main/src-tauri/migrations/<timestamp>_create_fts_index/up.sql` — FTS5 migration
+2. `apps/main/src-tauri/migrations/<timestamp>_create_fts_index/down.sql` — Drop FTS table and triggers
+3. `apps/main/src/components/search/SearchPanel.tsx` — Search panel UI
+4. `apps/main/src/hooks/useBookSearch.ts` — Search logic hook
+
+## Files to Modify
+
+1. `apps/main/src-tauri/src/sql.rs` — Add `search_book_text` command and `TextSearchResult` struct
+2. `apps/main/src-tauri/src/lib.rs` — Register `search_book_text` in `invoke_handler!`
+3. `apps/main/src/generated/commands.ts` — Add generated binding (auto via `cargo tauri dev`)
+4. `apps/main/src/generated/types.ts` — Add `TextSearchResult` type (auto-generated)
+5. Reader components (epub.tsx, pdf.tsx, mobi, djvu) — Add search icon to toolbar, wire `SearchPanel`
+
+## Out of Scope
+
+- Search across multiple books (library-wide search)
+- Search history / recent searches
+- Advanced search syntax beyond quoted exact match
+- Highlighting matches in the reader view itself (only in the search panel)


### PR DESCRIPTION
## Summary

- Adds in-book search with two modes: **exact text search** (as-you-type with 300ms debounce) and **semantic search** (on Enter)
- FTS5 virtual table on `chunk_data` for fast full-text search with snippet generation
- New `SearchPanel` slide-out component matching existing HighlightsPanel/ChatPanel UX
- Wired into all 4 readers (EPUB, PDF, MOBI, DjVu) with toolbar icon + `Cmd+F`/`Ctrl+F` shortcut
- Quoting a query (e.g. `"exact phrase"`) forces exact matching; unquoted queries trigger exact as-you-type and semantic on Enter

## Test plan

- [ ] Open an EPUB book, click the search icon or press Cmd+F — panel slides out
- [ ] Type a word — results appear with highlighted matches (exact search)
- [ ] Press Enter — semantic search runs, results shown without highlights
- [ ] Click a result — navigates to that page/location in the reader
- [ ] Repeat for PDF, MOBI, and DjVu formats
- [ ] Verify `cargo test search_book` passes