### PR TITLE
chore(sentry): switch to unified rishi project DSN

### DIFF
--- a/apps/rishi-electron/src/main/utils/sentry.ts
+++ b/apps/rishi-electron/src/main/utils/sentry.ts
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/electron/main'
 
 const DSN =
   process.env.SENTRY_DSN ||
-  'https://79d31f9f084402224dc303f699941691@o4510586781958144.ingest.de.sentry.io/4510586797555792'
+  'https://37b935f34d09bb053baeff3a28d6b9d1@o4510586781958144.ingest.de.sentry.io/4511372584747088'
 
 let initialized = false
 

--- a/apps/rishi-electron/src/renderer/src/utils/sentry.ts
+++ b/apps/rishi-electron/src/renderer/src/utils/sentry.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/electron/renderer'
 
 const DSN =
-  'https://79d31f9f084402224dc303f699941691@o4510586781958144.ingest.de.sentry.io/4510586797555792'
+  'https://37b935f34d09bb053baeff3a28d6b9d1@o4510586781958144.ingest.de.sentry.io/4511372584747088'
 
 let initialized = false
 


### PR DESCRIPTION
## Summary

Updates both main-process and renderer-process Sentry initializers to report to the new unified \`rishi\` project DSN (\`4511372584747088\`).

## Files changed

- \`apps/rishi-electron/src/main/utils/sentry.ts\` (line 6)
- \`apps/rishi-electron/src/renderer/src/utils/sentry.ts\` (line 4)

## Test plan

- [x] Both files compile (no logic change, just DSN string swap)
- [ ] Manual smoke (after merge): trigger a captured error and confirm it lands in the \`rishi\` Sentry project