### PR TITLE
refactor(voice-chat): Stage 2 — Effect-TS for cold-path activation (canary)

### DIFF
--- a/.canary-verdict.md
+++ b/.canary-verdict.md
@@ -1,112 +1,116 @@
-# TTS Stage 2 canary verdict
+# Voice Chat Stage 2 canary verdict
 
 **Status:** Neutral
 **Date:** 2026-05-11
 **Implementer:** subagent
+**Sibling canary:** TTS Stage 2 — Neutral (shipped)
 
 ## One-paragraph verdict
 
-Neutral. Effect-TS produced a working, type-safe replacement for the Stage 1
-queue + transport modules, but the canary did NOT deliver an obvious win in
-either readability or LoC. `program.ts + errors.ts = 381 lines` vs Stage 1's
-~268 lines (queue + transport) — a ~42% growth, just under the 400-line
-stopping ceiling. The compression Effect was supposed to provide
-(`Queue.bounded`, `Semaphore`, `Schedule`, `acquireUseRelease`) was real but
-offset by three boilerplate concerns that don't go away: (1) the Effect ↔
-Promise boundary needs `refGet`/`refUpdate`/`queueSize` helpers because v3.21
-no longer exposes the documented `Ref.unsafeGet` / `Ref.unsafeUpdate` /
-`Queue.unsafeSize` synchronous variants — every status/cancel call wraps an
-`Effect.runSync`; (2) `Effect.catchAllCause` does NOT fire on
-`Fiber.interrupt` causes, which cost ~20 minutes of debugging the cancelBook
-test failure and forced a switch to `Effect.onInterrupt`; (3) generator
-syntax (`Effect.gen(function*() { ... yield* ... })`) is noisy compared to
-the equivalent async/await. Debugging during the canary was tractable —
-stack traces did point into our code when something went wrong, not deep
-into `effect/dist`. Recommendation: **keep Effect in TTS, but treat each
-future Stage 2 adoption as a per-service judgment based on its rubric score;
-do NOT blanket-roll Effect into services that score below 3-of-5 on the
-meta-spec's rubric.** The win/loss ratio here is too thin to assume Effect
-will pay off everywhere.
+**Neutral.** The pipeline works, the full Stage-1 test suite passes unchanged
+(59 tests including the line-444 concurrent-activate boundary which the plan
+predicted would need an assertion rewrite — see "Deviations from the plan"
+below), and the public surface is byte-identical. The Effect-side code is
+correct and readable in places (the `acquireRelease` triple for mic / audio
+element / session captures the resource lifecycle cleanly), but enough small
+ceremony accumulated that the net rubric impact is flat: the `success` flag
+pattern that inverts each `acquireRelease`'s finalizer check is non-obvious;
+the `refGet`/`refSet`/`refUpd` helpers are unused dead weight kept only to
+document the lesson-#1 workaround; the `__VOICE_CHAT_INTERRUPTED__` sentinel
+Error string is a workaround for the fact that `Cause.isInterruptedOnly` is
+awkward to surface at the Promise boundary; and the "small win" of swapping
+`key-cache.ts` to `Effect.Cache.make` had to be reverted to the manual
+implementation because `Cache.make` uses the real wall clock for TTL and the
+test injects a fake clock. The verdict matches TTS's: **case-by-case, not
+blanket adoption.** Combined with TTS's Neutral, Stage 2 stops here.
 
-## Pain signals (per spec)
+## Pain signals (per spec § "Stopping rule")
 
 | Signal | Triggered? | Evidence |
 |---|---|---|
-| Boundary test failed ≥ 2 hours with no clear root cause | N | One test (`cancelBookRequests`) failed at Task 5; root cause located in <30 min (interrupts vs catchAllCause) via a small node REPL probe. |
-| Effect docs consulted > 3 times/hour for basic operations | N | No docs consulted during implementation. Three API-existence probes executed with `node -e` to confirm runtime presence of `Ref.unsafeUpdate`, `Queue.unsafeSize`, `onInterrupt` — these are diagnostic, not pedagogical. |
-| program.ts + errors.ts > 400 LoC (50% growth vs 268) | N | 381 lines (program.ts 325 + errors.ts 56). Under threshold but uncomfortably close. |
+| A boundary test failed ≥ 2 hours with no clear root cause and stack pointed into effect/dist | N | Did not occur. The full 59-test suite passed unchanged after each task; no debugging session needed. |
+| An Effect API surprise not in lessons #1–#4 cost ≥ 30 minutes and required reading Effect source | N | One minor surprise (Cache.get is not a module-level export; the cache instance has a .get() method). Solved in ~3 minutes via `node -e` reflection on the module exports — well under 30 min. |
+| activation-program.ts + errors.ts combined > 600 LoC | N | 368 LoC combined (290 + 78). Well under ceiling. |
 
 Abort rule: **two of three** signals trigger abort. This run: **0/3**.
 
-## API uncertainty resolutions
+## Evidence required by spec § "Canary verdict criteria"
 
-1. `Ref.unsafeUpdate` / `Ref.unsafeGet` — **FALLBACK**. Neither is exported at
-   runtime in `effect@3.21.2` (only `Ref.unsafeMake` is). Implemented
-   `refGet`/`refUpdate` helpers that wrap `Effect.runSync(Ref.get(ref))` and
-   `Effect.runSync(Ref.update(ref, fn))`. The plan listed only
-   `Ref.unsafeUpdate` as expected-missing; `Ref.unsafeGet` being missing was
-   a fresh surprise.
-2. `Effect.makeSemaphore` vs `Semaphore.make` — **PRIMARY**.
-   `Effect.makeSemaphore` exists; the `Semaphore` module is not exported.
-3. `Queue.unsafeSize` returns `number` vs `Option<number>` — **FALLBACK**.
-   `Queue.unsafeSize` is not exported at all; used
-   `Effect.runSync(Queue.size(q))` which returns a plain `number`. The
-   fallback's `sizeOf` Option-unwrapping ternary was not needed.
+- **LoC delta:** service.ts + activation-program.ts + errors.ts + key-cache.ts
+  = 339 + 290 + 78 + 53 = **760 lines** vs Stage 1's 433 + 0 + 0 + 42 = 475.
+  Delta: **+285 lines** (the cold path moved to a new file but did not shrink
+  net; the Effect program adds genuine code).
+- **Count of `Effect.run*` call sites in service.ts:** 3
+  (`Effect.runPromise(Fiber.interrupt(...))` in cold path; `Effect.runFork`
+  inside `stop()`; `Effect.runFork` inside `dispose()`). Target ≤ 5 — clean.
+- **Tests needing semantic revision:** **0**. The plan predicted line 444's
+  concurrent-activate assertion would need to flip from
+  `toHaveBeenCalledTimes(1)` to `toHaveBeenCalledTimes(2)` under the new
+  interrupt-previous model. In practice, the second `svc.activate()` call
+  interrupts the first fiber **before** the first fiber reaches the `connect`
+  step (the mock's `getUserMedia` doesn't resolve in time for that under the
+  test's synchronous-ish setup), so `session.connect` is called exactly once
+  by the second fiber and the assertion remains accurate. No test
+  modifications were needed.
+- **Smoke-test teardown bug surfaced by manual testing that tests missed:**
+  **Deferred** — manual smoke testing requires a signed macOS build per
+  project memory `project_macos_mic_entitlements.md`. Subagent cannot run
+  smoke; controller fills in below.
 
-## Smoke test results
+## Canary verdict matrix (from spec § "Canary verdict criteria")
 
-1. Audio playback (3 paragraphs end-to-end): **deferred** — automated suite
-   passed; manual smoke deferred to controller (no display in subagent).
-2. Cancellation cleanliness (DevTools blob: URLs): **deferred** — same.
-3. Concurrency cap at maxConcurrent=8: **deferred** — same.
-4. Auth failure produces user-visible error + onError fires: **deferred** —
-   same. The automated `service.test.ts` cases for auth failure (existing)
-   and retry-exhausted (new) all pass.
+| TTS verdict | Voice Chat verdict | Decision |
+|---|---|---|
+| Neutral (actual) | **Better** | Sync gets Effect. Book Import gets Effect. Stage 2 proceeds. |
+| Neutral (actual) | **Neutral (this run)** | **Stage 2 stops here. Sync + Book Import stay plain TS. Two services have Effect inside (TTS, Voice Chat) — final tally.** |
+| Neutral (actual) | **Worse** | Stage 2 branch reverted. Voice Chat returns to plain TS. TTS Stage 2 stays merged. Stage 2 declared done. |
 
-## Deviations from the plan
+Verdict for this canary: **Neutral**.
 
-1. **Task 1 commit body** — Added a note about the worktree lacking a root
-   `pnpm-workspace.yaml`, which made the plan's instruction to commit
-   `pnpm-lock.yaml (workspace root)` inapplicable. Only `package.json` was
-   committed; the per-app lockfile `apps/rishi-electron/pnpm-lock.yaml` was
-   not regenerated. `effect` is installed and resolves via a transient
-   workspace install. Controller should regenerate the lockfile post-merge.
-2. **Task 3 program.ts** — Added local helpers `refGet`, `refUpdate`,
-   `queueSize` at file top (lines 88–92) instead of using the bare API. See
-   API uncertainty resolutions above.
-3. **Task 5 program.ts** — Replaced `Effect.catchAllCause` with
-   `Effect.onInterrupt` for the cancellation handler (lines 197–203). The
-   plan's code used `catchAllCause`, which does not fire on
-   `Fiber.interrupt` in effect@3.21.2; `onInterrupt` does. Verified with a
-   one-liner repro before committing.
-4. **Task 5 service.test.ts** — Tightened `makeScriptedFetch`'s return type
-   from `ReturnType<typeof vi.fn>` to the concrete
-   `(url: string, init: RequestInit) => Promise<Response>` so the mock
-   satisfies `TtsServiceDeps.fetch` without a cast (was a typecheck error
-   under stricter mock typings). Committed alongside the service.ts rewire.
-5. **Task 6** — `priorityqueuejs` and `@types/priorityqueuejs` were removed
-   from `package.json` by direct edit, not `pnpm remove`, because the
-   worktree's missing root `pnpm-workspace.yaml` makes the workspace
-   resolver reject `@rishi/shared`. The lockfile entries for these packages
-   remain stale until the controller regenerates.
-6. **Task 7 verification** — All steps ran clean; no fixes/amends needed.
-   Test count after Task 6 is 43 (not 33 as the plan stated); the
-   discrepancy comes from vitest re-running `cache.test.ts` cases via
-   `service.test.ts`'s import of `makeIpc` from `./cache.test`, which the
-   plan author didn't account for. The actual unique test cases are
-   15 (service) + 10 (cache) + 3 (emitter) + 5 (errors) = 33.
+## Manual smoke test results (deferred — controller fills in after signed build)
 
-## Other observations for the meta-spec
+Tested on a signed dev build (macOS — mic needs entitlements):
 
-- **The plan's `Ref.unsafeUpdate` fallback only covers half the surface.**
-  `Ref.unsafeGet` is also missing in effect v3.21 — the plan should call
-  this out alongside the `unsafeUpdate` warning. Same for `Queue.unsafeSize`,
-  which isn't even exported.
-- **Interrupt semantics are an Effect footgun.** `Effect.catchAllCause`
-  intuitively *should* handle interrupt causes (and the docs imply so), but
-  in practice doesn't — only `Effect.onInterrupt` does. Future plans
-  using Fiber.interrupt should call this out explicitly.
-- **Generator syntax is verbose.** Many `Effect.gen(function*() { yield* ... })`
-  blocks in `program.ts` would have been one-line `await`s in async/await.
-  This is a stylistic cost Effect imposes that's worth weighting against
-  perceived gains when scoring future candidate services.
+1. **Cold activation works.** Open a book, click voice launcher, mic prompt
+   appears, session establishes, agent responds: [PASS/FAIL — notes]
+2. **Cancel mid-activation is clean.** Click stop during the "connecting"
+   window. No hot mic, no zombie WebRTC connection visible in
+   chrome://webrtc-internals: [PASS/FAIL — notes]
+3. **Idle timer auto-disposes.** Click stop after the session is active.
+   Verify 'paused' state, advance the system clock 15 minutes, verify
+   auto-dispose to 'idle': [PASS/FAIL — notes]
+4. **Offline mid-session.** Toggle airplane mode mid-session. Verify
+   'offline' state, session closed. Toggle back on, verify return to 'idle':
+   [PASS/FAIL — notes]
+5. **Different book.** Open a different book while a session is live. Verify
+   the old session closes (session.close called once), the new one starts:
+   [PASS/FAIL — notes]
+
+## Recommendation
+
+Based on the verdict cell selected in the matrix above (Neutral + Neutral),
+the controller's follow-up action is:
+
+- **Append "Stage 2 outcome" section to the meta-spec marking the program
+  done with 2 services on Effect (TTS + Voice Chat).** Do not start Sync
+  Stage 2. Do not start Book Import Stage 2. Stage 2 is now closed.
+
+## Notes for the controller
+
+- The line-444 boundary test passes without modification under the
+  interrupt-previous model — see Evidence § "Tests needing semantic revision"
+  above. The plan's Task 6 anticipated a rewrite that turned out unnecessary;
+  this is documented in commit `be0c0b1e refactor(voice-chat): wire cold-path
+  to Effect activation-program`.
+- `key-cache.ts` reverted to its Stage 1 manual implementation (byte-for-byte)
+  after the `Cache.make` attempt failed the existing TTL-expiry test. The
+  decision rule was baked into the plan (Task 4 step 2). The "small win" is
+  deferred until either (a) the test moves to a real clock + sleep, or
+  (b) we adopt Effect's `TestClock` as a parallel test infrastructure.
+- The `refGet` / `refSet` / `refUpd` helpers at the top of
+  `activation-program.ts` are currently unused; they remain as a runtime
+  workaround documentation for lesson #1 (`Ref.unsafeGet`/`unsafeUpdate` are
+  not exported in `effect@3.21.2`). If/when an intra-program Ref is needed,
+  the helpers are ready.
+- No new test files beyond `errors.test.ts` (the 5 new tagged-error cases).
+  Total voice-chat test count went 54 → 59.

--- a/apps/rishi-electron/src/renderer/src/services/voice-chat/activation-program.ts
+++ b/apps/rishi-electron/src/renderer/src/services/voice-chat/activation-program.ts
@@ -23,8 +23,7 @@ import type {
 // is needed (service.ts's getState/getError contract is synchronous).
 const refGet = <A>(r: Ref.Ref<A>): A => Effect.runSync(Ref.get(r))
 const refSet = <A>(r: Ref.Ref<A>, v: A): void => Effect.runSync(Ref.set(r, v))
-const refUpd = <A>(r: Ref.Ref<A>, f: (a: A) => A): void =>
-  Effect.runSync(Ref.update(r, f))
+const refUpd = <A>(r: Ref.Ref<A>, f: (a: A) => A): void => Effect.runSync(Ref.update(r, f))
 
 // Re-export the helpers under a void-suppressing reference so TS doesn't
 // complain about unused helpers in this file. They are part of the intended
@@ -73,10 +72,10 @@ export interface ActivationProgram {
    * listeners (agent_start, audio_start, audio_stopped, agent_end,
    * agent_tool_start, agent_tool_end).
    */
-  activate(input: {
-    bookId: number
-    ctx: VoiceChatContext
-  }): { promise: Promise<SessionHandle>; fiber: Fiber.RuntimeFiber<SessionHandle, ActivationError> }
+  activate(input: { bookId: number; ctx: VoiceChatContext }): {
+    promise: Promise<SessionHandle>
+    fiber: Fiber.RuntimeFiber<SessionHandle, ActivationError>
+  }
 }
 
 /** True iff a thrown value came from Effect interpreting an interrupt cause. */
@@ -232,8 +231,7 @@ export function makeActivationProgram(a: ActivationDeps): ActivationProgram {
         }).pipe(
           Effect.timeoutFail({
             duration: Duration.millis(deps.config.connectTimeoutMs),
-            onTimeout: () =>
-              new ConnectTimeoutError({ ms: deps.config.connectTimeoutMs })
+            onTimeout: () => new ConnectTimeoutError({ ms: deps.config.connectTimeoutMs })
           })
         )
 

--- a/apps/rishi-electron/src/renderer/src/services/voice-chat/activation-program.ts
+++ b/apps/rishi-electron/src/renderer/src/services/voice-chat/activation-program.ts
@@ -1,0 +1,292 @@
+import { Effect, Ref, Fiber, Duration, Cause, Exit } from 'effect'
+import {
+  MicDeniedError,
+  AuthFailedError,
+  ConnectTimeoutError,
+  ConnectFailedError,
+  SessionError,
+  toPublicError,
+  type ActivationError
+} from './errors'
+import type {
+  AudioElementLike,
+  ChatStatus,
+  MediaStreamLike,
+  RealtimeSessionLike,
+  VoiceChatContext,
+  VoiceChatServiceDeps
+} from './types'
+
+// --- Sync Ref helpers (lesson #1) ---
+// Ref.unsafeGet / Ref.unsafeUpdate are NOT runtime exports in effect@3.21.2.
+// Only Ref.unsafeMake is callable. Use these wrappers everywhere sync access
+// is needed (service.ts's getState/getError contract is synchronous).
+const refGet = <A>(r: Ref.Ref<A>): A => Effect.runSync(Ref.get(r))
+const refSet = <A>(r: Ref.Ref<A>, v: A): void => Effect.runSync(Ref.set(r, v))
+const refUpd = <A>(r: Ref.Ref<A>, f: (a: A) => A): void =>
+  Effect.runSync(Ref.update(r, f))
+
+// Re-export the helpers under a void-suppressing reference so TS doesn't
+// complain about unused helpers in this file. They are part of the intended
+// API surface for future intra-program state needs (see plan lesson #1).
+void refGet
+void refSet
+void refUpd
+
+/**
+ * Bundle returned by the activation program on success. `service.ts` stores
+ * these on its closure-scoped slots and wires the `'error'` event handler
+ * itself (xstate-land — see spec § "xstate / Effect interaction").
+ *
+ * Calling `cleanup()` detaches the 6 chat-status listeners. The mic stream,
+ * audio element, and session itself are released by the program's Scope on
+ * fiber interrupt; on success they are owned by service.ts.
+ */
+export interface SessionHandle {
+  readonly session: RealtimeSessionLike
+  readonly mediaStream: MediaStreamLike
+  readonly audioElement: AudioElementLike
+  readonly cleanup: () => void
+}
+
+export interface ActivationDeps {
+  readonly deps: VoiceChatServiceDeps
+  readonly emit: {
+    chatStatus: (status: ChatStatus) => void
+    endedByAgent: (reason: string) => void
+  }
+  /** Plain-TS facade over Cache.make — see key-cache.ts (Task 4). */
+  readonly keyCacheGet: () => Promise<string>
+}
+
+export interface ActivationProgram {
+  /**
+   * Run the cold-path activation pipeline. Returns a Promise that resolves
+   * with a SessionHandle on success, or rejects with one of:
+   *   - A plain Error (mapped from a tagged ActivationError via toPublicError)
+   *   - A "synthetic interrupt" Error when the activation was superseded by
+   *     a subsequent activate() call (service.ts detects this via
+   *     isInterruptCause and silently absorbs it).
+   *
+   * The caller is responsible for installing the session 'error' handler
+   * AFTER this Promise resolves — the program only wires the 6 chat-status
+   * listeners (agent_start, audio_start, audio_stopped, agent_end,
+   * agent_tool_start, agent_tool_end).
+   */
+  activate(input: {
+    bookId: number
+    ctx: VoiceChatContext
+  }): { promise: Promise<SessionHandle>; fiber: Fiber.RuntimeFiber<SessionHandle, ActivationError> }
+}
+
+/** True iff a thrown value came from Effect interpreting an interrupt cause. */
+export function isInterruptCause(err: unknown): boolean {
+  if (err instanceof Error && err.message === '__VOICE_CHAT_INTERRUPTED__') return true
+  // Belt-and-braces for unwrapped FiberFailure cases.
+  if (typeof err === 'object' && err !== null && 'cause' in err) {
+    const c = (err as { cause: unknown }).cause
+    if (Cause.isCause(c) && Cause.isInterruptedOnly(c)) return true
+  }
+  return false
+}
+
+function mapMicError(e: unknown): MicDeniedError {
+  const name = (e as { name?: string })?.name
+  const message = (e as { message?: string })?.message ?? String(e)
+  if (name === 'NotAllowedError' || name === 'NotFoundError') {
+    return new MicDeniedError({ name, message })
+  }
+  return new MicDeniedError({ name: 'Unknown', message })
+}
+
+function msgOf(e: unknown): string {
+  return e instanceof Error ? e.message : String(e)
+}
+
+interface BuiltSession {
+  session: RealtimeSessionLike
+  cleanup: () => void
+}
+
+export function makeActivationProgram(a: ActivationDeps): ActivationProgram {
+  const { deps, emit, keyCacheGet } = a
+
+  function buildSession(
+    bookId: number,
+    ctx: VoiceChatContext,
+    mediaStream: MediaStreamLike,
+    audioElement: AudioElementLike
+  ): BuiltSession {
+    const transport = deps.webrtcFactory({ mediaStream, audioElement })
+    const agent = deps.agentFactory({
+      bookId,
+      pageText: ctx.pageText,
+      outline: ctx.outline,
+      onEndConversation: (reason) => emit.endedByAgent(reason),
+      rag: deps.rag
+    })
+    const session = deps.sessionFactory(agent, { transport, apiKey: '' })
+
+    let hasFiredReadyChime = false
+    let isAgentSpeaking = false
+
+    const onAgentStart = (): void => {
+      if (!hasFiredReadyChime) {
+        hasFiredReadyChime = true
+        deps.effects.playReadyChime()
+      }
+      emit.chatStatus('thinking')
+    }
+    const onAudioStart = (): void => {
+      isAgentSpeaking = true
+      emit.chatStatus('speaking')
+    }
+    const onAudioStopped = (): void => {
+      isAgentSpeaking = false
+      emit.chatStatus('idle')
+    }
+    const onAgentEnd = (): void => {
+      if (!isAgentSpeaking) emit.chatStatus('idle')
+    }
+    const onToolStart = (): void => deps.effects.startThinkingSound()
+    const onToolEnd = (): void => deps.effects.stopThinkingSound()
+
+    const listeners: Array<readonly [string, (...args: unknown[]) => void]> = [
+      ['agent_start', onAgentStart],
+      ['audio_start', onAudioStart],
+      ['audio_stopped', onAudioStopped],
+      ['agent_end', onAgentEnd],
+      ['agent_tool_start', onToolStart],
+      ['agent_tool_end', onToolEnd]
+    ]
+    for (const [evt, fn] of listeners) session.on(evt, fn)
+    const cleanup = (): void => {
+      for (const [evt, fn] of listeners) session.off(evt, fn)
+    }
+
+    return { session, cleanup }
+  }
+
+  const activationPipeline = (
+    bookId: number,
+    ctx: VoiceChatContext
+  ): Effect.Effect<SessionHandle, ActivationError> => {
+    // We use Effect.scoped so finalizers run on failure/interrupt. On success
+    // the activation returns a SessionHandle and we DETACH the inner finalizers
+    // by tracking acquired resources in local vars and using `Effect.acquireRelease`
+    // semantics inverted: finalizer = "release iff not yet consumed".
+    let success = false
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        // mic
+        const mediaStream = yield* Effect.acquireRelease(
+          Effect.tryPromise({
+            try: () => deps.media.getUserMedia({ audio: true }),
+            catch: (e) => mapMicError(e)
+          }),
+          (s) =>
+            Effect.sync(() => {
+              if (!success) s.getTracks().forEach((t) => t.stop())
+            })
+        )
+
+        // audio el
+        const audioElement = yield* Effect.acquireRelease(
+          Effect.sync(() => deps.media.createAudioElement()),
+          (el) =>
+            Effect.sync(() => {
+              if (!success) {
+                el.pause()
+                el.srcObject = null
+              }
+            })
+        )
+
+        // session
+        const built = yield* Effect.acquireRelease(
+          Effect.sync(() => buildSession(bookId, ctx, mediaStream, audioElement)),
+          (h) =>
+            Effect.sync(() => {
+              if (!success) {
+                h.cleanup()
+                try {
+                  h.session.close()
+                } catch {
+                  /* best-effort */
+                }
+              }
+            })
+        )
+
+        // key
+        const apiKey = yield* Effect.tryPromise({
+          try: () => keyCacheGet(),
+          catch: (e) => new AuthFailedError({ message: msgOf(e) })
+        })
+
+        // connect with timeout
+        yield* Effect.tryPromise({
+          try: () => built.session.connect({ apiKey }),
+          catch: (e) => new ConnectFailedError({ message: msgOf(e) })
+        }).pipe(
+          Effect.timeoutFail({
+            duration: Duration.millis(deps.config.connectTimeoutMs),
+            onTimeout: () =>
+              new ConnectTimeoutError({ ms: deps.config.connectTimeoutMs })
+          })
+        )
+
+        // unmute
+        yield* Effect.sync(() => {
+          built.session.mute(false)
+          audioElement.muted = false
+        })
+
+        // Mark success so finalizers above become no-ops.
+        success = true
+
+        return {
+          session: built.session,
+          mediaStream,
+          audioElement,
+          cleanup: built.cleanup
+        } satisfies SessionHandle
+      })
+    )
+  }
+
+  return {
+    activate({ bookId, ctx }) {
+      const fiber = Effect.runFork(activationPipeline(bookId, ctx))
+      const promise = new Promise<SessionHandle>((resolve, reject) => {
+        fiber.addObserver((exit) => {
+          if (Exit.isSuccess(exit)) {
+            resolve(exit.value)
+            return
+          }
+          // exit is Exit.Failure
+          const cause = exit.cause
+          if (Cause.isInterruptedOnly(cause)) {
+            // Superseded — surface a marker the service layer can recognize.
+            reject(new Error('__VOICE_CHAT_INTERRUPTED__'))
+            return
+          }
+          // Find the first tagged error; map to plain Error via toPublicError.
+          const failures = Array.from(Cause.failures(cause))
+          const first = failures.length > 0 ? failures[0] : null
+          if (first) {
+            reject(toPublicError(first as ActivationError))
+            return
+          }
+          // Defect — surface a generic ConnectFailedError-mapped Error.
+          reject(new Error(Cause.pretty(cause)))
+        })
+      })
+      return { promise, fiber }
+    }
+  }
+}
+
+// Silence unused-export warning for SessionError — re-exported by errors.ts.
+void SessionError

--- a/apps/rishi-electron/src/renderer/src/services/voice-chat/errors.test.ts
+++ b/apps/rishi-electron/src/renderer/src/services/voice-chat/errors.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MicDeniedError,
+  AuthFailedError,
+  ConnectTimeoutError,
+  ConnectFailedError,
+  SessionError,
+  reasonOf,
+  toPublicError
+} from './errors'
+
+describe('voice-chat tagged errors', () => {
+  it('MicDeniedError → public Error preserves the NotAllowedError name', () => {
+    const e = new MicDeniedError({ name: 'NotAllowedError', message: 'Permission denied' })
+    expect(reasonOf(e)).toBe('mic_denied')
+    const pub = toPublicError(e)
+    expect(pub).toBeInstanceOf(Error)
+    expect(pub.name).toBe('NotAllowedError')
+    expect(pub.message).toBe('Permission denied')
+  })
+
+  it('AuthFailedError → reason "auth_failed" and message preserved', () => {
+    const e = new AuthFailedError({ message: 'Not authenticated' })
+    expect(reasonOf(e)).toBe('auth_failed')
+    expect(toPublicError(e).message).toBe('Not authenticated')
+  })
+
+  it('ConnectTimeoutError → message uses the Stage-1 "timed out after Ns" format', () => {
+    const e = new ConnectTimeoutError({ ms: 60_000 })
+    expect(reasonOf(e)).toBe('timeout')
+    expect(toPublicError(e).message).toBe('Realtime session connect timed out after 60s')
+  })
+
+  it('ConnectFailedError → reason "connect_failed" with message verbatim', () => {
+    const e = new ConnectFailedError({ message: 'boom' })
+    expect(reasonOf(e)).toBe('connect_failed')
+    expect(toPublicError(e).message).toBe('boom')
+  })
+
+  it('SessionError → reason "session_error" with message verbatim', () => {
+    const e = new SessionError({ message: 'session blew up' })
+    expect(reasonOf(e)).toBe('session_error')
+    expect(toPublicError(e).message).toBe('session blew up')
+  })
+})

--- a/apps/rishi-electron/src/renderer/src/services/voice-chat/errors.ts
+++ b/apps/rishi-electron/src/renderer/src/services/voice-chat/errors.ts
@@ -1,0 +1,78 @@
+import { Data } from 'effect'
+import type { VoiceErrorReason } from './types'
+
+/**
+ * Activation-pipeline errors. Each `_tag` maps 1-to-1 to a Stage 1
+ * `VoiceErrorReason` value (with `'unknown'` collapsed into `ConnectFailedError`
+ * since Stage 1's classifyError() falls through there for unknown causes).
+ */
+
+export class MicDeniedError extends Data.TaggedError('MicDeniedError')<{
+  readonly name: 'NotAllowedError' | 'NotFoundError' | 'Unknown'
+  readonly message: string
+}> {}
+
+export class AuthFailedError extends Data.TaggedError('AuthFailedError')<{
+  readonly message: string
+}> {}
+
+export class ConnectTimeoutError extends Data.TaggedError('ConnectTimeoutError')<{
+  readonly ms: number
+}> {}
+
+export class ConnectFailedError extends Data.TaggedError('ConnectFailedError')<{
+  readonly message: string
+}> {}
+
+export class SessionError extends Data.TaggedError('SessionError')<{
+  readonly message: string
+}> {}
+
+export type ActivationError =
+  | MicDeniedError
+  | AuthFailedError
+  | ConnectTimeoutError
+  | ConnectFailedError
+  | SessionError
+
+/** Map a tagged activation error to the Stage 1 VoiceErrorReason enum. */
+export function reasonOf(e: ActivationError): VoiceErrorReason {
+  switch (e._tag) {
+    case 'MicDeniedError':
+      return 'mic_denied'
+    case 'AuthFailedError':
+      return 'auth_failed'
+    case 'ConnectTimeoutError':
+      return 'timeout'
+    case 'ConnectFailedError':
+      return 'connect_failed'
+    case 'SessionError':
+      return 'session_error'
+  }
+}
+
+/**
+ * Map an activation error to the plain `Error` the public `activate()` Promise
+ * rejects with. Message strings are byte-identical to Stage 1 so that
+ * existing service.test.ts assertions pass without modification.
+ *
+ * IMPORTANT: MicDeniedError preserves `.name` (e.g. 'NotAllowedError') because
+ * service.test.ts line 493 asserts `rejects.toMatchObject({ name: 'NotAllowedError' })`.
+ */
+export function toPublicError(e: ActivationError): Error {
+  switch (e._tag) {
+    case 'MicDeniedError': {
+      const err = new Error(e.message || e.name)
+      Object.defineProperty(err, 'name', { value: e.name, writable: false })
+      return err
+    }
+    case 'AuthFailedError':
+      return new Error(e.message || 'Not authenticated')
+    case 'ConnectTimeoutError':
+      return new Error(`Realtime session connect timed out after ${e.ms / 1000}s`)
+    case 'ConnectFailedError':
+      return new Error(e.message)
+    case 'SessionError':
+      return new Error(e.message)
+  }
+}

--- a/apps/rishi-electron/src/renderer/src/services/voice-chat/key-cache.ts
+++ b/apps/rishi-electron/src/renderer/src/services/voice-chat/key-cache.ts
@@ -14,6 +14,18 @@ export interface KeyCacheDeps {
   clock: ClockPort
 }
 
+/**
+ * Stage 2 fallback implementation.
+ *
+ * Initial Stage 2 attempt swapped internals to `Cache.make` from Effect,
+ * which uses the real wall clock for TTL. The existing test injects a fake
+ * clock and advances it past the TTL via `clock.setNow(1001)`; under
+ * `Cache.make`, no real time elapsed so the cached entry was returned and
+ * the TTL-expiry test failed. Per the plan's documented decision rule we
+ * retain the Stage 1 manual implementation (byte-for-byte) so the public
+ * contract — and the four existing test cases — pass unchanged. The "small
+ * win" of replacing this with `Cache.make` is deferred.
+ */
 export function createKeyCache(deps: KeyCacheDeps): KeyCache {
   const { fetch, ttlMs, clock } = deps
   let cached: { key: string; fetchedAt: number } | null = null

--- a/apps/rishi-electron/src/renderer/src/services/voice-chat/service.ts
+++ b/apps/rishi-electron/src/renderer/src/services/voice-chat/service.ts
@@ -1,8 +1,11 @@
+import { Effect, Fiber } from 'effect'
 import { createActor } from 'xstate'
 import { voiceChatMachine } from './machine'
 import { createEmitter } from './emitter'
 import { createKeyCache } from './key-cache'
 import { OfflineError } from './types'
+import { makeActivationProgram, isInterruptCause, type SessionHandle } from './activation-program'
+import { type ActivationError } from './errors'
 import { captureError } from '@/utils/sentry'
 import type {
   AudioElementLike,
@@ -33,18 +36,7 @@ function fingerprintContext(ctx: VoiceChatContext): string {
 }
 
 export function createVoiceChatService(deps: VoiceChatServiceDeps): VoiceChatService {
-  const {
-    rag,
-    connectivity,
-    ipc,
-    webrtcFactory,
-    agentFactory,
-    sessionFactory,
-    media,
-    effects,
-    clock,
-    config
-  } = deps
+  const { rag, connectivity, ipc, agentFactory, effects, clock, config } = deps
 
   const stateEmitter = createEmitter<VoiceChatPublicState>()
   const chatStatusEmitter = createEmitter<ChatStatus>()
@@ -66,7 +58,16 @@ export function createVoiceChatService(deps: VoiceChatServiceDeps): VoiceChatSer
     clock
   })
 
-  // Session-scoped state, in closure (not module).
+  const program = makeActivationProgram({
+    deps,
+    emit: {
+      chatStatus: (s) => chatStatusEmitter.emit(s),
+      endedByAgent: (r) => endedByAgentEmitter.emit(r)
+    },
+    keyCacheGet: () => keyCache.get()
+  })
+
+  // Session-scoped state, in closure.
   let session: RealtimeSessionLike | null = null
   let sessionCleanup: (() => void) | null = null
   let currentBookId: number | null = null
@@ -75,11 +76,8 @@ export function createVoiceChatService(deps: VoiceChatServiceDeps): VoiceChatSer
   let audioElement: AudioElementLike | null = null
   let lastContextFingerprint: string | null = null
   let hasUsedVoiceInSession = false
-  let activateInFlight: Promise<void> | null = null
-  let activateGeneration = 0
+  let currentFiber: Fiber.RuntimeFiber<SessionHandle, ActivationError> | null = null
   let preconnectIntent = false
-  let hasFiredReadyChime = false
-  let isAgentSpeaking = false
   let connectivityUnsub: (() => void) | null = null
   let started = false
 
@@ -124,16 +122,22 @@ export function createVoiceChatService(deps: VoiceChatServiceDeps): VoiceChatSer
       audioElement = null
     }
     chatStatusEmitter.emit('idle')
-    hasFiredReadyChime = false
-    isAgentSpeaking = false
     lastContextFingerprint = null
   }
 
-  async function doActivate(
-    bookId: number,
-    ctx: VoiceChatContext,
-    gen: number
-  ): Promise<void> {
+  function onSessionError(err: unknown) {
+    captureError(err, { operation: 'voiceChatService', step: 'session_error' })
+    effects.stopThinkingSound()
+    actor.send({
+      type: 'SESSION_ERROR',
+      reason: 'session_error',
+      message: err instanceof Error ? err.message : undefined
+    })
+    disposeInternal()
+    actor.send({ type: 'DISPOSE' })
+  }
+
+  async function doActivate(bookId: number, ctx: VoiceChatContext): Promise<void> {
     clearIdleTimer()
 
     // Different bookId — dispose existing session first.
@@ -142,7 +146,7 @@ export function createVoiceChatService(deps: VoiceChatServiceDeps): VoiceChatSer
       actor.send({ type: 'DISPOSE' })
     }
 
-    // Warm path: same bookId, session still alive.
+    // Warm path: same bookId, session still alive. Plain TS — no Effect.
     if (session && currentBookId === bookId) {
       actor.send({ type: 'CONNECT_STARTED' })
       try {
@@ -156,165 +160,68 @@ export function createVoiceChatService(deps: VoiceChatServiceDeps): VoiceChatSer
             rag
           })
           await session.updateAgent(newAgent)
-          if (gen !== activateGeneration) return
           lastContextFingerprint = fp
         }
         session.mute(false)
         if (audioElement) audioElement.muted = false
-        if (gen !== activateGeneration) return
         actor.send({ type: 'CONNECT_SUCCEEDED' })
         chatStatusEmitter.emit('idle')
       } catch (err) {
         captureError(err, { operation: 'voiceChatService', step: 'activate_warm' })
-        if (gen === activateGeneration) {
-          actor.send({
-            type: 'CONNECT_FAILED',
-            reason: classifyError(err),
-            message: err instanceof Error ? err.message : undefined
-          })
-        }
-        throw err
-      }
-      return
-    }
-
-    // Cold path.
-    actor.send({ type: 'CONNECT_STARTED' })
-    chatStatusEmitter.emit('connecting')
-
-    let newSession: RealtimeSessionLike | null = null
-    try {
-      if (!mediaStream) {
-        mediaStream = await media.getUserMedia({ audio: true })
-      }
-      if (!audioElement) {
-        audioElement = media.createAudioElement()
-      }
-      const transport = webrtcFactory({ mediaStream, audioElement })
-      const agent = agentFactory({
-        bookId,
-        pageText: ctx.pageText,
-        outline: ctx.outline,
-        onEndConversation: (reason) => endedByAgentEmitter.emit(reason),
-        rag
-      })
-      newSession = sessionFactory(agent, { transport, apiKey: '' })
-
-      const status = (s: ChatStatus) => chatStatusEmitter.emit(s)
-      const onAgentStart = () => {
-        if (!hasFiredReadyChime) {
-          hasFiredReadyChime = true
-          effects.playReadyChime()
-        }
-        status('thinking')
-      }
-      const onAudioStart = () => {
-        isAgentSpeaking = true
-        status('speaking')
-      }
-      const onAudioStopped = () => {
-        isAgentSpeaking = false
-        status('idle')
-      }
-      const onAgentEnd = () => {
-        if (!isAgentSpeaking) status('idle')
-      }
-      const onToolStart = () => effects.startThinkingSound()
-      const onToolEnd = () => effects.stopThinkingSound()
-      const onError = (err: unknown) => {
-        captureError(err, { operation: 'voiceChatService', step: 'session_error' })
-        effects.stopThinkingSound()
-        actor.send({
-          type: 'SESSION_ERROR',
-          reason: 'session_error',
-          message: err instanceof Error ? err.message : undefined
-        })
-        disposeInternal()
-        actor.send({ type: 'DISPOSE' })
-      }
-      newSession.on('agent_start', onAgentStart)
-      newSession.on('audio_start', onAudioStart)
-      newSession.on('audio_stopped', onAudioStopped)
-      newSession.on('agent_end', onAgentEnd)
-      newSession.on('agent_tool_start', onToolStart)
-      newSession.on('agent_tool_end', onToolEnd)
-      newSession.on('error', onError)
-
-      const s = newSession
-      sessionCleanup = () => {
-        s.off('agent_start', onAgentStart)
-        s.off('audio_start', onAudioStart)
-        s.off('audio_stopped', onAudioStopped)
-        s.off('agent_end', onAgentEnd)
-        s.off('agent_tool_start', onToolStart)
-        s.off('agent_tool_end', onToolEnd)
-        s.off('error', onError)
-      }
-
-      const apiKey = await keyCache.get()
-
-      // Connect with timeout race.
-      let connectTimeout: ReturnType<ClockPort['setTimeout']> | null = null
-      try {
-        await Promise.race([
-          newSession.connect({ apiKey }),
-          new Promise<never>((_, reject) => {
-            connectTimeout = clock.setTimeout(() => {
-              reject(
-                new Error(
-                  `Realtime session connect timed out after ${config.connectTimeoutMs / 1000}s`
-                )
-              )
-            }, config.connectTimeoutMs)
-          })
-        ])
-      } finally {
-        if (connectTimeout !== null) clock.clearTimeout(connectTimeout)
-      }
-
-      if (gen !== activateGeneration) {
-        // Stale activation — tear down half-built session and bail without
-        // emitting CONNECT_SUCCEEDED.
-        if (sessionCleanup) sessionCleanup()
-        sessionCleanup = null
-        try {
-          newSession.close()
-        } catch {
-          /* best effort */
-        }
-        return
-      }
-
-      session = newSession
-      currentBookId = bookId
-      lastContextFingerprint = fingerprintContext(ctx)
-      if (audioElement) audioElement.muted = false
-      newSession.mute(false)
-      actor.send({ type: 'CONNECT_SUCCEEDED' })
-      chatStatusEmitter.emit('idle')
-      hasUsedVoiceInSession = true
-    } catch (err) {
-      captureError(err, { operation: 'voiceChatService', step: 'activate_cold' })
-      if (sessionCleanup) {
-        sessionCleanup()
-        sessionCleanup = null
-      }
-      if (newSession) {
-        try {
-          newSession.close()
-        } catch {
-          /* best effort */
-        }
-      }
-      if (gen === activateGeneration) {
         actor.send({
           type: 'CONNECT_FAILED',
           reason: classifyError(err),
           message: err instanceof Error ? err.message : undefined
         })
-        chatStatusEmitter.emit('idle')
+        throw err
       }
+      return
+    }
+
+    // Cold path — Effect program.
+    if (currentFiber) {
+      // Supersede the previous activation. The acquireRelease releases inside
+      // the program will tear down any half-built resources automatically.
+      await Effect.runPromise(Fiber.interrupt(currentFiber))
+    }
+
+    actor.send({ type: 'CONNECT_STARTED' })
+    chatStatusEmitter.emit('connecting')
+
+    const { promise, fiber } = program.activate({ bookId, ctx })
+    currentFiber = fiber
+
+    try {
+      const handle = await promise
+
+      // Hand resources to service.ts's closure.
+      session = handle.session
+      mediaStream = handle.mediaStream
+      audioElement = handle.audioElement
+      sessionCleanup = handle.cleanup
+      currentBookId = bookId
+      lastContextFingerprint = fingerprintContext(ctx)
+
+      // Wire the session 'error' handler post-resolve (xstate-land, not Effect).
+      session.on('error', onSessionError)
+
+      actor.send({ type: 'CONNECT_SUCCEEDED' })
+      chatStatusEmitter.emit('idle')
+      hasUsedVoiceInSession = true
+    } catch (err) {
+      // Superseded by a subsequent activate() — silent.
+      if (isInterruptCause(err)) return
+
+      captureError(err, { operation: 'voiceChatService', step: 'activate_cold' })
+      actor.send({
+        type: 'CONNECT_FAILED',
+        reason: classifyError(err),
+        message: err instanceof Error ? err.message : undefined
+      })
+      chatStatusEmitter.emit('idle')
       throw err
+    } finally {
+      if (currentFiber === fiber) currentFiber = null
     }
   }
 
@@ -335,10 +242,14 @@ export function createVoiceChatService(deps: VoiceChatServiceDeps): VoiceChatSer
     stop() {
       if (!started) return
       started = false
+      // Interrupt any in-flight activation, then tear down.
+      if (currentFiber) {
+        Effect.runFork(Fiber.interrupt(currentFiber))
+        currentFiber = null
+      }
       disposeInternal()
       if (connectivityUnsub) connectivityUnsub()
       connectivityUnsub = null
-      activateGeneration++
     },
 
     async activate(bookId, ctx) {
@@ -346,33 +257,17 @@ export function createVoiceChatService(deps: VoiceChatServiceDeps): VoiceChatSer
         actor.send({ type: 'OFFLINE' })
         throw new OfflineError()
       }
-      // A user-initiated activate (i.e. NOT initiated by preconnect itself)
-      // should clear preconnectIntent so the post-activate auto-mute in
-      // preconnect() becomes a no-op when the user has already taken over.
-      // preconnect() routes through activate() but suppresses this reset by
-      // first setting preconnectIntent itself then re-asserting after the
-      // activate resolves (see preconnect()).
-      activateGeneration++
-      const gen = activateGeneration
-      if (activateInFlight) return activateInFlight
-      activateInFlight = doActivate(bookId, ctx, gen)
-      try {
-        await activateInFlight
-      } finally {
-        activateInFlight = null
-      }
+      await doActivate(bookId, ctx)
     },
 
     async preconnect(bookId, ctx) {
       if (!hasUsedVoiceInSession) return
       if (!connectivity.isOnline()) return
       if (session && currentBookId === bookId) return
-      if (activateInFlight) return
       preconnectIntent = true
       try {
         await svc.activate(bookId, ctx)
         if (preconnectIntent && session) {
-          // Cast to RealtimeSessionLike for closure-scoped narrowing.
           const s: RealtimeSessionLike = session
           s.interrupt()
           s.mute(true)
@@ -404,6 +299,10 @@ export function createVoiceChatService(deps: VoiceChatServiceDeps): VoiceChatSer
     },
 
     dispose() {
+      if (currentFiber) {
+        Effect.runFork(Fiber.interrupt(currentFiber))
+        currentFiber = null
+      }
       disposeInternal()
       actor.send({ type: 'DISPOSE' })
     },


### PR DESCRIPTION
## Summary

Second Stage 2 retrofit, after TTS (PR #14 — Neutral). Scoped conservatively per the Neutral TTS verdict: only the cold-path activation pipeline + tagged errors move to Effect. xstate machine, emitter, idle timer, warm path, key-cache, connectivity subscription all stay plain TS.

## Canary verdict: Neutral

0 of 3 pain signals triggered — no abort. LoC delta +285 (about +60% of `service.ts`'s old size, but the new code is in a separate file).

**Wins:**
- `Effect.acquireRelease` triple for mic / audio element / session captures the WebRTC resource lifecycle cleanly — correct-by-construction teardown on success, failure, AND interrupt
- `Effect.timeoutFail` is a one-line replacement for the manual `Promise.race(...setTimeout)` connect-timeout
- All 54 boundary tests pass unchanged; 5 new tagged-error tests added (total 59); zero assertion modifications needed

**Friction:**
- `Effect.scoped` runs finalizers on **success** too — required a `success` flag inversion pattern that's non-obvious
- `Cause.isInterruptedOnly` is awkward to surface at the Promise boundary → resolved with a sentinel `Error.message` string (`__VOICE_CHAT_INTERRUPTED__`), a workaround that smells but is contained
- `key-cache.ts` swap to `Effect.Cache.make` had to be reverted — Effect's Cache uses wall clock, the existing test injects a fake clock. Reverted to manual TTL byte-for-byte
- The lesson-#1 `refGet`/`refSet`/`refUpd` helpers are kept at file top but currently unused; deadweight for documentation

## Canary decision matrix outcome

| TTS | Voice Chat | Result |
|---|---|---|
| Neutral | **Neutral (this PR)** | **Stage 2 stops here. Sync + Book Import stay plain TS.** |

Final Stage 2 tally: 2 services on Effect (TTS, Voice Chat). The meta-spec's deferred Stage 2 services (Sync, Book Import) are now explicitly closed.

## Code changes (5 commits)

1. \`refactor(voice-chat): add tagged activation errors for Stage 2\` — \`errors.ts\` (5 tagged classes + \`toPublicError\`) + \`errors.test.ts\` (5 cases). Byte-identical \`Error.message\` strings to Stage 1's \`ActivationErrorReason\` enum.
2. \`refactor(voice-chat): add Effect-based activation program (not yet wired)\` — 290-line \`activation-program.ts\`: \`Effect.gen\` cold-path with three \`acquireRelease\` blocks (mic stream, audio element, session listeners), \`Effect.timeoutFail\` for 60s connect timeout, success-flag inversion pattern for finalizer correctness.
3. \`refactor(voice-chat): document key-cache Cache.make deferral\` — \`key-cache.ts\` stays at its Stage 1 manual implementation. Adds explanatory comment.
4. \`refactor(voice-chat): wire cold-path to Effect activation-program\` — \`service.ts\` cold-path replaced by \`Effect.runFork(activationProgram(...))\` + fiber capture. \`stop()\`/\`dispose()\` use \`Effect.runFork(Fiber.interrupt(...))\`. The xstate machine doesn't know Effect exists.
5. \`chore(voice-chat): record Stage 2 canary verdict (Neutral)\` — \`.canary-verdict.md\` with full Neutral verdict and matrix outcome.

## What's frozen

\`\`\`bash
git diff main..HEAD -- apps/rishi-electron/src/renderer/src/services/voice-chat/index.ts apps/rishi-electron/src/renderer/src/services/voice-chat/types.ts apps/rishi-electron/src/renderer/src/services/voice-chat/machine.ts
# (empty)

grep -rn "from 'effect'" apps/rishi-electron/src/renderer/src/services/voice-chat/
# activation-program.ts, errors.ts, service.ts (the latter only for Effect.runFork + Fiber.interrupt at the Promise boundary)
\`\`\`

## Test plan

- [x] \`pnpm vitest run src/renderer/src/services/voice-chat/\` — 59 passed (54 baseline + 5 new errors.test.ts cases). Zero assertions modified.
- [x] \`pnpm typecheck:web\` — clean (only the 2 pre-existing errors on main: navStore.test.ts NAVIGATE enum + connectivity types.test.ts onLine assertion).
- [ ] Manual smoke (deferred — needs signed dev build for mic entitlements per project memory \`project_macos_mic_entitlements.md\`): cold activation works, cancel mid-activation has no zombie WebRTC, idle timer auto-disposes after 15m, offline mid-session closes cleanly, opening a different book closes the old session and starts the new.

## Follow-ups (not part of this PR)

- **Stage 2 is now done.** No follow-up Stage 2 work on Sync or Book Import per the verdict matrix.
- Append "Stage 2 outcome" section to \`docs/superpowers/specs/2026-05-11-services-and-effect-adoption-design.md\` marking the program closed with 2 services on Effect.