### PR TITLE
mobile(chat/input): theme tokens + hoist styles in ChatInput

### DIFF
--- a/apps/mobile/__tests__/components/ChatInput.test.tsx
+++ b/apps/mobile/__tests__/components/ChatInput.test.tsx
@@ -410,3 +410,49 @@ describe('ChatInput (mobile) — P1-AI stop button → onAbort', () => {
     }).not.toThrow()
   })
 })
+
+/**
+ * PRF-009 — TextInput previously rendered with
+ * `style={{ maxHeight: 96 }}` — an inline object literal allocated on
+ * every render, plus a magic number. Hoist to a module-scope StyleSheet
+ * so the same reference is reused across renders.
+ */
+describe('ChatInput (mobile) — PRF-009 TextInput style is hoisted', () => {
+  it('reuses the same TextInput style reference across renders', () => {
+    let tree!: TestRenderer.ReactTestRenderer
+    act(() => {
+      tree = TestRenderer.create(
+        <ChatInput onSend={jest.fn()} isLoading={false} disabled={false} />,
+      )
+    })
+    const styleA = (findTextInput(tree).props as { style?: unknown }).style
+
+    // Trigger a re-render by changing the text. If the maxHeight object
+    // is inline in JSX, a fresh `{ maxHeight: 96 }` is allocated on every
+    // render and `styleB !== styleA`.
+    act(() => {
+      ;(findTextInput(tree).props as { onChangeText: (t: string) => void }).onChangeText(
+        'trigger-rerender',
+      )
+    })
+    const styleB = (findTextInput(tree).props as { style?: unknown }).style
+
+    expect(styleB).toBe(styleA)
+  })
+
+  it('exposes a numeric maxHeight on the TextInput style (no NaN, no inline derivation)', () => {
+    let tree!: TestRenderer.ReactTestRenderer
+    act(() => {
+      tree = TestRenderer.create(
+        <ChatInput onSend={jest.fn()} isLoading={false} disabled={false} />,
+      )
+    })
+    const style = (findTextInput(tree).props as { style?: unknown }).style
+    if (style && typeof style === 'object' && !Array.isArray(style)) {
+      const styleObj = style as Record<string, unknown>
+      if ('maxHeight' in styleObj) {
+        expect(typeof styleObj.maxHeight).toBe('number')
+      }
+    }
+  })
+})

--- a/apps/mobile/__tests__/components/ChatInput.test.tsx
+++ b/apps/mobile/__tests__/components/ChatInput.test.tsx
@@ -35,6 +35,10 @@ jest.mock('react-native', () => {
     StyleSheet: { create: (s: Record<string, unknown>) => s },
     Platform: { OS: 'ios', select: <T,>(spec: Record<string, T>): T | undefined => spec.ios ?? spec.default },
     useColorScheme: () => 'light',
+    AccessibilityInfo: {
+      isReduceMotionEnabled: () => Promise.resolve(false),
+      addEventListener: () => ({ remove: () => undefined }),
+    },
     Linking: { openSettings: (...args: unknown[]) => mockOpenSettings(...args) },
   }
 })
@@ -54,10 +58,33 @@ jest.mock('@/components/VoiceMicButton', () => {
   }
 })
 
+// Stub `useTheme` so the test doesn't pull in the real
+// `AccessibilityInfo` side-effect (Promise → setState) which fires a
+// post-render `act` warning. We hand the component the light-mode token
+// table directly. The PRF-004 tests then assert the rendered styles use
+// values from this table — exactly what the production hook would
+// return on a light-mode device.
+jest.mock('@/lib/theme/useTheme', () => {
+  const { colorsLight } = require('@/lib/theme/colors')
+  return {
+    useTheme: () => ({
+      scheme: 'light',
+      colors: colorsLight,
+      typography: {},
+      spacing: {},
+      radius: {},
+      motion: {},
+      shadow: {},
+      reduceMotion: false,
+    }),
+  }
+})
+
 import React, { act } from 'react'
 import TestRenderer from 'react-test-renderer'
 import { Pressable, TextInput, TouchableOpacity } from 'react-native'
 import { ChatInput } from '@/components/ChatInput'
+import { colorsLight } from '@/lib/theme/colors'
 
 function findTextInput(tree: TestRenderer.ReactTestRenderer): TestRenderer.ReactTestInstance {
   return tree.root.findAll((n) => n.type === TextInput)[0]
@@ -454,5 +481,102 @@ describe('ChatInput (mobile) — PRF-009 TextInput style is hoisted', () => {
         expect(typeof styleObj.maxHeight).toBe('number')
       }
     }
+  })
+})
+
+/**
+ * PRF-004 — Send button colors must come from the theme token system, not
+ * from hardcoded hex literals interpolated into a className template.
+ *
+ * The previous implementation read:
+ *   className={`... ${showStop ? 'bg-[#0a7ea4]' : canSend ? 'bg-[#0a7ea4]' : 'bg-gray-200 ...'}`}
+ *   color={canSend || showStop ? '#FFFFFF' : '#9BA1A6'}
+ *
+ * That bypasses the theme — dark mode, accent overrides, and reskinning
+ * are all impossible. The accent must come from `colors.accent.primary`
+ * (see apps/mobile/lib/theme/colors.ts), exposed via the `useTheme()`
+ * hook used elsewhere in the codebase.
+ */
+describe('ChatInput (mobile) — PRF-004 send button uses theme tokens', () => {
+  function findSendButtonForTokens(
+    tree: TestRenderer.ReactTestRenderer,
+  ): TestRenderer.ReactTestInstance {
+    return tree.root.findAll(
+      (n) =>
+        n.type === TouchableOpacity &&
+        (n.props as { testID?: string }).testID === 'chat-send-btn',
+    )[0]
+  }
+
+  function flattenStyle(style: unknown): Record<string, unknown> {
+    if (!style) return {}
+    if (Array.isArray(style))
+      return style.reduce<Record<string, unknown>>(
+        (acc, s) => ({ ...acc, ...flattenStyle(s) }),
+        {},
+      )
+    return style as Record<string, unknown>
+  }
+
+  it('paints the active send button background with colors.accent.primary (no hex literal)', () => {
+    let tree!: TestRenderer.ReactTestRenderer
+    act(() => {
+      tree = TestRenderer.create(
+        <ChatInput onSend={jest.fn()} isLoading={false} disabled={false} />,
+      )
+    })
+
+    // Type something so canSend === true and the button paints accent.
+    act(() => {
+      ;(findTextInput(tree).props as { onChangeText: (t: string) => void }).onChangeText(
+        'hi',
+      )
+    })
+
+    const btn = findSendButtonForTokens(tree)
+    const style = flattenStyle((btn.props as { style?: unknown }).style)
+    expect(style.backgroundColor).toBe(colorsLight.accent.primary)
+
+    // No hardcoded teal hex should ever land on the rendered button —
+    // neither in the style nor in the className.
+    const cls = (btn.props as { className?: string }).className ?? ''
+    expect(cls).not.toMatch(/#0a7ea4/i)
+    expect(style.backgroundColor).not.toBe('#0a7ea4')
+  })
+
+  it('paints the stop-state background with colors.accent.primary while isLoading', () => {
+    let tree!: TestRenderer.ReactTestRenderer
+    act(() => {
+      tree = TestRenderer.create(
+        <ChatInput
+          onSend={jest.fn()}
+          isLoading={true}
+          disabled={false}
+          onAbort={jest.fn()}
+        />,
+      )
+    })
+
+    const btn = findSendButtonForTokens(tree)
+    const style = flattenStyle((btn.props as { style?: unknown }).style)
+    expect(style.backgroundColor).toBe(colorsLight.accent.primary)
+  })
+
+  it('keeps the teal hex literal out of the rendered send-button className', () => {
+    let tree!: TestRenderer.ReactTestRenderer
+    act(() => {
+      tree = TestRenderer.create(
+        <ChatInput onSend={jest.fn()} isLoading={false} disabled={false} />,
+      )
+    })
+    act(() => {
+      ;(findTextInput(tree).props as { onChangeText: (t: string) => void }).onChangeText(
+        'hello',
+      )
+    })
+
+    const btn = findSendButtonForTokens(tree)
+    const cls = (btn.props as { className?: string }).className ?? ''
+    expect(cls).not.toMatch(/#0a7ea4/i)
   })
 })

--- a/apps/mobile/components/ChatInput.tsx
+++ b/apps/mobile/components/ChatInput.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Linking, Pressable, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native'
 import { IconSymbol } from '@/components/ui/icon-symbol'
 import { VoiceMicButton } from '@/components/VoiceMicButton'
+import { useTheme } from '@/lib/theme/useTheme'
 
 // PRF-009 — Hoist the TextInput's per-render style into a module-scope
 // `StyleSheet.create` so the reference is stable across renders. The
@@ -9,6 +10,11 @@ import { VoiceMicButton } from '@/components/VoiceMicButton'
 // JSX, which allocated a fresh object literal on every render of the
 // input and made the magic `96` un-discoverable.
 const INPUT_MAX_HEIGHT = 96
+// PRF-004: disabled-state glyph tint. The active glyph is `#FFFFFF`
+// (on-accent label), the disabled tint is a neutral grey — there's no
+// semantic token for "glyph on neutral fill" yet, so we keep the
+// literal but name it.
+const INPUT_DISABLED_ICON_COLOR = '#9BA1A6'
 
 const styles = StyleSheet.create({
   textInput: {
@@ -68,6 +74,18 @@ export function ChatInput({
   onAbort,
 }: ChatInputProps) {
   const [text, setText] = useState('')
+  const { colors } = useTheme()
+
+  // PRF-004: per-state backgrounds pulled from theme tokens. Memoised so
+  // re-renders don't churn the style object reference.
+  const accentBackground = useMemo(
+    () => ({ backgroundColor: colors.accent.primary }),
+    [colors.accent.primary],
+  )
+  const idleBackground = useMemo(
+    () => ({ backgroundColor: colors.fill.tertiary }),
+    [colors.fill.tertiary],
+  )
 
   // When external text arrives (e.g. from voice transcription), populate input
   useEffect(() => {
@@ -147,20 +165,21 @@ export function ChatInput({
           // that, we keep the no-op for back-compat.
           onPress={showStop ? onAbort : handleSend}
           disabled={(!canSend && !showStop) || (showStop && !onAbort)}
-          className={`w-10 h-10 rounded-full items-center justify-center ml-2 ${
-            showStop
-              ? 'bg-[#0a7ea4]'
-              : canSend
-                ? 'bg-[#0a7ea4]'
-                : 'bg-gray-200 dark:bg-gray-700'
-          }`}
+          // PRF-004: background comes from theme tokens (accent.primary
+          // / fill.tertiary) instead of a hardcoded `#0a7ea4` baked into
+          // a Tailwind template literal. Dark mode + future reskins are
+          // honoured.
+          style={canSend || showStop ? accentBackground : idleBackground}
+          className="w-10 h-10 rounded-full items-center justify-center ml-2"
           accessibilityLabel={showStop ? 'Stop generating' : 'Send message'}
           accessibilityRole="button"
         >
           <IconSymbol
             name={showStop ? 'stop.fill' : 'arrow.up'}
             size={20}
-            color={canSend || showStop ? '#FFFFFF' : '#9BA1A6'}
+            // PRF-004: active icon stays `#FFFFFF` (on-accent label).
+            // Disabled tint hoisted to a named constant.
+            color={canSend || showStop ? '#FFFFFF' : INPUT_DISABLED_ICON_COLOR}
           />
         </TouchableOpacity>
       </View>
@@ -185,7 +204,11 @@ export function ChatInput({
             accessibilityRole="button"
             hitSlop={8}
           >
-            <Text className="text-sm font-semibold text-[#0a7ea4] ml-2">
+            {/* PRF-004: link colour pulled from theme accent token. */}
+            <Text
+              className="text-sm font-semibold ml-2"
+              style={{ color: colors.accent.primary }}
+            >
               Open Settings
             </Text>
           </Pressable>

--- a/apps/mobile/components/ChatInput.tsx
+++ b/apps/mobile/components/ChatInput.tsx
@@ -1,7 +1,20 @@
 import { useEffect, useState } from 'react'
-import { Linking, Pressable, Text, TextInput, TouchableOpacity, View } from 'react-native'
+import { Linking, Pressable, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native'
 import { IconSymbol } from '@/components/ui/icon-symbol'
 import { VoiceMicButton } from '@/components/VoiceMicButton'
+
+// PRF-009 — Hoist the TextInput's per-render style into a module-scope
+// `StyleSheet.create` so the reference is stable across renders. The
+// previous implementation used `style={{ maxHeight: 96 }}` directly in
+// JSX, which allocated a fresh object literal on every render of the
+// input and made the magic `96` un-discoverable.
+const INPUT_MAX_HEIGHT = 96
+
+const styles = StyleSheet.create({
+  textInput: {
+    maxHeight: INPUT_MAX_HEIGHT,
+  },
+})
 
 interface ChatInputProps {
   /**
@@ -97,6 +110,9 @@ export function ChatInput({
         <TextInput
           testID="chat-input"
           className="flex-1 bg-gray-100 dark:bg-[#2A2D2F] rounded-full px-4 py-2 text-base text-gray-900 dark:text-gray-100"
+          // PRF-009: stable style reference (module-scope StyleSheet)
+          // — no per-render `{ maxHeight: 96 }` allocation.
+          style={styles.textInput}
           placeholder={placeholder}
           placeholderTextColor="#687076"
           value={text}


### PR DESCRIPTION
Closes #109. Closes #113.

## Summary
- **PRF-004 (#109)** — Replace the send button's `bg-[#0a7ea4]` Tailwind interpolation with a memoised inline style that pulls `colors.accent.primary` / `colors.fill.tertiary` from `useTheme()`. Same fix applied to the "Open Settings" link below the input. Disabled icon tint hoisted to a named constant.
- **PRF-009 (#113)** — Hoist `style={{ maxHeight: 96 }}` into a module-scope `StyleSheet.create({ textInput: { maxHeight: INPUT_MAX_HEIGHT } })` so the same reference is reused across renders.

## Test plan
- [x] `__tests__/components/ChatInput.test.tsx` — 17 tests pass (12 existing + 2 PRF-009 + 3 PRF-004).
- [x] PRF-009 test asserts the TextInput style reference is identical across renders (failed before hoist, passes after).
- [x] PRF-004 tests assert the send button's `backgroundColor` equals `colorsLight.accent.primary` in both the canSend and showStop states, and the rendered className contains no `#0a7ea4` literal.
- [x] No new typecheck errors against ChatInput; preexisting `packages/shared/voice-chat/*` failures are untouched.