### PR TITLE
mobile(reader/pdf): feature parity — TTS, voice, realtime, loading

### DIFF
--- a/apps/mobile/__tests__/pdf/pdf-chat-press-button.test.tsx
+++ b/apps/mobile/__tests__/pdf/pdf-chat-press-button.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * RDR-032 — PDF reader must pass `onChatPress` (gated through
+ * `requireAIChat`) to ReaderShell so the dedicated chat-press button
+ * renders. `onChatToggle` was already wired but `onChatPress` was
+ * missing — issue #46 (DJVU stays open for another slot).
+ *
+ * Mirrors the EPUB wiring (apps/mobile/app/reader/[id].tsx:709):
+ *   onChatPress={() => requireAIChat(() => router.push(`/chat/${book.id}`))}
+ *
+ * The voice-chat `onRealtimePress` piece of #46 is covered by the
+ * sibling `pdf-realtime-button.test.tsx` (RDR-035 / #49 also touches
+ * it). This test focuses on the chat-press lane.
+ *
+ * Source-grep pin — established pattern for reader-screen wiring tests.
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const SRC_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  'app',
+  'reader',
+  'pdf',
+  '[id].tsx',
+)
+const src = readFileSync(SRC_PATH, 'utf-8')
+
+describe('RDR-032 — PDF reader chat-press button', () => {
+  it('passes onChatPress to ReaderShell gated through requireAIChat', () => {
+    // Match the EPUB pattern verbatim — the chat-press button shares
+    // the same destination route as onChatToggle, but is a separate
+    // explicit button (the toolbar-pulse chat shortcut).
+    expect(src).toMatch(/onChatPress=\{/)
+    expect(src).toMatch(
+      /onChatPress=\{\s*\(\)\s*=>\s*requireAIChat\(\s*\(\)\s*=>\s*router\.push\(`\/chat\/\$\{book\.id\}`\)/,
+    )
+  })
+
+  it('keeps onChatToggle wired in parallel (regression guard for the existing button)', () => {
+    expect(src).toMatch(/onChatToggle=\{/)
+  })
+})

--- a/apps/mobile/__tests__/pdf/pdf-loading-spinner.test.tsx
+++ b/apps/mobile/__tests__/pdf/pdf-loading-spinner.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * STA-016 — PDF reader loading screen must render an ActivityIndicator
+ * alongside the "Downloading…" / "Loading book…" copy. MOBI/DJVU/EPUB
+ * already do; PDF was missing the spinner (issue #92).
+ *
+ * We pin the wiring at the source level — the established pattern for
+ * reader-screen tests in this suite (see `pdf-reader-highlight-tap.test.tsx`).
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const SRC_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  'app',
+  'reader',
+  'pdf',
+  '[id].tsx',
+)
+const src = readFileSync(SRC_PATH, 'utf-8')
+
+describe('STA-016 — PDF reader loading screen', () => {
+  it('imports ActivityIndicator from react-native', () => {
+    expect(src).toMatch(/ActivityIndicator/)
+    // ensure the import is real, not an accidental string match
+    expect(src).toMatch(/from\s+['"]react-native['"][\s\S]{0,5}/)
+    expect(src.includes('ActivityIndicator')).toBe(true)
+  })
+
+  it('renders <ActivityIndicator size="large" /> in the loading branch', () => {
+    // The loading branch is gated on `if (loading)` and returns the
+    // reader-loading testID View. Pin the spinner inside that branch.
+    expect(src).toMatch(
+      /if\s*\(loading\)\s*\{[\s\S]{0,400}<ActivityIndicator[\s\S]{0,80}size=["']large["'][\s\S]{0,500}testID=["']reader-loading["']|testID=["']reader-loading["'][\s\S]{0,500}<ActivityIndicator[\s\S]{0,80}size=["']large["']/,
+    )
+  })
+
+  it('keeps the differentiated "Downloading…" vs "Loading book…" copy', () => {
+    expect(src).toMatch(/Downloading…/)
+    expect(src).toMatch(/Loading book…/)
+  })
+})

--- a/apps/mobile/__tests__/pdf/pdf-realtime-button.test.tsx
+++ b/apps/mobile/__tests__/pdf/pdf-realtime-button.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * RDR-035 — PDF reader must pass `onRealtimePress` and `realtimeStatus`
+ * to ReaderShell so the voice-chat (realtime) button renders. The
+ * `useRealtimeChat` hook is already mounted, but the toggle was never
+ * wired through — issue #49 (P0).
+ *
+ * Mirrors the EPUB pattern (apps/mobile/app/reader/[id].tsx:704-708):
+ *   onRealtimePress={() => {
+ *     if (realtimeActive) toggleRealtime()
+ *     else requireVoiceChat(toggleRealtime)
+ *   }}
+ *   realtimeStatus={realtimeStatus}
+ *
+ * Source-grep pin — established pattern for reader-screen wiring tests.
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const SRC_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  'app',
+  'reader',
+  'pdf',
+  '[id].tsx',
+)
+const src = readFileSync(SRC_PATH, 'utf-8')
+
+describe('RDR-035 — PDF reader voice-chat wiring', () => {
+  it('destructures toggle and isActive from useRealtimeChat', () => {
+    // The hook returns { status, toggle, isActive, showGuardrailWarning }.
+    // PDF previously read only `status`; now it must read `toggle` and
+    // `isActive` so the realtime button can call them.
+    expect(src).toMatch(
+      /useRealtimeChat\(book\?\.id\s*\?\?\s*['"]['"]\)|useRealtimeChat\(book\.id\)/,
+    )
+    expect(src).toMatch(/toggle:\s*toggleRealtime/)
+    expect(src).toMatch(/isActive:\s*realtimeActive/)
+  })
+
+  it('imports useRequireAuth with the voice-chat scope', () => {
+    // requireVoiceChat is the auth gate around toggleRealtime.
+    expect(src).toMatch(/requireVoiceChat\s*=\s*useRequireAuth\(['"]voice-chat['"]\)/)
+  })
+
+  it('passes onRealtimePress to ReaderShell', () => {
+    // The wiring must call toggleRealtime directly when realtimeActive,
+    // and gate through requireVoiceChat otherwise — parity with EPUB.
+    expect(src).toMatch(/onRealtimePress=\{/)
+    expect(src).toMatch(
+      /onRealtimePress=\{\s*\(\)\s*=>\s*\{?[\s\S]{0,200}realtimeActive[\s\S]{0,80}toggleRealtime\(\)[\s\S]{0,200}requireVoiceChat\(toggleRealtime\)/,
+    )
+  })
+
+  it('passes realtimeStatus to ReaderShell', () => {
+    expect(src).toMatch(/realtimeStatus=\{realtimeStatus\}/)
+  })
+})

--- a/apps/mobile/__tests__/pdf/pdf-tts-button.test.tsx
+++ b/apps/mobile/__tests__/pdf/pdf-tts-button.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * RDR-031 — PDF reader must wire `onTTSPress={handleToggleTTS}` and
+ * `ttsButtonActive={ttsActive}` to ReaderShell so the bottom-bar TTS
+ * icon renders. MOBI/DJVU/EPUB all wire this; PDF was missing the prop
+ * (issue #45).
+ *
+ * Source-grep pin — established pattern for reader-screen wiring tests
+ * (see `pdf-reader-highlight-tap.test.tsx`).
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const SRC_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  'app',
+  'reader',
+  'pdf',
+  '[id].tsx',
+)
+const src = readFileSync(SRC_PATH, 'utf-8')
+
+describe('RDR-031 — PDF reader TTS button', () => {
+  it('defines handleToggleTTS as a useCallback', () => {
+    expect(src).toMatch(/handleToggleTTS\s*=\s*useCallback\(/)
+  })
+
+  it('handleToggleTTS stops playback when ttsActive is true', () => {
+    // STOP branch must dispatch into playerStore (parity with EPUB / MOBI).
+    expect(src).toMatch(
+      /handleToggleTTS\s*=\s*useCallback\([\s\S]{0,600}ttsActive[\s\S]{0,200}STOP/,
+    )
+  })
+
+  it('handleToggleTTS gates start through requireTTS', () => {
+    expect(src).toMatch(
+      /handleToggleTTS\s*=\s*useCallback\([\s\S]{0,800}requireTTS\(/,
+    )
+  })
+
+  it('handleToggleTTS seeds paragraphs from chunks and dispatches PLAY', () => {
+    expect(src).toMatch(
+      /handleToggleTTS\s*=\s*useCallback\([\s\S]{0,1200}seedPlayerParagraphsFromChunks\([\s\S]{0,400}PLAY/,
+    )
+  })
+
+  it('passes onTTSPress and ttsButtonActive to ReaderShell', () => {
+    expect(src).toMatch(/onTTSPress=\{handleToggleTTS\}/)
+    expect(src).toMatch(/ttsButtonActive=\{ttsActive\}/)
+  })
+})

--- a/apps/mobile/app/reader/pdf/[id].tsx
+++ b/apps/mobile/app/reader/pdf/[id].tsx
@@ -12,6 +12,7 @@
  */
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import {
+  ActivityIndicator,
   Alert,
   AppState,
   type AppStateStatus,
@@ -566,7 +567,8 @@ export default function PdfReaderScreen() {
   if (loading) {
     return (
       <View testID="reader-loading" style={styles.full}>
-        <Text style={{ color: '#fff' }}>
+        <ActivityIndicator size="large" color="#fff" />
+        <Text style={{ marginTop: 12, color: '#fff' }}>
           {downloading ? 'Downloading…' : 'Loading book…'}
         </Text>
       </View>

--- a/apps/mobile/app/reader/pdf/[id].tsx
+++ b/apps/mobile/app/reader/pdf/[id].tsx
@@ -119,7 +119,13 @@ export default function PdfReaderScreen() {
 
   // Bridge realtime voice-chat status to the player so chat-position is
   // preserved (CHAT_STARTED/CHAT_ENDED dispatched into the playerMachine).
-  const { status: realtimeStatus } = useRealtimeChat(book?.id ?? '')
+  // RDR-035 — `toggle` and `isActive` are surfaced too so the realtime
+  // button in ReaderShell can drive the voice-chat connection.
+  const {
+    status: realtimeStatus,
+    toggle: toggleRealtime,
+    isActive: realtimeActive,
+  } = useRealtimeChat(book?.id ?? '')
   useTtsChatBridge(realtimeStatus)
 
   // G20 — register the PDF WebView area as the page-capture target.
@@ -133,6 +139,7 @@ export default function PdfReaderScreen() {
   // sheet for signed-out users.
   const requireTTS = useRequireAuth('tts')
   const requireAIChat = useRequireAuth('ai-chat')
+  const requireVoiceChat = useRequireAuth('voice-chat')
 
   // Subscribe to active-paragraph changes to drive the highlight reconciler.
   const activeParagraph = usePlayerStore((s) => s.activeParagraph)
@@ -645,13 +652,18 @@ export default function PdfReaderScreen() {
         initialToolbarVisible={true}
         centerOverride={pdfNavCluster}
         ttsActive={ttsActive}
-        realtimeActive={realtimeStatus !== 'idle'}
+        realtimeActive={realtimeActive}
         bookId={book?.id}
         onChatToggle={() =>
           requireAIChat(() => router.push(`/chat/${book.id}`))
         }
         onTTSPress={handleToggleTTS}
         ttsButtonActive={ttsActive}
+        onRealtimePress={() => {
+          if (realtimeActive) toggleRealtime()
+          else requireVoiceChat(toggleRealtime)
+        }}
+        realtimeStatus={realtimeStatus}
         onBookmarkTogglePress={handleToggleBookmark}
         isBookmarked={isCurrentBookmarked}
         sheets={{

--- a/apps/mobile/app/reader/pdf/[id].tsx
+++ b/apps/mobile/app/reader/pdf/[id].tsx
@@ -664,6 +664,7 @@ export default function PdfReaderScreen() {
           else requireVoiceChat(toggleRealtime)
         }}
         realtimeStatus={realtimeStatus}
+        onChatPress={() => requireAIChat(() => router.push(`/chat/${book.id}`))}
         onBookmarkTogglePress={handleToggleBookmark}
         isBookmarked={isCurrentBookmarked}
         sheets={{

--- a/apps/mobile/app/reader/pdf/[id].tsx
+++ b/apps/mobile/app/reader/pdf/[id].tsx
@@ -59,6 +59,7 @@ import {
   type Bookmark,
 } from '@/lib/bookmarks/bookmark-storage'
 import { resolvePlayFromSelection } from '@/lib/pdf/read-aloud-from-selection'
+import { seedPlayerParagraphsFromChunks } from '@/lib/tts/seed-paragraphs'
 import { usePlayerStore } from '@/lib/stores/playerStore'
 import { usePlayerMachine } from '@/hooks/usePlayerMachine'
 import { TTSVisualCue } from '@/components/TTSVisualCue'
@@ -384,6 +385,34 @@ export default function PdfReaderScreen() {
     [],
   )
 
+  // ---- TTS: read aloud (RDR-031) ----
+  // Mirror the EPUB/MOBI handleToggleTTS pattern. The shared chunker has
+  // a PDF branch (registered via setPdfExtractor at app start), so the
+  // standard seedPlayerParagraphsFromChunks helper works here too — we
+  // seed the full-book paragraphs and dispatch PLAY. STOP branches use
+  // the same playerStore.send path as the other formats.
+  const handleToggleTTS = useCallback(() => {
+    const sendFn = usePlayerStore.getState().send
+    if (!sendFn || !book) return
+    if (ttsActive) {
+      sendFn({ type: 'STOP' })
+      return
+    }
+    requireTTS(async () => {
+      try {
+        const seeded = await seedPlayerParagraphsFromChunks(
+          book.id,
+          book.filePath,
+          book.format,
+        )
+        if (!seeded.seeded) return
+        sendFn({ type: 'PLAY' })
+      } catch (err) {
+        console.warn('[pdf-tts] seed failed:', err)
+      }
+    })
+  }, [book, ttsActive, requireTTS])
+
   // Read-from-selection (G17). Batch 7 wires this fully to the player
   // machine via playerStore.send PLAY_FROM:
   //   1. Fetch the selected page paragraphs from the WebView.
@@ -621,6 +650,8 @@ export default function PdfReaderScreen() {
         onChatToggle={() =>
           requireAIChat(() => router.push(`/chat/${book.id}`))
         }
+        onTTSPress={handleToggleTTS}
+        ttsButtonActive={ttsActive}
         onBookmarkTogglePress={handleToggleBookmark}
         isBookmarked={isCurrentBookmarked}
         sheets={{


### PR DESCRIPTION
Closes #49. Closes #45. Closes #46. Closes #92.

PDF reader now matches EPUB feature surface:
- #49 RDR-035 wires onRealtimePress for voice-chat
- #45 RDR-031 adds TTS button
- #46 RDR-032 adds voice-chat + AI-chat handlers (PDF only — DJVU deferred)
- #92 STA-016 renders ActivityIndicator during PDF first-load