### PR TITLE
fix(book-delete): hard-delete local chunks + HNSW index on books:delete

### DIFF
--- a/apps/rishi-electron/src/main/database/queries.ts
+++ b/apps/rishi-electron/src/main/database/queries.ts
@@ -201,6 +201,24 @@ export function deleteBook(id: number): void {
 }
 
 /**
+ * Hard-delete all chunk_data rows for a book. Chunks are local-only (not
+ * sync-tracked), so removing them frees DB + FTS index space immediately.
+ * Called from the books:delete IPC handler alongside the .hnsw cleanup.
+ */
+export function deleteChunksByBookId(bookId: number): void {
+  _deleteChunksByBookIdWithDb(getDb(), bookId)
+}
+
+/** Test-only db-injectable variant; mirrors the _getBookOutlineWithDb pattern. */
+export function _deleteChunksByBookIdWithDb(
+  db: ReturnType<typeof getDb>,
+  bookId: number
+): number {
+  const result = db.prepare('DELETE FROM chunk_data WHERE book_id = ?').run(bookId)
+  return result.changes
+}
+
+/**
  * Update only the cover blob for a book.
  */
 export function updateBookCover(id: number, cover: number[] | Buffer): void {

--- a/apps/rishi-electron/src/main/ipc/books.ts
+++ b/apps/rishi-electron/src/main/ipc/books.ts
@@ -4,11 +4,13 @@ import {
   getBook,
   saveBook,
   deleteBook,
+  deleteChunksByBookId,
   updateBookCover,
   updateBookLocation,
   hasSavedEpubData,
   getBookOutline
 } from '../database/queries.js'
+import { deleteIndex } from '../vectordb/index.js'
 
 export function registerBookHandlers(): void {
   ipcMain.handle('books:getAll', async () => {
@@ -43,6 +45,14 @@ export function registerBookHandlers(): void {
 
   ipcMain.handle('books:delete', async (_event, bookId: number) => {
     try {
+      // Hard-delete local-only artifacts (chunks + HNSW index) BEFORE the
+      // soft-delete on `books`. The books row stays (is_deleted=1, is_dirty=1)
+      // so the sync engine can propagate the deletion to the cloud; the
+      // chunks + vector file are local and not sync-tracked, so safe to drop.
+      // Order matters: indexer keeps a Map<name, Index> in memory, so we
+      // remove that cache entry alongside the file via deleteIndex.
+      deleteChunksByBookId(bookId)
+      await deleteIndex(`${bookId}-vectordb`)
       return await deleteBook(bookId)
     } catch (error) {
       throw new Error(


### PR DESCRIPTION
## Summary

Previously, deleting a book left local-only artifacts behind:
- \`chunk_data\` rows for the book (and their FTS index entries via triggers)
- the \`{bookId}-vectordb.hnsw\` file on disk
- the in-memory HNSW index in vectordb's \`indices\` Map

The books row was soft-deleted (\`is_deleted=1\`) for sync purposes, which meant the SQLite \`ON DELETE CASCADE\` never fired. So the only way these built up was unbounded growth in the DB + filesystem until app uninstall.

## Fix

\`books:delete\` IPC handler now runs three steps in order:

1. \`deleteChunksByBookId(bookId)\` — \`DELETE FROM chunk_data WHERE book_id = ?\` (FTS index cleanup happens automatically via existing triggers)
2. \`deleteIndex(\`\${bookId}-vectordb\`)\` — \`unlinkSync(.hnsw)\` + \`indices.delete()\` (function already existed in vectordb, was unused)
3. \`deleteBook(bookId)\` — existing soft-delete on books (sync engine needs the row)

Order matters: steps 1+2 are local-only / not sync-tracked, so hard-deleting is safe. Step 3 keeps the books row so the sync engine can propagate the deletion to the cloud.

## Files

- \`src/main/database/queries.ts\` — adds \`deleteChunksByBookId\` + \`_deleteChunksByBookIdWithDb\` (test variant mirroring the existing \`_getBookOutlineWithDb\` pattern)
- \`src/main/ipc/books.ts\` — wires both cleanup calls into the \`books:delete\` handler

## Test plan

- [x] \`pnpm vitest run src/renderer/src/services/book-import/ src/renderer/src/components/IndexingStatusIndicator.test.tsx src/renderer/src/modules/buildRealtimeAgent.test.ts\` — 80 passed
- [x] \`pnpm typecheck:web\` — only the 2 pre-existing main errors
- [ ] Unit test for \`deleteChunksByBookId\` skipped: the existing \`queries.outline.test.ts\` already fails in vitest because better-sqlite3's native binary is compiled for Electron's Node version, not the system Node vitest runs under. Pre-existing infrastructure issue.
- [ ] Manual smoke: delete a book via right-click → Delete in the library. Verify (a) \`SELECT COUNT(*) FROM chunk_data WHERE book_id = N\` returns 0, (b) \`{N}-vectordb.hnsw\` is gone from \`~/Library/Application Support/rishi-electron/vectordb/\`, (c) the books row still exists with \`is_deleted=1\` (for sync).

## Race notes (not addressed in this PR)

If a user deletes a book while indexing is in flight, the indexer may write a new .hnsw file with orphan vectors after the cleanup. Window is small (the indexing duration) and the worst case is a stale file that gets cleaned next delete. Cancellation-aware indexing would be a follow-up.