### PR TITLE
fix(vectordb): enable allowReplaceDeleted on hnsw index creation + load

### DIFF
--- a/apps/rishi-electron/src/main/vectordb/index.ts
+++ b/apps/rishi-electron/src/main/vectordb/index.ts
@@ -75,7 +75,9 @@ function requireHnsw(): HierarchicalNSWType {
 function createIndex(dim: number, maxElements: number): InstanceType<HierarchicalNSWType> {
   const HNSW = requireHnsw()
   const index = new HNSW('cosine', dim)
-  index.initIndex(maxElements, M, EF_CONSTRUCTION)
+  // 5th arg `allowReplaceDeleted` must be true so saveVectors can call
+  // addPoint(..., replaceDeleted=true) when re-embedding existing chunks.
+  index.initIndex(maxElements, M, EF_CONSTRUCTION, 100, true)
   index.setEf(DEFAULT_EF_SEARCH)
   return index
 }
@@ -90,7 +92,9 @@ function loadIndexFromDisk(name: string, dim: number): IndexEntry | undefined {
 
   const HNSW = requireHnsw()
   const index = new HNSW('cosine', dim)
-  index.readIndexSync(filePath)
+  // 2nd arg `allowReplaceDeleted` must match what createIndex sets so
+  // addPoint(..., replaceDeleted=true) works for indices loaded from disk.
+  index.readIndexSync(filePath, true)
   index.setEf(DEFAULT_EF_SEARCH)
 
   const count = index.getCurrentCount()


### PR DESCRIPTION
## Summary

Fixes the "Hnswlib Error: Replacement of deleted elements is disabled in constructor" error in the vectors:save IPC handler, observed during smoke testing.

## Root cause

\`saveVectors\` (introduced in \`e44ab1b9 fix(rag): re-embed when chunks exist but vectors are missing\`) calls \`index.addPoint(vector, id, true /* replace_deleted */)\` when re-embedding existing chunks. hnswlib-node rejects that call unless the index was constructed with \`allowReplaceDeleted=true\`.

Both code paths that create or load an index were missing the flag:
- \`createIndex\` calls \`initIndex(maxElements, M, EF_CONSTRUCTION)\` — needs \`(..., 100, true)\` (5th arg, with 4th randomSeed defaulted to 100 to keep the prior implicit behavior)
- \`loadIndexFromDisk\` calls \`readIndexSync(filePath)\` — needs \`(filePath, true)\` (2nd arg)

## Verification

Manual smoke (in-flight): the user hit the error during re-embedding flow. After this fix the same flow should complete without the hnswlib exception.

## Test plan

- [ ] Re-run the flow that triggered the original error (open a book that triggers re-embedding); confirm no hnswlib error in main-process log
- [x] No automated test added: hnswlib is a native binary, so a meaningful test would require either pulling the real binary into vitest (slow + flaky) or mocking it (won't catch this argument-shape bug). The fix is 2 lines targeting a documented API contract.