### PR TITLE
fix(voice-chat): dump empty tool results, not just thrown errors

### DIFF
--- a/apps/rishi-electron/src/renderer/src/modules/buildRealtimeAgent.test.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/buildRealtimeAgent.test.ts
@@ -133,6 +133,42 @@ describe('buildRealtimeAgent', () => {
     expect(agent.instructions).not.toContain('undefined')
   })
 
+  it('bookContext empty result: dumps with context, warns to console, returns the empty array', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    searchSemanticMock.mockResolvedValueOnce([])
+
+    const agent = buildRealtimeAgent({
+      bookId: 42,
+      pageText: 'x',
+      onEndConversation: vi.fn()
+    })
+    const bookContextTool = agent.tools.find(
+      (t: { name: string }) => t.name === 'bookContext'
+    ) as unknown as {
+      execute: (args: { queryText: string }) => Promise<unknown>
+    }
+
+    const result = await bookContextTool.execute({ queryText: 'what is X' })
+    expect(result).toEqual([])
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      "[voice-chat] tool 'bookContext' returned empty result. context:",
+      'bookId=42 queryText="what is X"'
+    )
+    expect(window.electron.dumpError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'voice-chat-agent',
+        location: 'realtimeAgent.tools.bookContext',
+        error: 'empty result',
+        context: 'bookId=42 queryText="what is X"'
+      })
+    )
+    // Sentry should NOT fire on empty — only on real errors.
+    expect(captureErrorMock).not.toHaveBeenCalled()
+
+    consoleWarnSpy.mockRestore()
+  })
+
   it('bookContext failure: dumps to error file, logs to console, returns fallback', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     searchSemanticMock.mockRejectedValueOnce(new Error('rag exploded'))

--- a/apps/rishi-electron/src/renderer/src/modules/buildRealtimeAgent.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/buildRealtimeAgent.ts
@@ -7,10 +7,21 @@ import { Effect } from 'effect'
 import { captureError } from '@/utils/sentry'
 
 /**
- * Runs a realtime-agent tool execute under Effect so failures are observable
- * in three places at once (console, local error-dump file, Sentry) instead of
- * being silently swallowed by the OpenAI agents library. The tool still
- * resolves with `fallback` so the agent can keep the conversation flowing.
+ * Runs a realtime-agent tool execute under Effect so its outcome is
+ * observable in three places at once (console, local error-dump file,
+ * Sentry on error) instead of being silently swallowed by the OpenAI agents
+ * library. The tool still resolves with `fallback` on error so the agent
+ * can keep the conversation flowing.
+ *
+ * Three outcomes get logged:
+ *   - `error`  → console.error + dumpError + captureError, return fallback
+ *   - `empty`  → console.warn + dumpError (no Sentry), return real result
+ *   - `ok`     → console.info only
+ *
+ * "Empty" is opt-in via the optional `inspect` arg — the caller decides
+ * what counts as an empty result for that tool (e.g., `[].length === 0`
+ * for bookContext). Knowing the difference between "tool errored" and
+ * "tool returned 0 hits" is the most common debugging question.
  *
  * Effect is here (vs plain try/catch) because tool calls are the most
  * error-prone surface in the voice-chat flow — IPC, network, and provider
@@ -20,12 +31,37 @@ import { captureError } from '@/utils/sentry'
 function runToolCall<T>(
   toolName: string,
   fallback: T,
-  task: () => Promise<T>
+  task: () => Promise<T>,
+  inspect?: {
+    isEmpty: (result: T) => boolean
+    contextOnEmpty: () => string
+  }
 ): Promise<T> {
   const program = Effect.tryPromise({
     try: task,
     catch: (err) => (err instanceof Error ? err : new Error(String(err)))
   }).pipe(
+    Effect.tap((result) =>
+      Effect.sync(() => {
+        if (inspect && inspect.isEmpty(result)) {
+          console.warn(
+            `[voice-chat] tool '${toolName}' returned empty result. context:`,
+            inspect.contextOnEmpty()
+          )
+          void window.electron
+            .dumpError({
+              source: 'voice-chat-agent',
+              location: `realtimeAgent.tools.${toolName}`,
+              error: 'empty result',
+              stack: null,
+              context: inspect.contextOnEmpty()
+            })
+            .catch(() => undefined)
+        } else {
+          console.info(`[voice-chat] tool '${toolName}' ok`)
+        }
+      })
+    ),
     Effect.catchAll((err) =>
       Effect.sync(() => {
         console.error(`[voice-chat] tool '${toolName}' failed:`, err)
@@ -112,10 +148,18 @@ export function buildRealtimeAgent({
 }: BuildAgentOptions): RealtimeAgent {
   const ragService: RagService = rag ?? getRagService()
   const bookContextExecute = ({ queryText }: { queryText: string }) =>
-    runToolCall<string[]>('bookContext', ['Unable to retrieve book context at this time.'], async () => {
-      const chunks = await ragService.searchSemantic(queryText, bookId, 3)
-      return chunks.map((c) => c.text)
-    })
+    runToolCall<string[]>(
+      'bookContext',
+      ['Unable to retrieve book context at this time.'],
+      async () => {
+        const chunks = await ragService.searchSemantic(queryText, bookId, 3)
+        return chunks.map((c) => c.text)
+      },
+      {
+        isEmpty: (chunks) => chunks.length === 0,
+        contextOnEmpty: () => `bookId=${bookId} queryText=${JSON.stringify(queryText)}`
+      }
+    )
 
   const bookContextTool = Object.assign(
     tool({


### PR DESCRIPTION
## Summary

PR #19 dumped errors but missed the silent-empty case: when \`searchSemantic\` returns \`[]\` (no vectors saved, query too vague, hits don't resolve to chunks), it's not an exception. The agent gets \`[]\` and tells the user "I can't help beyond the current page" — indistinguishable from a real error in the dump file.

This PR adds an optional \`inspect\` arg to \`runToolCall\`:

\`\`\`ts
inspect?: { isEmpty: (result) => boolean, contextOnEmpty: () => string }
\`\`\`

When \`isEmpty(result)\` is true:
- \`console.warn(...)\` with the empty-context string
- \`window.electron.dumpError({ error: 'empty result', context })\` to the dump file
- NO Sentry capture — empty is a data problem, not a code problem

bookContext now uses it: empty array → dump entry with \`bookId=N queryText="..."\` so devs can see the user's question and the book it ran against.

## Three outcomes now logged

| Outcome | console | dump file | Sentry |
|---|---|---|---|
| error  | \`console.error\` | yes | yes |
| empty  | \`console.warn\`  | yes | no |
| ok     | \`console.info\`  | no  | no |

## Test plan

- [x] \`pnpm vitest run src/renderer/src/modules/buildRealtimeAgent.test.ts\` — 12 passed (1 new empty-result case)
- [ ] Manual smoke: ask the voice agent a question requiring book context for a book with no saved vectors. Confirm new entry in \`error-dump.json\` with \`error: "empty result"\` and \`context: "bookId=N queryText=\"...\""\`.