### PR TITLE
fix(book-index): chunk_data.id now matches hnsw vector labels (root-cause empty bookContext)

### DIFF
--- a/apps/rishi-electron/src/main/database/queries.ts
+++ b/apps/rishi-electron/src/main/database/queries.ts
@@ -274,18 +274,27 @@ export function hasSavedEpubData(bookId: number): boolean {
 
 /**
  * Bulk-insert page data rows inside a single transaction for performance.
+ *
+ * Honors `row.id` when supplied so callers (specifically the book-import
+ * indexer) can pin chunk PKs to the hash-derived IDs produced by
+ * `stringToNumberID(bookId-section-startCfi-endCfi)`. Those same IDs are
+ * used as hnsw vector labels in saveVectors, so chunk_data.id and hnsw
+ * labels must align for getTextFromVectorId lookups to resolve.
+ *
+ * If `row.id` is omitted, SQLite assigns an AUTOINCREMENT id (legacy path).
  */
 export function savePageDataMany(pageData: PageData[]): void {
   if (pageData.length === 0) return
 
   const db = getDb()
   const stmt = db.prepare(
-    'INSERT INTO chunk_data (page_number, book_id, data) VALUES (@pageNumber, @bookId, @data)'
+    'INSERT INTO chunk_data (id, page_number, book_id, data) VALUES (@id, @pageNumber, @bookId, @data)'
   )
 
   const insertMany = db.transaction((rows: PageData[]) => {
     for (const row of rows) {
       stmt.run({
+        id: row.id ?? null,
         pageNumber: row.pageNumber,
         bookId: row.bookId,
         data: row.data


### PR DESCRIPTION
## Root cause

After PR #22 shipped the indexing indicator, the user re-imported a book and ran a clean indexing pass. The indicator hid (indexing succeeded). But voice-chat \`bookContext\` *still* returned empty for reasonable queries like \"Chapter 3, Logic and Critical Thinking\".

Direct inspection:

\`\`\`bash
$ sqlite3 ~/Library/Application\\ Support/rishi-electron/rishi.db \\
    'SELECT MIN(id), MAX(id), COUNT(*) FROM chunk_data WHERE book_id=1'
1 | 580 | 580

$ node -e "const {HierarchicalNSW}=require('hnswlib-node'); const i=new HierarchicalNSW('cosine',384); i.readIndexSync('.../1-vectordb.hnsw',true); const q=new Array(384).fill(0).map(()=>Math.random()-0.5); console.log(i.searchKnn(q,5).neighbors)"
[ 697431709, 1571515557, 438324003, 384221857, 1761291347 ]
\`\`\`

580 chunks with IDs **1..580**, but hnsw vectors carry **hash-derived labels** like 697431709. \`searchVectors\` returns hits, \`getTextFromVectorId(697431709)\` resolves nothing, all hits filter out, agent gets \`[]\`.

## Why the mismatch

\`epubwrapper.ts:388\` generates a stable hash ID per paragraph:

\`\`\`ts
id: stringToNumberID(bookId + '-' + sectionId + '-' + startCfi + '-' + endCfi)
\`\`\`

The indexer passes this to BOTH \`savePageDataMany\` (chunk DB insert) AND \`saveVectors\` (hnsw label). But \`savePageDataMany\` was silently dropping the \`id\`:

\`\`\`ts
// before
'INSERT INTO chunk_data (page_number, book_id, data) VALUES (...)'
\`\`\`

SQLite assigned AUTOINCREMENT IDs 1..N. The hash IDs went to hnsw unchanged. The two diverged.

## Fix

Include \`id\` in the INSERT. When \`row.id\` is supplied, SQLite uses it; when omitted, pass null and SQLite autoincrements (backward compat for any legacy caller).

After this fix, chunk_data.id = vector label = hash-of-paragraph-cfi. \`getTextFromVectorId\` resolves cleanly.

Bonus: hash IDs are stable across imports (same paragraph → same id), so re-indexing the same book doesn't churn IDs.

## Impact

Existing books need their chunks + .hnsw rebuilt for the fix to apply. PR #23 (already merged) made \`books:delete\` clean up chunks + hnsw, so the user can: right-click → Delete in the library → re-import.

## Test plan

- [x] \`pnpm typecheck:web\` — only the 2 pre-existing main errors
- [ ] Manual smoke: delete + re-import a book → after indexing finishes, sqlite chunk_data.id range matches hnsw label range, voice chat returns real content for queries like \"what does chapter 3 say about logic\"