### PR TITLE
feat(book-import): visible indexing — UI indicator + agent awareness

### DIFF
--- a/apps/rishi-electron/src/renderer/src/components/IndexingStatusIndicator.test.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/IndexingStatusIndicator.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { IndexingStatusIndicator } from './IndexingStatusIndicator'
+import type { ImportProgressEvent } from '@/services/book-import'
+
+const subscribers = new Set<(e: ImportProgressEvent) => void>()
+const emit = (e: ImportProgressEvent): void => subscribers.forEach((cb) => cb(e))
+
+vi.mock('@/services', () => ({
+  getBookImportService: () => ({
+    onImportProgress: (cb: (e: ImportProgressEvent) => void) => {
+      subscribers.add(cb)
+      return () => subscribers.delete(cb)
+    }
+  })
+}))
+
+describe('IndexingStatusIndicator', () => {
+  it('renders nothing when idle', () => {
+    const { container } = render(<IndexingStatusIndicator />)
+    expect(container.textContent).toBe('')
+  })
+
+  it('shows "Indexing..." while an indexing event is in flight', () => {
+    const { container } = render(<IndexingStatusIndicator />)
+    act(() => {
+      emit({ kind: 'indexing', bookId: 42, reason: 'vectors-missing' })
+    })
+    expect(container.textContent).toContain('Indexing...')
+  })
+
+  it('hides itself when indexing completes successfully', () => {
+    const { container } = render(<IndexingStatusIndicator />)
+    act(() => emit({ kind: 'indexing', bookId: 42, reason: 'chunks-missing' }))
+    expect(container.textContent).toContain('Indexing...')
+    act(() => emit({ kind: 'indexed', bookId: 42, ok: true }))
+    expect(container.textContent).toBe('')
+  })
+
+  it('shows "Indexing failed" when indexing completes with ok=false', () => {
+    const { container } = render(<IndexingStatusIndicator />)
+    act(() => emit({ kind: 'indexing', bookId: 42, reason: 'vectors-missing' }))
+    act(() => emit({ kind: 'indexed', bookId: 42, ok: false }))
+    expect(container.textContent).toContain('Indexing failed')
+  })
+})

--- a/apps/rishi-electron/src/renderer/src/components/IndexingStatusIndicator.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/IndexingStatusIndicator.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react'
+import { getBookImportService } from '@/services'
+
+/**
+ * Shows "Indexing..." with a spinner whenever the book-import service is
+ * embedding chunks into the vector store. Mounted in the bottom-right of
+ * the app shell, mirroring the SyncStatusIndicator (bottom-left). Hides
+ * itself when no indexing is in flight.
+ *
+ * Listens to ImportProgressEvent: 'indexing' / 'indexed' from book-import.
+ */
+type IndexingPhase = 'idle' | 'indexing' | 'failed'
+
+export function IndexingStatusIndicator() {
+  const [phase, setPhase] = useState<IndexingPhase>('idle')
+
+  useEffect(() => {
+    return getBookImportService().onImportProgress((event) => {
+      if (event.kind === 'indexing') setPhase('indexing')
+      else if (event.kind === 'indexed') setPhase(event.ok ? 'idle' : 'failed')
+    })
+  }, [])
+
+  if (phase === 'idle') return null
+
+  const labels: Record<Exclude<IndexingPhase, 'idle'>, { text: string; color: string }> = {
+    indexing: { text: 'Indexing...', color: 'text-blue-500' },
+    failed: { text: 'Indexing failed', color: 'text-red-500' }
+  }
+  const label = labels[phase]
+
+  return (
+    <div className={`text-xs ${label.color} flex items-center gap-1`}>
+      {phase === 'indexing' && (
+        <span className="animate-spin inline-block w-3 h-3 border border-current border-t-transparent rounded-full" />
+      )}
+      {label.text}
+    </div>
+  )
+}

--- a/apps/rishi-electron/src/renderer/src/modules/buildRealtimeAgent.test.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/buildRealtimeAgent.test.ts
@@ -2,10 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { buildRealtimeAgent } from './buildRealtimeAgent'
 
 const searchSemanticMock = vi.fn().mockResolvedValue([{ text: 'stub', vectorId: 1, score: 0.9 }])
+const isIndexingMock = vi.fn().mockReturnValue(false)
 
 vi.mock('@/services', () => ({
   getRagService: () => ({
     searchSemantic: searchSemanticMock
+  }),
+  getBookImportService: () => ({
+    isIndexing: isIndexingMock
   })
 }))
 
@@ -17,6 +21,7 @@ vi.mock('@/utils/sentry', () => ({
 describe('buildRealtimeAgent', () => {
   beforeEach(() => {
     captureErrorMock.mockClear()
+    isIndexingMock.mockReturnValue(false)
     ;(window.electron.dumpError as ReturnType<typeof vi.fn>).mockClear()
   })
   it('embeds the current page text into the instructions', () => {
@@ -131,6 +136,30 @@ describe('buildRealtimeAgent', () => {
     expect(agent.instructions).toContain('Anon Book')
     expect(agent.instructions).not.toContain('null')
     expect(agent.instructions).not.toContain('undefined')
+  })
+
+  it('bookContext while indexing: returns wait-message, does NOT call searchSemantic', async () => {
+    isIndexingMock.mockReturnValue(true)
+    searchSemanticMock.mockClear()
+
+    const agent = buildRealtimeAgent({
+      bookId: 42,
+      pageText: 'x',
+      onEndConversation: vi.fn()
+    })
+    const bookContextTool = agent.tools.find(
+      (t: { name: string }) => t.name === 'bookContext'
+    ) as unknown as {
+      execute: (args: { queryText: string }) => Promise<unknown>
+    }
+
+    const result = (await bookContextTool.execute({
+      queryText: 'what does chapter 3 say'
+    })) as string[]
+
+    expect(searchSemanticMock).not.toHaveBeenCalled()
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatch(/still indexing/i)
   })
 
   it('bookContext empty result: dumps with context, warns to console, returns the empty array', async () => {

--- a/apps/rishi-electron/src/renderer/src/modules/buildRealtimeAgent.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/buildRealtimeAgent.ts
@@ -1,4 +1,4 @@
-import { getRagService } from '@/services'
+import { getRagService, getBookImportService } from '@/services'
 import type { BookOutline } from '@/lib/api'
 import type { RagService } from '@/services/rag'
 import { RealtimeAgent, tool } from '@openai/agents/realtime'
@@ -152,6 +152,15 @@ export function buildRealtimeAgent({
       'bookContext',
       ['Unable to retrieve book context at this time.'],
       async () => {
+        // If indexing is still in flight for this book, the vector store
+        // doesn't have all embeddings yet — searchSemantic would return a
+        // partial or empty result. Return a sentinel instruction that the
+        // agent reads aloud so the user knows to wait a moment.
+        if (getBookImportService().isIndexing(bookId)) {
+          return [
+            "I'm still indexing this book — please give me a moment and try asking again."
+          ]
+        }
         const chunks = await ragService.searchSemantic(queryText, bookId, 3)
         return chunks.map((c) => c.text)
       },

--- a/apps/rishi-electron/src/renderer/src/routes/__root.tsx
+++ b/apps/rishi-electron/src/renderer/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import { useEffect, type JSX } from 'react'
 import { getBooks } from '@/lib/api'
 import { getSyncService } from '@/services'
 import { SyncStatusIndicator } from '../components/SyncStatusIndicator'
+import { IndexingStatusIndicator } from '../components/IndexingStatusIndicator'
 import { NetworkBanner } from '../components/NetworkBanner'
 import { WelcomeModal } from '@/components/auth/WelcomeModal'
 import { SignInBanner } from '@/components/auth/SignInBanner'
@@ -62,6 +63,9 @@ function RootComponent(): JSX.Element {
       <TourProvider />
       <div className="fixed bottom-4 left-4 z-50 w-40">
         <SyncStatusIndicator />
+      </div>
+      <div className="fixed bottom-4 right-4 z-50 w-40 flex justify-end">
+        <IndexingStatusIndicator />
       </div>
       <NetworkBanner />
     </>

--- a/apps/rishi-electron/src/renderer/src/services/book-import/indexer.test.ts
+++ b/apps/rishi-electron/src/renderer/src/services/book-import/indexer.test.ts
@@ -106,7 +106,10 @@ describe('indexBook — full pipeline (chunks + vectors)', () => {
     expect(saveVectorsCalls).toHaveLength(1)
     expect(saveVectorsCalls[0].name).toBe('42-vectordb')
     expect(saveVectorsCalls[0].dim).toBe(3)
-    expect(events).toEqual([{ kind: 'indexing', bookId: 42, reason: 'chunks-missing' }])
+    expect(events).toEqual([
+      { kind: 'indexing', bookId: 42, reason: 'chunks-missing' },
+      { kind: 'indexed', bookId: 42, ok: true }
+    ])
   })
 })
 
@@ -127,7 +130,10 @@ describe('indexBook — re-embed regression (chunks exist, vectors missing)', ()
     expect(savePageDataCalls).toEqual([])
     expect(saveVectorsCalls).toHaveLength(1)
     expect(saveVectorsCalls[0].name).toBe('42-vectordb')
-    expect(events).toEqual([{ kind: 'indexing', bookId: 42, reason: 'vectors-missing' }])
+    expect(events).toEqual([
+      { kind: 'indexing', bookId: 42, reason: 'vectors-missing' },
+      { kind: 'indexed', bookId: 42, ok: true }
+    ])
   })
 })
 
@@ -167,6 +173,28 @@ describe('indexBook — reads pageData from DB when omitted', () => {
 
     expect(db.getAllPageDataByBookId).toHaveBeenCalledWith(42)
     expect(saveVectorsCalls).toHaveLength(1)
-    expect(events).toEqual([{ kind: 'indexing', bookId: 42, reason: 'vectors-missing' }])
+    expect(events).toEqual([
+      { kind: 'indexing', bookId: 42, reason: 'vectors-missing' },
+      { kind: 'indexed', bookId: 42, ok: true }
+    ])
+  })
+})
+
+describe('indexBook — emits `indexed: ok=false` on embed failure', () => {
+  it('still emits the final indexed event so listeners (e.g. UI indicators) can clear', async () => {
+    const { db } = makeDb({ chunksExist: false })
+    const rag = makeRag()
+    const embed = makeEmbed({ failNTimes: 1 })
+    const events: ImportProgressEvent[] = []
+
+    await indexBook(
+      { db, rag, embed, embedBatchSize: 2 },
+      42,
+      samplePageData,
+      (e) => events.push(e)
+    )
+
+    const indexed = events.find((e) => e.kind === 'indexed')
+    expect(indexed).toEqual({ kind: 'indexed', bookId: 42, ok: false })
   })
 })

--- a/apps/rishi-electron/src/renderer/src/services/book-import/indexer.ts
+++ b/apps/rishi-electron/src/renderer/src/services/book-import/indexer.ts
@@ -67,6 +67,7 @@ export async function indexBook(
   }
 
   // Embed + save vectors. Best-effort: swallow failures so page data stays.
+  let ok = true
   try {
     const embedParams: EmbedParam[] = pageData.map((p) => ({
       text: p.data,
@@ -80,6 +81,8 @@ export async function indexBook(
       }
     }
   } catch (err) {
+    ok = false
     console.error('[book-import] embedding/vector save failed, will retry on next open:', err)
   }
+  progressEmit({ kind: 'indexed', bookId, ok })
 }

--- a/apps/rishi-electron/src/renderer/src/services/book-import/service.test.ts
+++ b/apps/rishi-electron/src/renderer/src/services/book-import/service.test.ts
@@ -210,6 +210,30 @@ describe('BookImportService.indexBook', () => {
     expect(db.getAllPageDataByBookId).toHaveBeenCalledWith(42)
     expect(db.saveVectors).toHaveBeenCalledTimes(1)
   })
+
+  it('isIndexing reflects in-flight state: false → true during run → false after', async () => {
+    const { db } = makeRagDb({ chunksExist: false })
+    const rag = makeRag()
+    // Use a deferred embed so we can observe the in-flight state mid-call.
+    let resolveEmbed!: (value: never[]) => void
+    const embedDeferred = new Promise<never[]>((res) => {
+      resolveEmbed = res as (v: never[]) => void
+    })
+    const embed = vi.fn(() => embedDeferred) as unknown as ReturnType<typeof makeEmbed>
+    const service = createBookImportService(makeDeps({ db, rag, embed }))
+
+    expect(service.isIndexing(42)).toBe(false)
+
+    const inflight = service.indexBook(42, [{ id: 1, pageNumber: 1, bookId: 42, data: 'A' }])
+    // Yield once so the indexer reaches its await on embed().
+    await Promise.resolve()
+    expect(service.isIndexing(42)).toBe(true)
+    expect(service.isIndexing(99)).toBe(false)
+
+    resolveEmbed([] as never[])
+    await inflight
+    expect(service.isIndexing(42)).toBe(false)
+  })
 })
 
 describe('BookImportService.startDiscovery', () => {

--- a/apps/rishi-electron/src/renderer/src/services/book-import/service.ts
+++ b/apps/rishi-electron/src/renderer/src/services/book-import/service.ts
@@ -61,13 +61,24 @@ export function createBookImportService(deps: BookImportServiceDeps): BookImport
     return results
   }
 
+  const indexingBookIds = new Set<number>()
+
   async function indexBook(bookId: number, pageData?: PageDataInsertable[]): Promise<void> {
-    await runIndex(
-      { db: deps.db, rag: deps.rag, embed: deps.embed, embedBatchSize: deps.config.embedBatchSize },
-      bookId,
-      pageData,
-      (e) => progress.emit(e)
-    )
+    indexingBookIds.add(bookId)
+    try {
+      await runIndex(
+        { db: deps.db, rag: deps.rag, embed: deps.embed, embedBatchSize: deps.config.embedBatchSize },
+        bookId,
+        pageData,
+        (e) => progress.emit(e)
+      )
+    } finally {
+      indexingBookIds.delete(bookId)
+    }
+  }
+
+  function isIndexing(bookId: number): boolean {
+    return indexingBookIds.has(bookId)
   }
 
   function startDiscovery(mode: 'default' | 'full'): void {
@@ -92,6 +103,7 @@ export function createBookImportService(deps: BookImportServiceDeps): BookImport
     importFromPath,
     importBatch,
     indexBook,
+    isIndexing,
     startDiscovery,
     cancelDiscovery,
     onDiscoveryEvent: (listener) => discovery.on(listener),

--- a/apps/rishi-electron/src/renderer/src/services/book-import/types.ts
+++ b/apps/rishi-electron/src/renderer/src/services/book-import/types.ts
@@ -55,6 +55,7 @@ export type ImportProgressEvent =
   | { kind: 'upload-started'; filePath: string; bookId: number }
   | { kind: 'upload-failed'; filePath: string; bookId: number; error: string }
   | { kind: 'indexing'; bookId: number; reason: 'chunks-missing' | 'vectors-missing' }
+  | { kind: 'indexed'; bookId: number; ok: boolean }
   | { kind: 'done'; filePath: string; bookId: number; format: BookFormat }
   | { kind: 'failed'; filePath: string; stage: ImportFailure['stage']; error: string }
 
@@ -166,6 +167,13 @@ export interface BookImportService {
    * chunks from the DB via `db.getAllPageDataByBookId`.
    */
   indexBook(bookId: number, pageData?: PageDataInsertable[]): Promise<void>
+
+  /**
+   * Returns true while `indexBook(bookId, …)` is in flight. Used by the
+   * voice-chat realtime agent to tell the user "still indexing, try again"
+   * instead of returning an empty bookContext result.
+   */
+  isIndexing(bookId: number): boolean
 
   /**
    * Start the scanner. Calling while a scan is running cancels the prior scan


### PR DESCRIPTION
## Summary

Two complementary visibility upgrades for the indexing pipeline:

### 1. IndexingStatusIndicator (bottom-right)

Mirrors \`SyncStatusIndicator\` in the bottom-left. Shows "Indexing..." with a spinner during indexing, hides itself on success, shows "Indexing failed" on failure.

Mounted in \`__root.tsx\` at \`fixed bottom-4 right-4 z-50\`.

### 2. Voice-chat agent indexing awareness

The realtime agent's \`bookContext\` tool now checks \`getBookImportService().isIndexing(bookId)\` BEFORE calling \`searchSemantic\`. If indexing is in flight, returns a sentinel string the agent reads aloud:

> "I'm still indexing this book — please give me a moment and try asking again."

This avoids the silent-empty failure mode where the agent says "I can't help" for what's really just a timing problem (book opened, indexing kicked off, user asks question, indexing hasn't finished yet).

## What changed

### New surfaces
- \`ImportProgressEvent\`: + \`{ kind: 'indexed'; bookId; ok: boolean }\` — emitted at end of \`indexBook\` so listeners can clear
- \`BookImportService\`: + \`isIndexing(bookId): boolean\` — tracked via in-flight Set, set/cleared in service.indexBook wrapper

### Files
- \`services/book-import/types.ts\` — added \`indexed\` event + \`isIndexing\` method
- \`services/book-import/indexer.ts\` — emits \`indexed\` at end (ok=true on success, ok=false on failure)
- \`services/book-import/service.ts\` — wraps \`indexBook\` to track in-flight bookIds; exposes \`isIndexing\`
- \`components/IndexingStatusIndicator.tsx\` — new component (mirrors SyncStatusIndicator)
- \`routes/__root.tsx\` — mounts new indicator in bottom-right
- \`modules/buildRealtimeAgent.ts\` — bookContext checks \`isIndexing\` before RAG call

### Tests (+10 cases)
- \`indexer.test.ts\` — \`indexed\` event emitted with ok=true/false
- \`service.test.ts\` — \`isIndexing\` lifecycle (false → true mid-call → false)
- \`IndexingStatusIndicator.test.tsx\` — 4 cases (idle / indexing / success-hide / failure-show)
- \`buildRealtimeAgent.test.ts\` — bookContext returns wait-message when isIndexing=true, skips searchSemantic

## Test plan

- [x] \`pnpm vitest run\` for affected suites — 54 passed
- [x] \`pnpm typecheck:web\` — only the 2 pre-existing main errors (navStore NAVIGATE, connectivity types onLine)
- [ ] Manual smoke: delete \`~/Library/Application Support/rishi-electron/vectordb/1-vectordb.hnsw\` (per prior diagnosis — file has corrupt IDs), reopen the book, verify the bottom-right shows "Indexing..." for ~30s-2min until embedding completes, hides on done. While indexing, ask the voice agent about chapter content; the agent should say "still indexing" instead of the silent-empty fallback.