### PR TITLE
fix(voice-chat): surface realtime-agent tool-call failures (dump + console + sentry)

### DIFF
--- a/apps/rishi-electron/src/renderer/src/modules/buildRealtimeAgent.test.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/buildRealtimeAgent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { buildRealtimeAgent } from './buildRealtimeAgent'
 
 const searchSemanticMock = vi.fn().mockResolvedValue([{ text: 'stub', vectorId: 1, score: 0.9 }])
@@ -9,7 +9,16 @@ vi.mock('@/services', () => ({
   })
 }))
 
+const captureErrorMock = vi.fn()
+vi.mock('@/utils/sentry', () => ({
+  captureError: (...args: unknown[]) => captureErrorMock(...args)
+}))
+
 describe('buildRealtimeAgent', () => {
+  beforeEach(() => {
+    captureErrorMock.mockClear()
+    ;(window.electron.dumpError as ReturnType<typeof vi.fn>).mockClear()
+  })
   it('embeds the current page text into the instructions', () => {
     const agent = buildRealtimeAgent({
       bookId: 42,
@@ -122,5 +131,74 @@ describe('buildRealtimeAgent', () => {
     expect(agent.instructions).toContain('Anon Book')
     expect(agent.instructions).not.toContain('null')
     expect(agent.instructions).not.toContain('undefined')
+  })
+
+  it('bookContext failure: dumps to error file, logs to console, returns fallback', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    searchSemanticMock.mockRejectedValueOnce(new Error('rag exploded'))
+
+    const agent = buildRealtimeAgent({
+      bookId: 42,
+      pageText: 'x',
+      onEndConversation: vi.fn()
+    })
+    const bookContextTool = agent.tools.find(
+      (t: { name: string }) => t.name === 'bookContext'
+    ) as unknown as {
+      execute: (args: { queryText: string }) => Promise<unknown>
+    }
+
+    const result = await bookContextTool.execute({ queryText: 'anything' })
+    expect(result).toEqual(['Unable to retrieve book context at this time.'])
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[voice-chat] tool 'bookContext' failed:",
+      expect.objectContaining({ message: 'rag exploded' })
+    )
+    expect(window.electron.dumpError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'voice-chat-agent',
+        location: 'realtimeAgent.tools.bookContext',
+        error: 'rag exploded'
+      })
+    )
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'rag exploded' }),
+      expect.objectContaining({ operation: 'realtime', step: 'bookContext_tool' })
+    )
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('endConversation failure: callback throw still dumps + logs + does not propagate', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const onEnd = vi.fn().mockImplementation(() => {
+      throw new Error('callback boom')
+    })
+
+    const agent = buildRealtimeAgent({
+      bookId: 42,
+      pageText: 'x',
+      onEndConversation: onEnd
+    })
+    const endTool = agent.tools.find(
+      (t: { name: string }) => t.name === 'endConversation'
+    ) as unknown as {
+      execute: (args: { reason: string }) => Promise<unknown>
+    }
+
+    // Must not throw — the agent infra would otherwise be unable to advance.
+    await expect(endTool.execute({ reason: 'bye' })).resolves.toBeUndefined()
+
+    expect(window.electron.dumpError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'voice-chat-agent',
+        location: 'realtimeAgent.tools.endConversation',
+        error: 'callback boom'
+      })
+    )
+    expect(captureErrorMock).toHaveBeenCalled()
+
+    consoleErrorSpy.mockRestore()
   })
 })

--- a/apps/rishi-electron/src/renderer/src/modules/buildRealtimeAgent.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/buildRealtimeAgent.ts
@@ -3,7 +3,48 @@ import type { BookOutline } from '@/lib/api'
 import type { RagService } from '@/services/rag'
 import { RealtimeAgent, tool } from '@openai/agents/realtime'
 import { z } from 'zod'
+import { Effect } from 'effect'
 import { captureError } from '@/utils/sentry'
+
+/**
+ * Runs a realtime-agent tool execute under Effect so failures are observable
+ * in three places at once (console, local error-dump file, Sentry) instead of
+ * being silently swallowed by the OpenAI agents library. The tool still
+ * resolves with `fallback` so the agent can keep the conversation flowing.
+ *
+ * Effect is here (vs plain try/catch) because tool calls are the most
+ * error-prone surface in the voice-chat flow — IPC, network, and provider
+ * latency all converge — and we want the option to add `Effect.timeout` /
+ * retry later without restructuring.
+ */
+function runToolCall<T>(
+  toolName: string,
+  fallback: T,
+  task: () => Promise<T>
+): Promise<T> {
+  const program = Effect.tryPromise({
+    try: task,
+    catch: (err) => (err instanceof Error ? err : new Error(String(err)))
+  }).pipe(
+    Effect.catchAll((err) =>
+      Effect.sync(() => {
+        console.error(`[voice-chat] tool '${toolName}' failed:`, err)
+        void window.electron
+          .dumpError({
+            source: 'voice-chat-agent',
+            location: `realtimeAgent.tools.${toolName}`,
+            error: err.message,
+            stack: err.stack ?? null,
+            context: null
+          })
+          .catch(() => undefined)
+        captureError(err, { operation: 'realtime', step: `${toolName}_tool` })
+        return fallback
+      })
+    )
+  )
+  return Effect.runPromise(program)
+}
 
 export interface BuildAgentOptions {
   bookId: number
@@ -70,15 +111,11 @@ export function buildRealtimeAgent({
   rag
 }: BuildAgentOptions): RealtimeAgent {
   const ragService: RagService = rag ?? getRagService()
-  const bookContextExecute = async ({ queryText }: { queryText: string }) => {
-    try {
+  const bookContextExecute = ({ queryText }: { queryText: string }) =>
+    runToolCall<string[]>('bookContext', ['Unable to retrieve book context at this time.'], async () => {
       const chunks = await ragService.searchSemantic(queryText, bookId, 3)
       return chunks.map((c) => c.text)
-    } catch (err) {
-      captureError(err, { operation: 'realtime', step: 'bookContext_tool' })
-      return ['Unable to retrieve book context at this time.']
-    }
-  }
+    })
 
   const bookContextTool = Object.assign(
     tool({
@@ -93,9 +130,10 @@ export function buildRealtimeAgent({
     { execute: bookContextExecute }
   )
 
-  const endConversationExecute = async ({ reason }: { reason: string }) => {
-    onEndConversation(reason)
-  }
+  const endConversationExecute = ({ reason }: { reason: string }) =>
+    runToolCall<void>('endConversation', undefined, async () => {
+      onEndConversation(reason)
+    })
 
   const endConversationTool = Object.assign(
     tool({


### PR DESCRIPTION
## Summary

When the bookContext tool call fails (e.g., RAG IPC throws), the user reported they only see "Unable to retrieve book context at this time." with zero information about what failed. The catch block only sent the error to Sentry — nothing to local console, nothing to the error-dump file.

This PR routes every realtime-agent tool failure through three channels at once:

1. \`console.error(\`[voice-chat] tool '\${name}' failed:\`, err)\` — visible in DevTools
2. \`window.electron.dumpError({ source, location, error, stack, context })\` — appears in \`apps/main/error-dump.json\` per project memory \`reference_error_dump.md\`
3. \`captureError(err, { operation: 'realtime', step: \`\${name}_tool\` })\` — Sentry (was already there for bookContext only)

The tool still resolves with a fallback so the agent can keep talking. Endconversation tool also gets the same treatment (it had no error handling at all).

## Why Effect

The user asked for this area to be handled by Effect-TS because it's error-prone. The wrapper is built on \`Effect.tryPromise\` + \`Effect.catchAll\`. The win isn't a big LoC compression here — it's that tool calls are the most error-prone surface in the voice-chat flow (IPC + network + provider latency converge), and the wrapper leaves the door open for \`Effect.timeout\` / retry later without restructuring callers. Per the Stage 2 verdict's case-by-case rubric: this is a contained boundary, not a service-wide retrofit.

## What changed

- \`buildRealtimeAgent.ts\`: new \`runToolCall\` Effect helper; bookContext + endConversation executes now route through it.
- \`buildRealtimeAgent.test.ts\`: 2 new tests pinning failure behavior (dump shape, console message, fallback return, no propagation).

## Test plan

- [x] \`pnpm vitest run src/renderer/src/modules/buildRealtimeAgent.test.ts\` — 11 passed (9 baseline + 2 new failure-path)
- [x] \`pnpm typecheck:web\` — only the 2 pre-existing main errors (navStore NAVIGATE, connectivity types onLine)
- [ ] Manual smoke (in-flight): trigger a bookContext call that fails (e.g., disable network), verify (a) console log shows the error, (b) \`apps/main/error-dump.json\` gets a new entry, (c) agent still responds with the fallback