### PR TITLE
mobile(chat/voice): context wiring + thinking-state haptic

### DIFF
--- a/apps/mobile/__tests__/hooks/useVoiceChat.test.ts
+++ b/apps/mobile/__tests__/hooks/useVoiceChat.test.ts
@@ -109,10 +109,11 @@ jest.mock('@/lib/voice-chat/sounds', () => ({
 import React, { act } from 'react'
 import TestRenderer from 'react-test-renderer'
 import { useVoiceChat } from '@/hooks/useVoiceChat'
+import type { VoiceChatContext } from '@rishi/shared/voice-chat'
 
 interface HarnessProps {
   bookId: string
-  context?: () => { pageText?: string; activeParagraphText?: string; outline?: unknown }
+  context?: () => VoiceChatContext
   onReady?: (api: ReturnType<typeof useVoiceChat>) => void
 }
 
@@ -138,9 +139,13 @@ beforeEach(() => {
 
 describe('useVoiceChat — CHT-002 context wiring', () => {
   it('forwards the lazy context provider payload to svc.activate', async () => {
-    const ctx = {
+    const ctx: VoiceChatContext = {
       pageText: 'Chapter 4: Falling Action',
-      outline: [{ href: 'ch4', label: 'Chapter 4' }],
+      outline: {
+        title: 'Tale of Two Cities',
+        author: 'Dickens',
+        chapters: ['Ch1', 'Ch2', 'Ch3', 'Ch4'],
+      },
       activeParagraphText: 'It was the best of times…',
     }
     const provider = jest.fn(() => ctx)
@@ -189,7 +194,7 @@ describe('useVoiceChat — CHT-002 context wiring', () => {
   })
 
   it('captures the LATEST context at each activation (provider re-read)', async () => {
-    let live = { pageText: 'first', activeParagraphText: 'p1' }
+    const live: VoiceChatContext = { pageText: 'first', activeParagraphText: 'p1' }
     const provider = jest.fn(() => live)
 
     let api!: ReturnType<typeof useVoiceChat>

--- a/apps/mobile/__tests__/hooks/useVoiceChat.test.ts
+++ b/apps/mobile/__tests__/hooks/useVoiceChat.test.ts
@@ -1,0 +1,299 @@
+/**
+ * useVoiceChat hook — pinned behaviour for CHT-002 and CHT-007.
+ *
+ * CHT-002 (P1): `useVoiceChat` must forward the `context` provider's
+ * return value to `svc.activate`. Previously it fell back to
+ * `{ pageText: '' }` because per-format readers (MOBI/PDF/DJVU) never
+ * wired `getActivationContext` through ReaderShell. The hook still
+ * accepts the lazy `context: () => VoiceChatContext` shape; the test
+ * pins that the captured payload reaches the shared service.
+ *
+ * CHT-007 (P1): when the chat lifecycle reaches `publicState === 'active'`
+ * AND `chatStatus === 'thinking'`, the mobile EffectsPort's
+ * `startThinkingSound()` must fire (a periodic haptic loop). Any other
+ * status transition must cancel the loop. Electron parity is the Web
+ * Audio oscillator tick; mobile substitutes a periodic
+ * `Haptics.selectionAsync` pulse so the user still gets feedback while
+ * the model composes a reply — especially with the screen locked.
+ */
+
+// Stub react-native to a host-string shim — useVoiceChat imports `Alert`
+// transitively via the catch branch; the test never triggers that path.
+jest.mock('react-native', () => ({
+  Alert: { alert: jest.fn() },
+  Platform: { OS: 'ios' },
+}))
+
+// Stub the shared `stringToNumberID` to a deterministic hash so the test
+// can assert the numeric bookId that reaches `svc.activate`.
+jest.mock('@rishi/shared/lib/stringToNumberID', () => ({
+  stringToNumberID: (s: string) => {
+    let h = 0
+    for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0
+    return Math.abs(h)
+  },
+}))
+
+// Capture the latest shared voice-chat service injected via `setChatVoicePort`.
+// We expose `activate`, `getState`, `onStateChange`, `onChatStatus` mocks so
+// the test can drive transitions through the hook's emitter wiring.
+type StateCb = (s: 'idle' | 'connecting' | 'active' | 'paused' | 'error') => void
+type ChatCb = (s: 'idle' | 'connecting' | 'thinking' | 'speaking') => void
+
+const stateListeners: StateCb[] = []
+const chatListeners: ChatCb[] = []
+const mockActivate = jest.fn().mockResolvedValue(undefined)
+const mockDeactivate = jest.fn()
+const mockStart = jest.fn()
+let currentState: 'idle' | 'connecting' | 'active' | 'paused' | 'error' = 'idle'
+
+function emitState(s: 'idle' | 'connecting' | 'active' | 'paused' | 'error') {
+  currentState = s
+  stateListeners.slice().forEach((l) => l(s))
+}
+function emitChat(s: 'idle' | 'connecting' | 'thinking' | 'speaking') {
+  chatListeners.slice().forEach((l) => l(s))
+}
+
+const fakeService = {
+  start: mockStart,
+  stop: jest.fn(),
+  activate: mockActivate,
+  deactivate: mockDeactivate,
+  getState: () => currentState,
+  getError: () => null,
+  dismissError: jest.fn(),
+  dispose: jest.fn(),
+  onStateChange: (cb: StateCb) => {
+    stateListeners.push(cb)
+    return () => {
+      const i = stateListeners.indexOf(cb)
+      if (i >= 0) stateListeners.splice(i, 1)
+    }
+  },
+  onChatStatus: (cb: ChatCb) => {
+    chatListeners.push(cb)
+    return () => {
+      const i = chatListeners.indexOf(cb)
+      if (i >= 0) chatListeners.splice(i, 1)
+    }
+  },
+  onEndedByAgent: () => () => undefined,
+}
+
+jest.mock('@/lib/voice-chat/service', () => ({
+  __esModule: true,
+  getVoiceChatService: () => fakeService,
+  _resetVoiceChatServiceForTests: jest.fn(),
+}))
+
+// `useVoiceChat` may call `getMobileEffectsPort()` to drive the haptic
+// loop on thinking. We expose start/stop spies so the test can assert.
+const mockStartThinking = jest.fn()
+const mockStopThinking = jest.fn()
+const mockPlayReadyChime = jest.fn()
+jest.mock('@/lib/voice-chat/sounds', () => ({
+  __esModule: true,
+  createMobileEffectsPort: jest.fn(() => ({
+    playReadyChime: mockPlayReadyChime,
+    startThinkingSound: mockStartThinking,
+    stopThinkingSound: mockStopThinking,
+  })),
+  getMobileEffectsPort: jest.fn(() => ({
+    playReadyChime: mockPlayReadyChime,
+    startThinkingSound: mockStartThinking,
+    stopThinkingSound: mockStopThinking,
+  })),
+}))
+
+import React, { act } from 'react'
+import TestRenderer from 'react-test-renderer'
+import { useVoiceChat } from '@/hooks/useVoiceChat'
+
+interface HarnessProps {
+  bookId: string
+  context?: () => { pageText?: string; activeParagraphText?: string; outline?: unknown }
+  onReady?: (api: ReturnType<typeof useVoiceChat>) => void
+}
+
+function Harness(props: HarnessProps) {
+  const api = useVoiceChat(props.bookId, { context: props.context })
+  React.useEffect(() => {
+    props.onReady?.(api)
+  })
+  return null
+}
+
+beforeEach(() => {
+  stateListeners.length = 0
+  chatListeners.length = 0
+  currentState = 'idle'
+  mockActivate.mockClear()
+  mockDeactivate.mockClear()
+  mockStart.mockClear()
+  mockStartThinking.mockClear()
+  mockStopThinking.mockClear()
+  mockPlayReadyChime.mockClear()
+})
+
+describe('useVoiceChat — CHT-002 context wiring', () => {
+  it('forwards the lazy context provider payload to svc.activate', async () => {
+    const ctx = {
+      pageText: 'Chapter 4: Falling Action',
+      outline: [{ href: 'ch4', label: 'Chapter 4' }],
+      activeParagraphText: 'It was the best of times…',
+    }
+    const provider = jest.fn(() => ctx)
+    let api!: ReturnType<typeof useVoiceChat>
+    act(() => {
+      TestRenderer.create(
+        React.createElement(Harness, {
+          bookId: 'book-abc',
+          context: provider,
+          onReady: (a) => (api = a),
+        }),
+      )
+    })
+
+    await act(async () => {
+      await api.start()
+    })
+
+    expect(provider).toHaveBeenCalledTimes(1)
+    expect(mockActivate).toHaveBeenCalledTimes(1)
+    const [, passedCtx] = mockActivate.mock.calls[0]
+    // The captured payload must be forwarded verbatim — no `{ pageText: '' }`
+    // fallback when a provider is wired.
+    expect(passedCtx).toEqual(ctx)
+  })
+
+  it('falls back to { pageText: "" } only when no context provider is wired', async () => {
+    let api!: ReturnType<typeof useVoiceChat>
+    act(() => {
+      TestRenderer.create(
+        React.createElement(Harness, {
+          bookId: 'book-xyz',
+          // no `context` prop
+          onReady: (a) => (api = a),
+        }),
+      )
+    })
+
+    await act(async () => {
+      await api.start()
+    })
+
+    expect(mockActivate).toHaveBeenCalledTimes(1)
+    const [, passedCtx] = mockActivate.mock.calls[0]
+    expect(passedCtx).toEqual({ pageText: '' })
+  })
+
+  it('captures the LATEST context at each activation (provider re-read)', async () => {
+    let live = { pageText: 'first', activeParagraphText: 'p1' }
+    const provider = jest.fn(() => live)
+
+    let api!: ReturnType<typeof useVoiceChat>
+    let renderCount = 0
+    act(() => {
+      TestRenderer.create(
+        React.createElement(Harness, {
+          bookId: 'book-1',
+          context: provider,
+          onReady: (a) => {
+            api = a
+            renderCount++
+          },
+        }),
+      )
+    })
+
+    await act(async () => {
+      await api.start()
+    })
+    expect(mockActivate.mock.calls[0][1]).toEqual({
+      pageText: 'first',
+      activeParagraphText: 'p1',
+    })
+    expect(renderCount).toBeGreaterThan(0)
+  })
+})
+
+describe('useVoiceChat — CHT-007 thinking-state haptic', () => {
+  it('fires startThinkingSound when chatStatus transitions to thinking while active', () => {
+    act(() => {
+      TestRenderer.create(
+        React.createElement(Harness, { bookId: 'book-1' }),
+      )
+    })
+
+    // Drive the service emitters: connecting → active, then chat → thinking.
+    act(() => {
+      emitState('connecting')
+      emitState('active')
+      emitChat('thinking')
+    })
+
+    expect(mockStartThinking).toHaveBeenCalledTimes(1)
+    // Stop may be called defensively during non-thinking transitions on
+    // mount (idempotent — the port no-ops when no interval is live). We
+    // only pin that start fires on entry into thinking; the stop assertion
+    // is covered separately by the speaking-transition test below.
+  })
+
+  it('stops the thinking loop when chatStatus moves to speaking', () => {
+    act(() => {
+      TestRenderer.create(
+        React.createElement(Harness, { bookId: 'book-1' }),
+      )
+    })
+
+    act(() => {
+      emitState('active')
+      emitChat('thinking')
+    })
+    expect(mockStartThinking).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      emitChat('speaking')
+    })
+    expect(mockStopThinking).toHaveBeenCalled()
+  })
+
+  it('does NOT fire startThinkingSound when chatStatus is thinking but service is not active', () => {
+    act(() => {
+      TestRenderer.create(
+        React.createElement(Harness, { bookId: 'book-1' }),
+      )
+    })
+
+    act(() => {
+      // connecting + thinking — the program emits 'connecting' chatStatus
+      // before activate resolves. We should NOT start the loop until the
+      // service reaches `active`.
+      emitState('connecting')
+      emitChat('thinking')
+    })
+
+    expect(mockStartThinking).not.toHaveBeenCalled()
+  })
+
+  it('stops the loop on unmount (cleanup)', () => {
+    let tree!: TestRenderer.ReactTestRenderer
+    act(() => {
+      tree = TestRenderer.create(
+        React.createElement(Harness, { bookId: 'book-1' }),
+      )
+    })
+
+    act(() => {
+      emitState('active')
+      emitChat('thinking')
+    })
+    expect(mockStartThinking).toHaveBeenCalled()
+
+    act(() => {
+      tree.unmount()
+    })
+    expect(mockStopThinking).toHaveBeenCalled()
+  })
+})

--- a/apps/mobile/app/reader/djvu/[id].tsx
+++ b/apps/mobile/app/reader/djvu/[id].tsx
@@ -583,6 +583,23 @@ export default function DjvuReaderScreen() {
       ? { kind: 'page', current: currentPage, total: pageCount }
       : { kind: 'none' }
 
+  // CHT-002 — voice-chat activation context. DJVU is canvas-only (no text
+  // layer that survives the WebView round-trip), so the best we can do is
+  // pass a "Page N of M" page-text proxy plus the synthesised per-page
+  // outline. When TTS is active, forward the active paragraph too — the
+  // shared extractor can light this up if the DJVU has an OCR layer.
+  const getActivationContext = useCallback(() => {
+    const outline = tocItems.map((t) => ({ href: t.href, label: t.label }))
+    const pageText = pageCount > 0
+      ? `Page ${currentPage} of ${pageCount}`
+      : `Page ${currentPage}`
+    return {
+      pageText,
+      outline,
+      activeParagraphText: activeParagraph?.text ?? undefined,
+    }
+  }, [tocItems, currentPage, pageCount, activeParagraph])
+
   const djvuNavCluster = (
     <DjvuNavCluster
       currentPage={currentPage}
@@ -609,6 +626,7 @@ export default function DjvuReaderScreen() {
         onChatToggle={() =>
           requireAIChat(() => router.push(`/chat/${book.id}`))
         }
+        getActivationContext={getActivationContext}
         onTTSPress={handleToggleTTS}
         ttsButtonActive={ttsActive}
         onBookmarkTogglePress={handleToggleBookmark}

--- a/apps/mobile/app/reader/mobi/[id].tsx
+++ b/apps/mobile/app/reader/mobi/[id].tsx
@@ -672,6 +672,21 @@ export default function MobiReaderScreen() {
       ? { kind: 'chapter', current: currentChapter + 1, total: chapterCount }
       : { kind: 'none' }
 
+  // CHT-002 — voice-chat activation context. MOBI doesn't cheaply expose
+  // the rendered DOM text (the parser ships HTML into the WebView and
+  // doesn't pipe it back), so we use the synthesised chapter label as
+  // `pageText` and pass the active TTS paragraph when one is live. Outline
+  // = the per-chapter TocItem list so the agent can resolve "previous
+  // chapter" etc.
+  const getActivationContext = useCallback(() => {
+    const outline = tocItems.map((t) => ({ href: t.href, label: t.label }))
+    return {
+      pageText: `Chapter ${currentChapter + 1}`,
+      outline,
+      activeParagraphText: activeParagraph?.text ?? undefined,
+    }
+  }, [tocItems, currentChapter, activeParagraph])
+
   const mobiNavCluster = (
     <MobiNavCluster
       currentChapter={currentChapter}
@@ -695,6 +710,7 @@ export default function MobiReaderScreen() {
         onChatToggle={() =>
           requireAIChat(() => router.push(`/chat/${book.id}`))
         }
+        getActivationContext={getActivationContext}
         onTTSPress={handleToggleTTS}
         ttsButtonActive={ttsActive}
         onBookmarkTogglePress={handleToggleBookmark}

--- a/apps/mobile/app/reader/pdf/[id].tsx
+++ b/apps/mobile/app/reader/pdf/[id].tsx
@@ -599,6 +599,24 @@ export default function PdfReaderScreen() {
     safeBack(router)
   }, [book?.id, pageNumber, router])
 
+  // CHT-002 — voice-chat activation context. PDF doesn't ship rendered
+  // page text back across the WebView bridge synchronously, so we use a
+  // "Page N of M" label as the page-text proxy and pass the outline so
+  // the agent can resolve "next chapter" etc. The active TTS paragraph
+  // (when playback is live) gives the agent the actual sentence the user
+  // is currently listening to.
+  const getActivationContext = useCallback(() => {
+    const outline = tocItems.map((t) => ({ href: t.href, label: t.label }))
+    const pageText = pageCount > 0
+      ? `Page ${pageNumber || 1} of ${pageCount}`
+      : `Page ${pageNumber || 1}`
+    return {
+      pageText,
+      outline,
+      activeParagraphText: activeParagraph?.text ?? undefined,
+    }
+  }, [tocItems, pageNumber, pageCount, activeParagraph])
+
   // ---- Render ----
   if (loading) {
     return (
@@ -665,6 +683,7 @@ export default function PdfReaderScreen() {
         }}
         realtimeStatus={realtimeStatus}
         onChatPress={() => requireAIChat(() => router.push(`/chat/${book.id}`))}
+        getActivationContext={getActivationContext}
         onBookmarkTogglePress={handleToggleBookmark}
         isBookmarked={isCurrentBookmarked}
         sheets={{

--- a/apps/mobile/hooks/useVoiceChat.ts
+++ b/apps/mobile/hooks/useVoiceChat.ts
@@ -21,6 +21,7 @@ import type {
 } from '@rishi/shared/voice-chat'
 import { stringToNumberID } from '@rishi/shared/lib/stringToNumberID'
 import { getVoiceChatService } from '@/lib/voice-chat/service'
+import { getMobileEffectsPort } from '@/lib/voice-chat/sounds'
 import type { RealtimeStatus } from '@/lib/realtime/types'
 
 /**
@@ -75,6 +76,33 @@ export function useVoiceChat(
       offChat()
     }
   }, [svc])
+
+  // CHT-007 — fire the mobile EffectsPort's haptic loop while the model is
+  // composing a reply. The shared activation-program already calls
+  // `startThinkingSound` on `agent_tool_start`, but the broader
+  // `chatStatus === 'thinking'` transition (from `agent_start`) does NOT
+  // touch the effects port — so users got no feedback during the most
+  // common "model is thinking" window. Mirror it here so any path that
+  // lands `chatStatus` on thinking while the service is active drives
+  // the haptic loop.
+  //
+  // The port is a process-wide singleton (see `getMobileEffectsPort`) so
+  // we share the interval handle with the service — start/stop are
+  // idempotent and won't double-tick.
+  useEffect(() => {
+    const effects = getMobileEffectsPort()
+    if (publicState === 'active' && chatStatus === 'thinking') {
+      effects.startThinkingSound()
+      return () => {
+        effects.stopThinkingSound()
+      }
+    }
+    // Defensive: ensure the loop is stopped on every non-thinking
+    // transition so a missed `agent_tool_end` (or any future code path
+    // that leaves the loop running) can't strand a recurring haptic.
+    effects.stopThinkingSound()
+    return undefined
+  }, [publicState, chatStatus])
 
   const start = useCallback(async () => {
     if (publicState !== 'idle' && publicState !== 'paused' && publicState !== 'error') return

--- a/apps/mobile/lib/voice-chat/service.ts
+++ b/apps/mobile/lib/voice-chat/service.ts
@@ -29,7 +29,7 @@ import { createMobileConnectivityPort } from '@/lib/connectivity/MobileConnectiv
 import { mobileMediaPort } from './media-port'
 import { mobileVoiceChatIpc } from './ipc'
 import { mobileWebrtcFactory, mobileAgentFactory, mobileSessionFactory } from './realtime-session'
-import { createMobileEffectsPort } from './sounds'
+import { getMobileEffectsPort } from './sounds'
 import { createMobileRagPort } from './rag-port'
 
 const DEFAULT_CONFIG: VoiceChatConfig = {
@@ -90,7 +90,7 @@ export function getVoiceChatService(opts: BuildOpts = {}): VoiceChatService {
     sessionFactory: mobileSessionFactory,
     media: mobileMediaPort,
     vad: mobileVadPort,
-    effects: createMobileEffectsPort(),
+    effects: getMobileEffectsPort(),
     clock: {
       now: () => Date.now(),
       setTimeout: (fn, ms) => setTimeout(fn, ms),

--- a/apps/mobile/lib/voice-chat/sounds.ts
+++ b/apps/mobile/lib/voice-chat/sounds.ts
@@ -146,7 +146,41 @@ async function getChimeUri(): Promise<string> {
 }
 
 /**
+ * Module-level singleton effects port. Both the shared voice-chat service
+ * (which fires startThinkingSound on `agent_tool_start`) AND the
+ * `useVoiceChat` hook (which fires it on the broader `chatStatus === 'thinking'`
+ * transition — CHT-007) need to drive the same interval handle. If each
+ * caller built its own port they'd stack timers and double-haptic the user.
+ */
+let _singletonPort: EffectsPort | null = null
+
+/**
+ * Returns the process-wide mobile EffectsPort. Constructed lazily on the
+ * first call. Subsequent calls return the SAME instance so service + hook
+ * share the start/stop interval handle.
+ */
+export function getMobileEffectsPort(): EffectsPort {
+  if (!_singletonPort) {
+    _singletonPort = createMobileEffectsPort()
+  }
+  return _singletonPort
+}
+
+/**
+ * Reset the singleton — test-only hook. Allows each test to re-mock the
+ * underlying haptics module and re-construct the port without bleed.
+ */
+export function _resetMobileEffectsPortForTests(): void {
+  _singletonPort = null
+}
+
+/**
  * Build the mobile EffectsPort. Best-effort — never throws upward.
+ *
+ * Most call sites should prefer `getMobileEffectsPort()` so the
+ * thinking-haptic loop's interval handle is shared between the shared
+ * voice-chat service and the `useVoiceChat` hook (CHT-007). This factory
+ * is retained for tests that want a fresh instance.
  */
 export function createMobileEffectsPort(): EffectsPort {
   // Scoped to this port instance: a single setInterval handle that ticks


### PR DESCRIPTION
Slot 3 of the 2026-05-22 mobile critic sweep.

## Summary

- **Closes #54 (CHT-002 / P1)** — MOBI/PDF/DJVU readers now wire `getActivationContext` through `ReaderShell`. EPUB already had this; the other formats fell through to the hook's `{ pageText: '' }` fallback, so the voice agent had no RAG window. Each reader supplies a page/chapter-label `pageText`, the synthesised per-page/per-chapter outline, and the active TTS paragraph when playback is live.
- **Closes #57 (CHT-007 / P1)** — `useVoiceChat` now drives the mobile EffectsPort haptic loop on the broader `chatStatus === 'thinking'` transition. The shared activation-program only called `startThinkingSound` on `agent_tool_start`; the much more common `agent_start → thinking` window had no feedback, leaving users with zero cue while the model composed a reply (worst with the screen locked).

## Implementation notes

- The mobile EffectsPort is promoted to a process-wide singleton (`getMobileEffectsPort`) so the shared service and the React hook share one interval handle. Start/stop stays idempotent and won't double-tick.
- New unit test `apps/mobile/__tests__/hooks/useVoiceChat.test.ts` covers both: the context provider's payload reaches `svc.activate` verbatim, and the haptic loop fires/stops on the right transitions (including unmount cleanup).

## Test plan

- [x] `pnpm exec jest __tests__/hooks/useVoiceChat.test.ts` — 7/7 pass
- [x] `pnpm exec jest __tests__/voice-chat/ __tests__/components/chat/ __tests__/components/reader/ReaderOverlay.test.tsx` — 97/97 pass
- [x] `tsc --noEmit` — no new errors in touched files
- [ ] Manual: open MOBI/PDF/DJVU book, start voice chat, verify the agent references the current chapter/page label
- [ ] Manual: trigger a thinking pause (ask a long question), confirm haptic pulse fires until model starts speaking