### PR TITLE
mobile(library/import): data-integrity — atomic insert, idempotent embed, in-flight lock

### DIFF
--- a/apps/mobile/__tests__/book-import/data-integrity.test.ts
+++ b/apps/mobile/__tests__/book-import/data-integrity.test.ts
@@ -1,0 +1,496 @@
+/**
+ * Data-integrity regressions for the mobile book-import pipeline.
+ *
+ *   DAT-001 (#114): Import must not leave an orphan books row when the
+ *                   filesystem copy step fails.
+ *   DAT-004 (#117): Mid-batch embedding failure must NOT leave the book
+ *                   half-indexed — all chunks for that bookId must be
+ *                   removed on throw so a retry can run cleanly.
+ *   DAT-007 (#120): Concurrent generateChunks(bookId) calls must coalesce
+ *                   onto a single in-flight promise; only one insert loop
+ *                   runs.
+ *
+ * The adapters in `apps/mobile/lib/book-import/adapters.ts` wrap mobile-
+ * specific I/O for the shared `@rishi/shared/book-import` service. These
+ * tests exercise the ports directly so the failure modes are isolated
+ * from the picker / service plumbing.
+ */
+
+// ── Shared mocks (kept minimal — adapters import lots of native modules) ────
+jest.mock('@rishi/shared/schema', () => ({ books: { id: 'id' } }))
+jest.mock('drizzle-orm', () => ({ eq: jest.fn((col, val) => ({ col, val })) }))
+jest.mock('@rishi/shared/formats/epub-cover', () => ({
+  extractEpubCover: jest.fn(),
+}))
+jest.mock('@rishi/shared/formats/mobi', () => ({
+  extractMobiCover: jest.fn(),
+}))
+
+const dbState = {
+  rows: new Map<string, Record<string, unknown>>(),
+  insertCalls: [] as Array<Record<string, unknown>>,
+  deleteCalls: [] as Array<unknown>,
+}
+
+jest.mock('@/lib/db', () => ({
+  db: {
+    insert: () => ({
+      values: (v: Record<string, unknown>) => ({
+        run: () => {
+          dbState.insertCalls.push(v)
+          dbState.rows.set(String(v.id), v)
+        },
+      }),
+    }),
+    update: () => ({
+      set: () => ({ where: () => ({ run: jest.fn() }) }),
+    }),
+    delete: () => ({
+      where: (w: unknown) => ({
+        run: () => {
+          dbState.deleteCalls.push(w)
+          // Remove rows matching the where filter we receive from drizzle's
+          // `eq` mock above (we stored the value in {col,val}).
+          if (
+            w &&
+            typeof w === 'object' &&
+            'val' in (w as Record<string, unknown>)
+          ) {
+            dbState.rows.delete(String((w as { val: unknown }).val))
+          }
+        },
+      }),
+    }),
+  },
+}))
+
+jest.mock('@/lib/sync/triggers', () => ({
+  triggerSyncOnWrite: jest.fn(),
+}))
+
+jest.mock('@/lib/sync/file-sync', () => ({
+  hashBookFile: jest.fn(),
+  uploadBookFile: jest.fn(),
+  UploadLimitError: class extends Error {},
+}))
+
+jest.mock('@/lib/sync/upload-error-store', () => ({
+  useUploadErrorStore: { getState: () => ({ show: jest.fn() }) },
+}))
+
+// expo-file-system: track which directories were created + simulate copy
+// throwing on demand.
+let copyShouldThrow = false
+const createdDirs: string[] = []
+
+jest.mock('expo-file-system', () => {
+  const Paths = { document: '/docs' }
+
+  class Directory {
+    uri: string
+    exists = true
+    constructor(arg1: unknown, name?: string) {
+      const base =
+        typeof arg1 === 'string'
+          ? arg1
+          : ((arg1 as { uri?: string })?.uri ?? '/docs')
+      this.uri = name ? `${base}/${name}` : base
+    }
+    create(_opts?: unknown) {
+      createdDirs.push(this.uri)
+    }
+  }
+
+  class File {
+    uri: string
+    constructor(arg1: unknown, name?: string) {
+      const base =
+        typeof arg1 === 'string'
+          ? arg1
+          : ((arg1 as { uri?: string })?.uri ?? '/docs')
+      this.uri = name ? `${base}/${name}` : base
+    }
+    copy(_dest: unknown) {
+      if (copyShouldThrow) throw new Error('ENOSPC: out of disk')
+    }
+    delete() {
+      /* no-op */
+    }
+    write() {
+      /* no-op */
+    }
+    async bytes(): Promise<Uint8Array> {
+      return new Uint8Array()
+    }
+    get size(): number {
+      return 0
+    }
+  }
+
+  return { File, Directory, Paths }
+})
+
+// rag/chunker + embedder + vector-store: tests configure these per-suite.
+const chunkerState = {
+  chunks: [] as Array<{
+    id: string
+    chunkIndex: number
+    text: string
+    chapter: string | null
+  }>,
+  callCount: 0,
+}
+jest.mock('@/lib/rag/chunker', () => ({
+  getChunks: jest.fn(async () => {
+    chunkerState.callCount += 1
+    return chunkerState.chunks
+  }),
+}))
+
+const embedderState = {
+  ready: true,
+  throwOnCall: 0, // 0 = never; N = throw on the Nth call (1-indexed)
+  callCount: 0,
+}
+jest.mock('@/lib/rag/embedder', () => ({
+  isEmbeddingReady: jest.fn(() => embedderState.ready),
+  embedBatch: jest.fn(async (texts: string[]) => {
+    embedderState.callCount += 1
+    if (
+      embedderState.throwOnCall > 0 &&
+      embedderState.callCount === embedderState.throwOnCall
+    ) {
+      throw new Error('embed failed mid-batch')
+    }
+    return texts.map(() => new Array(384).fill(0.1))
+  }),
+}))
+
+const serverState = {
+  throwOnCall: 0,
+  callCount: 0,
+}
+jest.mock('@/lib/rag/server-fallback', () => ({
+  embedTextsOnServer: jest.fn(async (texts: string[]) => {
+    serverState.callCount += 1
+    if (
+      serverState.throwOnCall > 0 &&
+      serverState.callCount === serverState.throwOnCall
+    ) {
+      throw new Error('server embed failed mid-batch')
+    }
+    return texts.map(() => new Array(384).fill(0.5))
+  }),
+}))
+
+const vectorState = {
+  insertCalls: [] as Array<{
+    chunkId: string
+    bookId: string
+    chunkIndex: number
+  }>,
+  deletedBookIds: [] as string[],
+  /** Set bookId here to make `isBookEmbedded` return true. */
+  embeddedBookIds: new Set<string>(),
+}
+jest.mock('@/lib/rag/vector-store', () => ({
+  insertChunkWithVector: jest.fn(
+    (
+      chunkId: string,
+      bookId: string,
+      chunkIndex: number,
+      _text: string,
+      _chapter: string | null,
+      _embedding: number[],
+    ) => {
+      vectorState.insertCalls.push({ chunkId, bookId, chunkIndex })
+    },
+  ),
+  isBookEmbedded: jest.fn((bookId: string) =>
+    vectorState.embeddedBookIds.has(bookId),
+  ),
+  deleteBookChunks: jest.fn((bookId: string) => {
+    vectorState.deletedBookIds.push(bookId)
+    vectorState.insertCalls = vectorState.insertCalls.filter(
+      (c) => c.bookId !== bookId,
+    )
+  }),
+}))
+
+import {
+  createMobileDbPort,
+  createMobileFsPort,
+  createMobileEmbedPort,
+} from '@/lib/book-import/adapters'
+
+function resetAll() {
+  dbState.rows.clear()
+  dbState.insertCalls.length = 0
+  dbState.deleteCalls.length = 0
+  createdDirs.length = 0
+  copyShouldThrow = false
+  chunkerState.chunks = []
+  chunkerState.callCount = 0
+  embedderState.ready = true
+  embedderState.throwOnCall = 0
+  embedderState.callCount = 0
+  serverState.throwOnCall = 0
+  serverState.callCount = 0
+  vectorState.insertCalls.length = 0
+  vectorState.deletedBookIds.length = 0
+  vectorState.embeddedBookIds.clear()
+  jest.clearAllMocks()
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// DAT-001 — atomic insert: copy failure leaves NO orphan books row.
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('DAT-001 — atomic insert vs file copy', () => {
+  beforeEach(resetAll)
+
+  /**
+   * Drive the shape the shared service would: call FsPort.copyBookToAppData
+   * FIRST, and only on success call DbPort.saveBook. We assert that when
+   * the copy step throws the DbPort is never asked to insert and no row
+   * exists. This pins the contract that the shared service enforces.
+   */
+  it('does not insert a books row when copyBookToAppData throws', async () => {
+    copyShouldThrow = true
+    const fs = createMobileFsPort({ bookId: 'b-fail', format: 'epub' })
+    const db = createMobileDbPort()
+
+    let copied = false
+    let inserted = false
+    try {
+      await fs.copyBookToAppData('/Downloads/x.epub')
+      copied = true
+      await db.saveBook({
+        id: 'b-fail',
+        title: 't',
+        author: 'a',
+        coverPath: null,
+        filePath: '/docs/books/b-fail/book.epub',
+        format: 'epub',
+        currentCfi: null,
+        currentPage: null,
+        createdAt: 1,
+      })
+      inserted = true
+    } catch {
+      /* expected */
+    }
+
+    expect(copied).toBe(false)
+    expect(inserted).toBe(false)
+    expect(dbState.insertCalls).toHaveLength(0)
+    expect(dbState.rows.size).toBe(0)
+  })
+
+  /**
+   * The other failure mode the issue surfaces: saveBook itself can fail
+   * mid-way (the row write succeeds but a follow-up step inside the
+   * adapter throws). The adapter must roll back the inserted row before
+   * propagating the error so callers can retry without an orphan.
+   */
+  it('rolls back the inserted row when saveBook fails after the row write', async () => {
+    const triggers = require('@/lib/sync/triggers') as {
+      triggerSyncOnWrite: jest.Mock
+    }
+    triggers.triggerSyncOnWrite.mockImplementationOnce(() => {
+      throw new Error('sync trigger blew up')
+    })
+
+    const db = createMobileDbPort()
+
+    await expect(
+      db.saveBook({
+        id: 'b-rollback',
+        title: 't',
+        author: 'a',
+        coverPath: null,
+        filePath: '/docs/books/b-rollback/book.epub',
+        format: 'epub',
+        currentCfi: null,
+        currentPage: null,
+        createdAt: 1,
+      }),
+    ).rejects.toThrow()
+
+    // Row was inserted then deleted as part of rollback — net effect: gone.
+    expect(dbState.insertCalls).toHaveLength(1)
+    expect(dbState.deleteCalls).toHaveLength(1)
+    expect(dbState.rows.has('b-rollback')).toBe(false)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// DAT-004 — embedding failure mid-batch must leave NO chunks for that book.
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('DAT-004 — embedding failure rolls back chunks', () => {
+  beforeEach(resetAll)
+
+  it('removes all inserted chunks when a later batch throws', async () => {
+    // 15 chunks → 2 batches of 10 + 5. Force the server path (on-device
+    // not ready) and make the SECOND server embed call throw. This pins
+    // the recoverable-failure mode: the FIRST batch's 10 chunks already
+    // landed in sqlite, then the second batch blew up; without rollback
+    // isBookEmbedded would (wrongly) return true forever after.
+    chunkerState.chunks = Array.from({ length: 15 }, (_, i) => ({
+      id: `c-${i}`,
+      chunkIndex: i,
+      text: `t-${i}`,
+      chapter: null,
+    }))
+    embedderState.ready = false // force server fallback
+    serverState.throwOnCall = 2
+
+    const port = createMobileEmbedPort()
+
+    await expect(
+      port.generateChunks({
+        bookId: 'book-half' as unknown as string,
+        filePath: '/docs/books/book-half/book.epub',
+        format: 'epub',
+      }),
+    ).rejects.toThrow(/embed failed/i)
+
+    // Critical: NO chunks remain for the failed book. The next retry can
+    // re-run cleanly.
+    expect(
+      vectorState.insertCalls.filter((c) => c.bookId === 'book-half'),
+    ).toHaveLength(0)
+    expect(vectorState.deletedBookIds).toContain('book-half')
+  })
+
+  it('does not delete chunks for OTHER books on failure', async () => {
+    // Pre-populate as if another book is fully embedded.
+    vectorState.insertCalls.push({
+      chunkId: 'other-1',
+      bookId: 'other-book',
+      chunkIndex: 0,
+    })
+
+    chunkerState.chunks = Array.from({ length: 11 }, (_, i) => ({
+      id: `c-${i}`,
+      chunkIndex: i,
+      text: `t-${i}`,
+      chapter: null,
+    }))
+    embedderState.ready = false
+    serverState.throwOnCall = 2
+
+    const port = createMobileEmbedPort()
+    await expect(
+      port.generateChunks({
+        bookId: 'book-fail' as unknown as string,
+        filePath: '/p',
+        format: 'epub',
+      }),
+    ).rejects.toThrow()
+
+    expect(
+      vectorState.insertCalls.filter((c) => c.bookId === 'other-book'),
+    ).toHaveLength(1)
+    expect(vectorState.deletedBookIds).toEqual(['book-fail'])
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// DAT-007 — in-flight lock: concurrent generateChunks coalesce.
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('DAT-007 — generateChunks in-flight lock', () => {
+  beforeEach(resetAll)
+
+  it('runs only ONE insert loop for two concurrent calls on the same bookId', async () => {
+    chunkerState.chunks = [
+      { id: 'c-0', chunkIndex: 0, text: 't-0', chapter: null },
+      { id: 'c-1', chunkIndex: 1, text: 't-1', chapter: null },
+      { id: 'c-2', chunkIndex: 2, text: 't-2', chapter: null },
+    ]
+
+    const port = createMobileEmbedPort()
+
+    const [a, b] = await Promise.all([
+      port.generateChunks({
+        bookId: 'book-race' as unknown as string,
+        filePath: '/p',
+        format: 'epub',
+      }),
+      port.generateChunks({
+        bookId: 'book-race' as unknown as string,
+        filePath: '/p',
+        format: 'epub',
+      }),
+    ])
+
+    // Chunker called once — second caller awaited the same in-flight promise.
+    expect(chunkerState.callCount).toBe(1)
+    // Exactly one set of vectors written (3 chunks, no duplicates).
+    expect(
+      vectorState.insertCalls.filter((c) => c.bookId === 'book-race'),
+    ).toHaveLength(3)
+    // Both callers see a result (return shape doesn't matter — the contract
+    // is "they coalesce" not "they return the same array reference").
+    expect(Array.isArray(a)).toBe(true)
+    expect(Array.isArray(b)).toBe(true)
+  })
+
+  it('releases the lock after completion so a fresh call can run again', async () => {
+    chunkerState.chunks = [
+      { id: 'c-0', chunkIndex: 0, text: 't-0', chapter: null },
+    ]
+    const port = createMobileEmbedPort()
+
+    await port.generateChunks({
+      bookId: 'book-release' as unknown as string,
+      filePath: '/p',
+      format: 'epub',
+    })
+    // Pretend a retry/reindex happens. The lock must have cleared so the
+    // chunker is asked again.
+    chunkerState.callCount = 0
+    vectorState.embeddedBookIds.delete('book-release')
+
+    await port.generateChunks({
+      bookId: 'book-release' as unknown as string,
+      filePath: '/p',
+      format: 'epub',
+    })
+
+    expect(chunkerState.callCount).toBe(1)
+  })
+
+  it('releases the lock on failure so a retry can run', async () => {
+    chunkerState.chunks = [
+      { id: 'c-0', chunkIndex: 0, text: 't-0', chapter: null },
+    ]
+    embedderState.ready = false
+    serverState.throwOnCall = 1
+
+    const port = createMobileEmbedPort()
+
+    await expect(
+      port.generateChunks({
+        bookId: 'book-retry' as unknown as string,
+        filePath: '/p',
+        format: 'epub',
+      }),
+    ).rejects.toThrow()
+
+    // Reset embedder to succeed; retry must actually re-run the pipeline.
+    serverState.throwOnCall = 0
+    serverState.callCount = 0
+    chunkerState.callCount = 0
+
+    await port.generateChunks({
+      bookId: 'book-retry' as unknown as string,
+      filePath: '/p',
+      format: 'epub',
+    })
+
+    expect(chunkerState.callCount).toBe(1)
+  })
+})

--- a/apps/mobile/lib/book-import/adapters.ts
+++ b/apps/mobile/lib/book-import/adapters.ts
@@ -28,7 +28,11 @@ import { triggerSyncOnWrite } from "@/lib/sync/triggers";
 import { getChunks } from "@/lib/rag/chunker";
 import { embedBatch, isEmbeddingReady } from "@/lib/rag/embedder";
 import { embedTextsOnServer } from "@/lib/rag/server-fallback";
-import { insertChunkWithVector, isBookEmbedded } from "@/lib/rag/vector-store";
+import {
+  deleteBookChunks,
+  insertChunkWithVector,
+  isBookEmbedded,
+} from "@/lib/rag/vector-store";
 
 /**
  * Mobile-specific Book row shape used by the shared service. Mirrors
@@ -128,6 +132,17 @@ export function createMobileDbPort(): DbPort<
 > {
   return {
     async saveBook(insertable) {
+      // DAT-001 (#114): atomic insert. If anything between the row write
+      // and returning the row shape throws (e.g. triggerSyncOnWrite blows
+      // up on the sync engine, or row-shape construction fails), we MUST
+      // roll back the just-inserted row. Otherwise the books table keeps
+      // a row pointing at a copied file whose post-save pipeline never
+      // completed, and the user sees a permanently broken entry.
+      //
+      // The shared importer already runs copy BEFORE save (see
+      // packages/shared/src/book-import/importer.ts), so a copy failure
+      // never reaches this path. This guard covers the other half of the
+      // window: failures DURING save itself.
       db.insert(books)
         .values({
           id: insertable.id,
@@ -144,23 +159,36 @@ export function createMobileDbPort(): DbPort<
           isDeleted: false,
         })
         .run();
-      // Without this, the new book row sits with isDirty=true until either
-      // the app is backgrounded or the 5-minute periodic timer fires. The
-      // legacy `book-storage.insertBook` path triggers sync; we must too
-      // so freshly imported books reach D1 promptly. (H3-03)
-      triggerSyncOnWrite();
-      // Construct the row shape the service expects (the inserted row).
-      return {
-        id: insertable.id,
-        title: insertable.title,
-        author: insertable.author,
-        coverPath: insertable.coverPath,
-        filePath: insertable.filePath,
-        format: insertable.format,
-        currentCfi: insertable.currentCfi,
-        currentPage: insertable.currentPage,
-        createdAt: insertable.createdAt,
-      };
+      try {
+        // Without this, the new book row sits with isDirty=true until either
+        // the app is backgrounded or the 5-minute periodic timer fires. The
+        // legacy `book-storage.insertBook` path triggers sync; we must too
+        // so freshly imported books reach D1 promptly. (H3-03)
+        triggerSyncOnWrite();
+        // Construct the row shape the service expects (the inserted row).
+        return {
+          id: insertable.id,
+          title: insertable.title,
+          author: insertable.author,
+          coverPath: insertable.coverPath,
+          filePath: insertable.filePath,
+          format: insertable.format,
+          currentCfi: insertable.currentCfi,
+          currentPage: insertable.currentPage,
+          createdAt: insertable.createdAt,
+        };
+      } catch (err) {
+        // Roll back the orphan row before rethrowing so the import surface
+        // sees a clean "save failed" outcome (no row, no file ownership).
+        try {
+          db.delete(books).where(eq(books.id, insertable.id)).run();
+        } catch {
+          /* best-effort; the row may still be there if delete itself
+             failed, but rethrowing the original error is more useful to
+             the caller than masking it. */
+        }
+        throw err;
+      }
     },
 
     async savePageDataMany(_pageData) {
@@ -270,55 +298,107 @@ export function createMobileUploadPort(): UploadPort<string> {
  * still useful for the regression-recovery branch on electron, so we keep
  * it.
  */
+/**
+ * DAT-007 (#120): module-level in-flight lock. Concurrent
+ * `generateChunks(bookId)` calls must coalesce onto the same Promise so
+ * we never run two embed loops for the same book. Previously, two
+ * callers (e.g. file-import.runImportWithService's fire-and-forget
+ * indexBook AND a user-initiated reindex from the chat screen) could
+ * both win the `isBookEmbedded` check before either had written its
+ * first chunk, then race each other into duplicate vectors.
+ *
+ * Keyed on String(bookId); the entry is deleted in a finally block so
+ * the lock releases on both success and failure, allowing genuine
+ * retries to proceed.
+ */
+const inFlightEmbedByBookId = new Map<
+  string,
+  Promise<PageDataInsertable<string>[]>
+>();
+
+async function runEmbedPipeline(
+  bookId: string,
+  filePath: string,
+  format: BookFormat,
+): Promise<PageDataInsertable<string>[]> {
+  if (isBookEmbedded(bookId)) return [];
+
+  const chunks = await getChunks(filePath, format, bookId);
+  if (chunks.length === 0) return [];
+
+  const BATCH_SIZE = 10;
+  try {
+    for (let i = 0; i < chunks.length; i += BATCH_SIZE) {
+      const batch = chunks.slice(i, i + BATCH_SIZE);
+      const texts = batch.map((c) => c.text);
+
+      let embeddings: number[][];
+      if (isEmbeddingReady()) {
+        try {
+          embeddings = await embedBatch(texts);
+        } catch (err) {
+          console.warn(
+            "[book-import] on-device embed failed, falling back to server:",
+            err,
+          );
+          embeddings = await embedTextsOnServer(texts);
+        }
+      } else {
+        embeddings = await embedTextsOnServer(texts);
+      }
+
+      for (let j = 0; j < batch.length; j++) {
+        const chunk = batch[j];
+        insertChunkWithVector(
+          chunk.id,
+          bookId,
+          chunk.chunkIndex,
+          chunk.text,
+          chunk.chapter,
+          embeddings[j],
+        );
+      }
+    }
+  } catch (err) {
+    // DAT-004 (#117): mid-batch failure must NOT leave the book
+    // half-indexed. `isBookEmbedded` returns true as soon as ≥1 chunk
+    // is in sqlite, so without this rollback the book would be stuck
+    // in a "partially indexed, will never re-index" state. Delete
+    // every chunk we wrote for this book before re-throwing so a
+    // retry sees a clean slate.
+    try {
+      deleteBookChunks(bookId);
+    } catch (cleanupErr) {
+      console.warn(
+        "[book-import] failed to roll back partial chunks after embed error:",
+        cleanupErr,
+      );
+    }
+    throw err;
+  }
+
+  // Sentinel: signal "chunks exist now" without re-emitting them so the
+  // shared indexer's savePageDataMany branch becomes a no-op on mobile.
+  return chunks.map((c, idx) => ({
+    id: idx,
+    pageNumber: idx,
+    bookId,
+    data: c.text,
+  }));
+}
+
 export function createMobileEmbedPort(): EmbedPort {
   return {
     async generateChunks({ bookId, filePath, format }) {
-      if (isBookEmbedded(String(bookId))) return [];
+      const key = String(bookId);
+      const existing = inFlightEmbedByBookId.get(key);
+      if (existing) return existing;
 
-      const chunks = await getChunks(filePath, format, String(bookId));
-      if (chunks.length === 0) return [];
-
-      const BATCH_SIZE = 10;
-      for (let i = 0; i < chunks.length; i += BATCH_SIZE) {
-        const batch = chunks.slice(i, i + BATCH_SIZE);
-        const texts = batch.map((c) => c.text);
-
-        let embeddings: number[][];
-        if (isEmbeddingReady()) {
-          try {
-            embeddings = await embedBatch(texts);
-          } catch (err) {
-            console.warn(
-              "[book-import] on-device embed failed, falling back to server:",
-              err,
-            );
-            embeddings = await embedTextsOnServer(texts);
-          }
-        } else {
-          embeddings = await embedTextsOnServer(texts);
-        }
-
-        for (let j = 0; j < batch.length; j++) {
-          const chunk = batch[j];
-          insertChunkWithVector(
-            chunk.id,
-            String(bookId),
-            chunk.chunkIndex,
-            chunk.text,
-            chunk.chapter,
-            embeddings[j],
-          );
-        }
-      }
-
-      // Sentinel: signal "chunks exist now" without re-emitting them so the
-      // shared indexer's savePageDataMany branch becomes a no-op on mobile.
-      return chunks.map((c, idx) => ({
-        id: idx,
-        pageNumber: idx,
-        bookId: String(bookId),
-        data: c.text,
-      }));
+      const promise = runEmbedPipeline(key, filePath, format).finally(() => {
+        inFlightEmbedByBookId.delete(key);
+      });
+      inFlightEmbedByBookId.set(key, promise);
+      return promise;
     },
 
     async embed(_params) {


### PR DESCRIPTION
## Summary

Three P1 data-integrity fixes for the mobile import + embed pipeline, each scoped to `apps/mobile/lib/book-import/` and its `rag/*` collaborators. Tests live in `apps/mobile/__tests__/book-import/data-integrity.test.ts` (7 cases, all green).

### DAT-001 (#114) — atomic insert

`createMobileDbPort().saveBook` now wraps everything between the row write and the row-shape return in a `try/catch`. On throw (e.g. `triggerSyncOnWrite` blowing up the sync engine, row-shape build error) it deletes the just-inserted row before re-throwing, so the books table never keeps an orphan pointing at a file the post-save pipeline couldn't seal.

Note: the shared importer already runs **copy → parse → save** in `packages/shared/src/book-import/importer.ts`, so a `copyBookToAppData` failure short-circuits before save is ever called. The new test pins that contract explicitly; the new `try/catch` covers the second window (failures during save).

### DAT-004 (#117) — idempotent embed retry

`generateChunks` wraps the embed-then-insert loop in `try/catch`. On any throw (on-device embed AND server fallback both failed for a batch) it calls `deleteBookChunks(bookId)` to remove every chunk written so far, then re-throws. Previously the book stayed half-indexed because `isBookEmbedded` returns true on the first row.

### DAT-007 (#120) — in-flight lock

Added a module-level `Map<string, Promise<PageDataInsertable<string>[]>>` keyed on bookId. First caller seeds the promise; concurrent callers await the same promise. The entry is cleared in `finally` so legitimate retries (after success or failure) re-run. Closes the duplicate-vector race between `runImportWithService`'s fire-and-forget `indexBook` and any user-initiated re-index.

## Test plan

- [x] `apps/mobile/__tests__/book-import/data-integrity.test.ts` — 7 cases pass:
  - DAT-001: copy throw leaves no row; saveBook post-write throw rolls back the row
  - DAT-004: mid-batch server failure deletes all chunks for that book; doesn't touch other books
  - DAT-007: two concurrent `generateChunks` calls coalesce to one chunker+one insert loop; lock releases on success; lock releases on failure (retry runs)
- [x] `apps/mobile/__tests__/rag-pipeline.test.ts` — 11/11 still pass (no regression in `lib/rag/pipeline.ts`)
- [x] `apps/mobile/__tests__/book-import/cover-extraction-failure.test.ts` — 4/4 still pass (CoverPort untouched)
- [x] `apps/mobile/__tests__/book-import/url-import.test.ts` — still passes
- [x] Typecheck: no new errors in `lib/book-import/adapters.ts` or the new test file

Known pre-existing test failure (`book-import/file-import.test.ts` — `app/_layout` import chain) is unchanged.

Closes #114.
Closes #117.
Closes #120.