### PR TITLE
mobile(auth): clear dismissedFeatures on sign-out (explicit + 401)

### DIFF
--- a/apps/mobile/__tests__/stores/authStore.test.ts
+++ b/apps/mobile/__tests__/stores/authStore.test.ts
@@ -283,5 +283,54 @@ describe('authStore (mobile)', () => {
       useAuthStore.getState().setSession('tok', 'user-1')
       expect(useAuthStore.getState().dismissedFeatures.size).toBe(0)
     })
+
+    // GAT-101 (#74) — explicit sign-out must wipe dismissedFeatures so that
+    // a subsequent sign-in as a different user does not inherit the previous
+    // user's session dismissals.
+    it('clearSession() (explicit sign-out) clears dismissedFeatures (#74)', () => {
+      const { useAuthStore } = require('@/lib/stores/authStore')
+      // Seed an authenticated session and a dismissed feature.
+      useAuthStore.getState().setSession('tok-1', 'user-a')
+      useAuthStore.getState().openPremiumGate('tts')
+      useAuthStore.getState().closePremiumGate()
+      expect(useAuthStore.getState().dismissedFeatures.has('tts')).toBe(true)
+
+      // User signs out explicitly.
+      useAuthStore.getState().clearSession()
+
+      const s = useAuthStore.getState()
+      expect(s.dismissedFeatures).toBeInstanceOf(Set)
+      expect(s.dismissedFeatures.size).toBe(0)
+      // Re-tapping a previously-dismissed feature should reopen the gate.
+      useAuthStore.getState().openPremiumGate('tts')
+      expect(useAuthStore.getState().premiumGateOpen).toBe(true)
+    })
+
+    // GAT-102 (#75) — the 401 forced sign-out path goes through
+    // clearSession() (see lib/api.ts), so the same invariant must hold when
+    // clearSession is invoked imperatively (as the 401 handler does).
+    it('clearSession() (401 forced sign-out path) clears dismissedFeatures (#75)', () => {
+      const { useAuthStore } = require('@/lib/stores/authStore')
+      // Simulate the seeded "currently signed-in user with a dismissed gate"
+      // state that the 401 handler would walk into.
+      useAuthStore.setState({
+        user: { id: 'u-pre-401', email: 'pre@example.com' },
+        isAuthenticated: true,
+        sessionToken: 'expired-token',
+      })
+      useAuthStore.getState().openPremiumGate('ai-chat')
+      useAuthStore.getState().closePremiumGate()
+      expect(useAuthStore.getState().dismissedFeatures.has('ai-chat')).toBe(true)
+
+      // This is exactly what apps/mobile/lib/api.ts does after a 401:
+      //   useAuthStore.getState().clearSession()
+      useAuthStore.getState().clearSession()
+
+      const s = useAuthStore.getState()
+      expect(s.isAuthenticated).toBe(false)
+      expect(s.user).toBeNull()
+      expect(s.sessionToken).toBeNull()
+      expect(s.dismissedFeatures.size).toBe(0)
+    })
   })
 })

--- a/apps/mobile/lib/stores/authStore.ts
+++ b/apps/mobile/lib/stores/authStore.ts
@@ -17,8 +17,10 @@
  *     MMKV, and flips `isAuthenticated` to true. It does NOT persist the
  *     token itself — `lib/auth.signIn()` writes to secure-store before
  *     calling this.
- *   - `clearSession()` wipes both the in-memory + persisted user id and flips
- *     `isAuthenticated` to false. `lib/auth.signOut()` calls
+ *   - `clearSession()` wipes both the in-memory + persisted user id, flips
+ *     `isAuthenticated` to false, and clears `dismissedFeatures` /
+ *     `pendingAction` so a re-auth (or different user) starts from a clean
+ *     gate state (GAT-101 / GAT-102). `lib/auth.signOut()` calls
  *     `SecureStore.deleteItemAsync` to remove the actual bearer.
  *   - `isAuthenticating` is a UI flag for the sign-in screen's loading state.
  */
@@ -226,11 +228,22 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
   },
 
   clearSession: () => {
+    // GAT-101 / GAT-102 (#74 / #75): sign-out — whether explicit ("Sign out"
+    // button) or forced (apiClient 401 handler) — must wipe the session-only
+    // `dismissedFeatures` set. Otherwise the next user to sign in on this
+    // device (account-switch on a shared phone, re-auth after a 401, etc.)
+    // inherits the previous user's premium-gate dismissals and the
+    // surfaces stay hidden until the next cold start.
+    //
+    // Also clear `pendingAction` so a stashed gated-tap from before the
+    // sign-out cannot replay against the next session.
     set({
       sessionToken: null,
       user: null,
       isAuthenticated: false,
       isAuthenticating: false,
+      pendingAction: null,
+      dismissedFeatures: new Set<PremiumFeature>(),
     })
     try {
       bucket.removeItem(USER_ID_KEY)


### PR DESCRIPTION
## Summary
- `clearSession()` now resets `dismissedFeatures` (session-only Set of premium gates the user dismissed with "Maybe later") and `pendingAction` alongside the existing session/token/user wipe.
- This covers both entry points that funnel through `clearSession()`:
  - Explicit "Sign out" (#74) — `apps/mobile/lib/stores/authStore.ts:228`.
  - 401 forced sign-out (#75) — `apps/mobile/lib/api.ts:58-69` already calls `useAuthStore.getState().clearSession()`; same fix covers it.
- Updated store header doc to reflect the new invariants.

Without this, switching accounts on a shared device or re-authenticating after a 401 silently inherits the previous session's gate dismissals: premium controls stay hidden / disabled until the next cold start.

## Tests (TDD)
Added two failing tests first, then implemented:

- `clearSession() (explicit sign-out) clears dismissedFeatures (#74)` — seeds an authenticated session, dismisses TTS gate, calls `clearSession()`, asserts the Set is empty and the gate can be re-opened.
- `clearSession() (401 forced sign-out path) clears dismissedFeatures (#75)` — replicates the seeded "signed in + dismissed gate" state the 401 handler walks into, calls `clearSession()` (the exact line `lib/api.ts` runs after a 401), asserts the Set is empty plus the standard signed-out invariants.

All 28 authStore tests pass; the 3 auth-related suites (authStore, auth-hydration, api-401) report 35/35 green; the 4 `__tests__/auth/` suites report 20/20 green.

## Test plan
- [x] `npx jest __tests__/stores/authStore.test.ts` — 28 passed
- [x] `npx jest __tests__/api/api-401.test.ts __tests__/stores/authStore.test.ts __tests__/stores/auth-hydration.test.ts` — 35 passed
- [x] `npx jest __tests__/auth/` — 20 passed
- [x] No new typecheck errors involving `authStore.ts` (pre-existing unrelated errors confirmed not introduced by this change)

Closes #74. Closes #75.