### PR TITLE
mobile(chat/detail): P1 cluster — abort, gates, errors, embed-guard

### DIFF
--- a/apps/mobile/__tests__/chat/abort-stop-button.test.tsx
+++ b/apps/mobile/__tests__/chat/abort-stop-button.test.tsx
@@ -1,0 +1,293 @@
+/**
+ * CHT-006 (#56) / A11Y-006 (#103) — Stop button during LLM generation
+ * MUST abort the in-flight request.
+ *
+ * Pre-fix, ChatInput accepted an `onAbort` prop but the chat detail screen
+ * never passed one. When the user tapped the stop icon during generation,
+ * the button no-op'd: the network call continued, `isQuerying` stayed
+ * true, and the only way to "recover" was to wait it out.
+ *
+ * Red signal:
+ *   1. `chat/[bookId].tsx` MUST pass an `onAbort` function to ChatInput.
+ *   2. Invoking that `onAbort` MUST abort the AbortController whose
+ *      signal is threaded into `askQuestion`.
+ *   3. After abort, `isLoading` flips back to false (the hook's catch
+ *      block resets state when fetch rejects with AbortError).
+ */
+
+jest.mock('react-native', () => {
+  const React = require('react')
+  const mk = (name: string) =>
+    React.forwardRef((p: any, r: unknown) =>
+      React.createElement(name, { ...p, ref: r }, p.children),
+    )
+  const FlatList = React.forwardRef((p: any, r: unknown) => {
+    const { data = [], renderItem, keyExtractor, ListHeaderComponent, ListFooterComponent, ListEmptyComponent } = p
+    const items = (data as unknown[]).map((item, index) => {
+      const key = keyExtractor ? keyExtractor(item, index) : String(index)
+      const rendered = renderItem ? renderItem({ item, index }) : null
+      return React.createElement(React.Fragment, { key }, rendered)
+    })
+    return React.createElement(
+      'FlatList',
+      { ...p, ref: r },
+      ListHeaderComponent ?? null,
+      items.length === 0 ? ListEmptyComponent ?? null : items,
+      ListFooterComponent ?? null,
+    )
+  })
+  return {
+    View: mk('View'),
+    Text: mk('Text'),
+    Pressable: mk('Pressable'),
+    TouchableOpacity: mk('TouchableOpacity'),
+    TextInput: mk('TextInput'),
+    Image: mk('Image'),
+    ActivityIndicator: mk('ActivityIndicator'),
+    KeyboardAvoidingView: mk('KeyboardAvoidingView'),
+    ScrollView: mk('ScrollView'),
+    FlatList,
+    Alert: { alert: jest.fn() },
+    StyleSheet: { create: (s: Record<string, unknown>) => s, hairlineWidth: 0.5 },
+    Platform: {
+      OS: 'ios',
+      select: <T,>(spec: Record<string, T>): T | undefined =>
+        spec.ios ?? spec.default,
+    },
+    useColorScheme: () => 'light',
+    AccessibilityInfo: {
+      isReduceMotionEnabled: jest.fn(() => new Promise(() => {})),
+      addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+    },
+  }
+})
+
+jest.mock('react-native-reanimated', () => {
+  const React = require('react')
+  const View = React.forwardRef((p: any, r: unknown) =>
+    React.createElement('Animated.View', { ...p, ref: r }, p.children),
+  )
+  return {
+    __esModule: true,
+    default: { View, createAnimatedComponent: (c: unknown) => c },
+    View,
+    FadeIn: { duration: () => ({ withInitialValues: () => ({}) }) },
+    FadeOut: { duration: () => ({}) },
+    SlideInLeft: { duration: () => ({}) },
+    SlideInRight: { duration: () => ({}) },
+    useSharedValue: (v: unknown) => ({ value: v }),
+    useAnimatedStyle: () => ({}),
+    withTiming: (v: unknown) => v,
+    withSpring: (v: unknown) => v,
+    Easing: { out: () => null, quad: null, inOut: () => null },
+  }
+})
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react')
+  const SafeAreaView = (p: any) =>
+    React.createElement('SafeAreaView', p, p.children)
+  return {
+    SafeAreaView,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  }
+})
+
+const pushSpy = jest.fn()
+const localParams: { current: Record<string, string | undefined> } = {
+  current: {},
+}
+jest.mock('expo-router', () => {
+  const React = require('react')
+  return {
+    useRouter: () => ({ push: pushSpy, replace: jest.fn(), back: jest.fn() }),
+    useLocalSearchParams: () => localParams.current,
+    useFocusEffect: (cb: () => void) => {
+      React.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [cb])
+    },
+  }
+})
+
+jest.mock('@/components/ui/icon-symbol', () => {
+  const React = require('react')
+  return {
+    IconSymbol: (p: any) =>
+      React.createElement('IconSymbol', { testID: `icon-${p.name}`, ...p }),
+  }
+})
+
+jest.mock('@/lib/stores/authStore', () => ({
+  __esModule: true,
+  useAuthStore: Object.assign(
+    <T,>(selector: (s: { isAuthenticated: boolean }) => T) =>
+      selector({ isAuthenticated: true }),
+    { getState: () => ({ isAuthenticated: true, authHydrated: true, openPremiumGate: jest.fn() }) },
+  ),
+}))
+
+jest.mock('@/components/auth/useRequireAuth', () => ({
+  useRequireAuth: () => (action: () => void) => action(),
+}))
+
+jest.mock('@/lib/conversation-storage', () => ({
+  getAllConversations: () => [],
+  getConversationsForBook: (bookId: string) => [
+    { id: `conv-${bookId}`, bookId, title: 'T', createdAt: 1, updatedAt: 2 },
+  ],
+  getMessages: () => [],
+  addMessage: jest.fn((conversationId: string, role: string, content: string) => ({
+    id: `msg-${Math.random()}`,
+    conversationId,
+    role,
+    content,
+    sourceChunks: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  })),
+  softDeleteConversation: jest.fn(),
+  createConversation: jest.fn(),
+}))
+
+jest.mock('@/lib/book-storage', () => ({
+  getBookById: () => ({ id: 'book-1', title: 'Book', format: 'epub' }),
+  getBooks: () => [],
+  getBookForReading: jest.fn(async () => ({
+    id: 'book-1',
+    title: 'Book',
+    format: 'epub',
+    filePath: '/tmp/book.epub',
+  })),
+}))
+
+jest.mock('@/lib/rag/vector-store', () => ({
+  isBookEmbedded: () => true,
+  searchSimilarChunks: jest.fn(),
+}))
+jest.mock('@/lib/rag/pipeline', () => ({
+  embedBook: jest.fn(async () => undefined),
+}))
+
+// `askQuestion` returns a never-resolving promise so we can simulate an
+// in-flight request. It captures the `signal` (3rd arg) so the test can
+// inspect whether the screen aborted it.
+let capturedSignal: AbortSignal | null = null
+const askQuestionSpy = jest.fn(
+  (_text: string, _history: unknown, signal?: AbortSignal) => {
+    capturedSignal = signal ?? null
+    return new Promise<{ answer: string; sources: unknown[] }>(() => {
+      /* never resolves — represents an in-flight LLM call */
+    })
+  },
+)
+jest.mock('@/hooks/useRAGQuery', () => ({
+  useRAGQuery: () => ({
+    askQuestion: askQuestionSpy,
+    // `isLoading` is driven by the screen reading the hook; for this
+    // test we don't need to flip it from inside the mock — the screen
+    // passes `onAbort` whenever it has a controller, regardless.
+    isLoading: false,
+  }),
+}))
+jest.mock('@/hooks/useEmbeddingModel', () => ({
+  useEmbeddingModel: () => ({ isReady: true, downloadProgress: 1 }),
+}))
+jest.mock('@/hooks/useVoiceInput', () => ({
+  useVoiceInput: () => ({
+    isRecording: false,
+    isTranscribing: false,
+    error: null,
+    permissionDenied: false,
+    startRecording: jest.fn(),
+    stopAndTranscribe: jest.fn(),
+  }),
+}))
+
+jest.mock('@/components/ChatMessage', () => {
+  const React = require('react')
+  return { ChatMessage: (p: any) => React.createElement('ChatMessage', p) }
+})
+
+// Capture both the `onSend` callback (to trigger a fake user send) and
+// the `onAbort` callback (the unit under test).
+const chatInputRegistry: {
+  onSend: ((text: string) => void) | null
+  onAbort: (() => void) | null
+} = { onSend: null, onAbort: null }
+jest.mock('@/components/ChatInput', () => {
+  const React = require('react')
+  return {
+    ChatInput: (p: any) => {
+      chatInputRegistry.onSend = p.onSend
+      chatInputRegistry.onAbort = p.onAbort ?? null
+      return React.createElement('ChatInput', { testID: 'chat-input' })
+    },
+  }
+})
+jest.mock('@/components/ModelDownloadCard', () => {
+  const React = require('react')
+  return {
+    ModelDownloadCard: (p: any) => React.createElement('ModelDownloadCard', p),
+  }
+})
+jest.mock('@/components/EmbeddingProgress', () => {
+  const React = require('react')
+  return {
+    EmbeddingProgress: (p: any) => React.createElement('EmbeddingProgress', p),
+  }
+})
+
+import React, { act } from 'react'
+import TestRenderer from 'react-test-renderer'
+
+describe('CHT-006 / A11Y-006 — Stop button aborts in-flight LLM call (#56 #103)', () => {
+  beforeEach(() => {
+    askQuestionSpy.mockClear()
+    chatInputRegistry.onSend = null
+    chatInputRegistry.onAbort = null
+    capturedSignal = null
+    localParams.current = { bookId: 'book-1' }
+  })
+
+  it('passes an AbortSignal into askQuestion and invokes abort() when onAbort fires', async () => {
+    const BookChatScreen = require('@/app/chat/[bookId]').default
+    let tree!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      tree = TestRenderer.create(<BookChatScreen />)
+    })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(chatInputRegistry.onSend).toBeTruthy()
+
+    // Send a question — askQuestion is called with (text, history, signal).
+    await act(async () => {
+      chatInputRegistry.onSend!('what is this book about?')
+      await Promise.resolve()
+    })
+
+    expect(askQuestionSpy).toHaveBeenCalledTimes(1)
+
+    // 1. The screen must thread an AbortSignal into askQuestion.
+    expect(capturedSignal).not.toBeNull()
+    expect(capturedSignal!.aborted).toBe(false)
+
+    // 2. The screen must expose an onAbort callback on ChatInput.
+    expect(chatInputRegistry.onAbort).toBeInstanceOf(Function)
+
+    // 3. Invoking onAbort must abort the same signal.
+    await act(async () => {
+      chatInputRegistry.onAbort!()
+      await Promise.resolve()
+    })
+
+    expect(capturedSignal!.aborted).toBe(true)
+
+    // Silence unused-tree lint.
+    expect(tree).toBeDefined()
+  })
+})

--- a/apps/mobile/__tests__/chat/deleted-book-guard.test.tsx
+++ b/apps/mobile/__tests__/chat/deleted-book-guard.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * DAT-018 (#130) — Chat embedding must verify the book row still exists
+ * in the local DB before firing `embedBook`. If the book was deleted
+ * (e.g. via the library bulk-delete path) the screen should render a
+ * "Book was deleted" error screen instead of trying to chunk a stale
+ * file path.
+ *
+ * Red signal:
+ *   1. Mock `getBookForReading` to resolve null (book missing).
+ *   2. Mount the chat detail screen.
+ *   3. `embedBook` MUST NOT have been called.
+ *   4. The screen MUST render an error message containing
+ *      "Book was deleted" (testID `chat-deleted-book-error`).
+ */
+
+jest.mock('react-native', () => {
+  const React = require('react')
+  const mk = (name: string) =>
+    React.forwardRef((p: any, r: unknown) =>
+      React.createElement(name, { ...p, ref: r }, p.children),
+    )
+  const FlatList = React.forwardRef((p: any, r: unknown) => {
+    const {
+      data = [],
+      renderItem,
+      keyExtractor,
+      ListHeaderComponent,
+      ListFooterComponent,
+      ListEmptyComponent,
+    } = p
+    const items = (data as unknown[]).map((item, index) => {
+      const key = keyExtractor ? keyExtractor(item, index) : String(index)
+      const rendered = renderItem ? renderItem({ item, index }) : null
+      return React.createElement(React.Fragment, { key }, rendered)
+    })
+    return React.createElement(
+      'FlatList',
+      { ...p, ref: r },
+      ListHeaderComponent ?? null,
+      items.length === 0 ? ListEmptyComponent ?? null : items,
+      ListFooterComponent ?? null,
+    )
+  })
+  return {
+    View: mk('View'),
+    Text: mk('Text'),
+    Pressable: mk('Pressable'),
+    TouchableOpacity: mk('TouchableOpacity'),
+    TextInput: mk('TextInput'),
+    Image: mk('Image'),
+    ActivityIndicator: mk('ActivityIndicator'),
+    KeyboardAvoidingView: mk('KeyboardAvoidingView'),
+    ScrollView: mk('ScrollView'),
+    FlatList,
+    Alert: { alert: jest.fn() },
+    StyleSheet: { create: (s: Record<string, unknown>) => s, hairlineWidth: 0.5 },
+    Platform: {
+      OS: 'ios',
+      select: <T,>(spec: Record<string, T>): T | undefined =>
+        spec.ios ?? spec.default,
+    },
+    useColorScheme: () => 'light',
+    AccessibilityInfo: {
+      isReduceMotionEnabled: jest.fn(() => new Promise(() => {})),
+      addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+    },
+  }
+})
+
+jest.mock('react-native-reanimated', () => {
+  const React = require('react')
+  const View = React.forwardRef((p: any, r: unknown) =>
+    React.createElement('Animated.View', { ...p, ref: r }, p.children),
+  )
+  return {
+    __esModule: true,
+    default: { View, createAnimatedComponent: (c: unknown) => c },
+    View,
+    FadeIn: { duration: () => ({ withInitialValues: () => ({}) }) },
+    FadeOut: { duration: () => ({}) },
+    SlideInLeft: { duration: () => ({}) },
+    SlideInRight: { duration: () => ({}) },
+    useSharedValue: (v: unknown) => ({ value: v }),
+    useAnimatedStyle: () => ({}),
+    withTiming: (v: unknown) => v,
+    withSpring: (v: unknown) => v,
+    Easing: { out: () => null, quad: null, inOut: () => null },
+  }
+})
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react')
+  const SafeAreaView = (p: any) =>
+    React.createElement('SafeAreaView', p, p.children)
+  return {
+    SafeAreaView,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  }
+})
+
+const pushSpy = jest.fn()
+const localParams: { current: Record<string, string | undefined> } = {
+  current: {},
+}
+jest.mock('expo-router', () => {
+  const React = require('react')
+  return {
+    useRouter: () => ({ push: pushSpy, replace: jest.fn(), back: jest.fn() }),
+    useLocalSearchParams: () => localParams.current,
+    useFocusEffect: (cb: () => void) => {
+      React.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [cb])
+    },
+  }
+})
+
+jest.mock('@/components/ui/icon-symbol', () => {
+  const React = require('react')
+  return {
+    IconSymbol: (p: any) =>
+      React.createElement('IconSymbol', { testID: `icon-${p.name}`, ...p }),
+  }
+})
+
+jest.mock('@/lib/stores/authStore', () => ({
+  __esModule: true,
+  useAuthStore: Object.assign(
+    <T,>(selector: (s: { isAuthenticated: boolean }) => T) =>
+      selector({ isAuthenticated: true }),
+    {
+      getState: () => ({
+        isAuthenticated: true,
+        authHydrated: true,
+        openPremiumGate: jest.fn(),
+      }),
+    },
+  ),
+}))
+
+jest.mock('@/components/auth/useRequireAuth', () => ({
+  useRequireAuth: () => (action: () => void) => action(),
+}))
+
+jest.mock('@/lib/conversation-storage', () => ({
+  getAllConversations: () => [],
+  getConversationsForBook: (bookId: string) => [
+    { id: `conv-${bookId}`, bookId, title: 'T', createdAt: 1, updatedAt: 2 },
+  ],
+  getMessages: () => [],
+  addMessage: jest.fn(),
+  softDeleteConversation: jest.fn(),
+  createConversation: jest.fn(),
+}))
+
+// Book is missing — both lookup paths return null.
+const getBookByIdSpy = jest.fn(() => null)
+const getBookForReadingSpy = jest.fn(async () => null)
+jest.mock('@/lib/book-storage', () => ({
+  getBookById: (...args: unknown[]) => getBookByIdSpy(...args),
+  getBooks: () => [],
+  getBookForReading: (...args: unknown[]) => getBookForReadingSpy(...args),
+}))
+
+jest.mock('@/lib/rag/vector-store', () => ({
+  isBookEmbedded: () => false,
+  searchSimilarChunks: jest.fn(),
+}))
+
+const embedBookSpy = jest.fn(async () => undefined)
+jest.mock('@/lib/rag/pipeline', () => ({
+  embedBook: (...args: unknown[]) => embedBookSpy(...args),
+}))
+
+jest.mock('@/hooks/useRAGQuery', () => ({
+  useRAGQuery: () => ({
+    askQuestion: jest.fn(async () => ({ answer: '', sources: [] })),
+    isLoading: false,
+  }),
+}))
+jest.mock('@/hooks/useEmbeddingModel', () => ({
+  useEmbeddingModel: () => ({ isReady: true, downloadProgress: 1 }),
+}))
+jest.mock('@/hooks/useVoiceInput', () => ({
+  useVoiceInput: () => ({
+    isRecording: false,
+    isTranscribing: false,
+    error: null,
+    permissionDenied: false,
+    startRecording: jest.fn(),
+    stopAndTranscribe: jest.fn(),
+  }),
+}))
+
+jest.mock('@/components/ChatMessage', () => {
+  const React = require('react')
+  return { ChatMessage: (p: any) => React.createElement('ChatMessage', p) }
+})
+
+jest.mock('@/components/ChatInput', () => {
+  const React = require('react')
+  return {
+    ChatInput: (p: any) => React.createElement('ChatInput', { testID: 'chat-input', ...p }),
+  }
+})
+jest.mock('@/components/ModelDownloadCard', () => {
+  const React = require('react')
+  return {
+    ModelDownloadCard: (p: any) => React.createElement('ModelDownloadCard', p),
+  }
+})
+jest.mock('@/components/EmbeddingProgress', () => {
+  const React = require('react')
+  return {
+    EmbeddingProgress: (p: any) => React.createElement('EmbeddingProgress', p),
+  }
+})
+
+import React, { act } from 'react'
+import TestRenderer from 'react-test-renderer'
+
+function findByTestID(
+  tree: TestRenderer.ReactTestRenderer,
+  testID: string,
+): TestRenderer.ReactTestInstance | null {
+  const matches = tree.root.findAll(
+    (n) => (n.props as { testID?: string } | null)?.testID === testID,
+  )
+  return matches[0] ?? null
+}
+
+describe('DAT-018 — chat embed guards against deleted books (#130)', () => {
+  beforeEach(() => {
+    embedBookSpy.mockClear()
+    getBookByIdSpy.mockClear()
+    getBookForReadingSpy.mockClear()
+    getBookByIdSpy.mockReturnValue(null)
+    getBookForReadingSpy.mockResolvedValue(null)
+    localParams.current = { bookId: 'gone-book' }
+  })
+
+  it('does not fire embedBook and renders a deleted-book error when the row is missing', async () => {
+    const BookChatScreen = require('@/app/chat/[bookId]').default
+    let tree!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      tree = TestRenderer.create(<BookChatScreen />)
+    })
+    // Drain async getBookForReading.
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(embedBookSpy).not.toHaveBeenCalled()
+
+    const errScreen = findByTestID(tree, 'chat-deleted-book-error')
+    expect(errScreen).not.toBeNull()
+  })
+})

--- a/apps/mobile/__tests__/chat/deleted-book-guard.test.tsx
+++ b/apps/mobile/__tests__/chat/deleted-book-guard.test.tsx
@@ -155,12 +155,12 @@ jest.mock('@/lib/conversation-storage', () => ({
 }))
 
 // Book is missing — both lookup paths return null.
-const getBookByIdSpy = jest.fn(() => null)
-const getBookForReadingSpy = jest.fn(async () => null)
+const getBookByIdSpy = jest.fn((_id: string) => null)
+const getBookForReadingSpy = jest.fn(async (_id: string) => null)
 jest.mock('@/lib/book-storage', () => ({
-  getBookById: (...args: unknown[]) => getBookByIdSpy(...args),
+  getBookById: (id: string) => getBookByIdSpy(id),
   getBooks: () => [],
-  getBookForReading: (...args: unknown[]) => getBookForReadingSpy(...args),
+  getBookForReading: (id: string) => getBookForReadingSpy(id),
 }))
 
 jest.mock('@/lib/rag/vector-store', () => ({
@@ -168,9 +168,10 @@ jest.mock('@/lib/rag/vector-store', () => ({
   searchSimilarChunks: jest.fn(),
 }))
 
-const embedBookSpy = jest.fn(async () => undefined)
+const embedBookSpy = jest.fn(async (..._args: unknown[]) => undefined)
 jest.mock('@/lib/rag/pipeline', () => ({
-  embedBook: (...args: unknown[]) => embedBookSpy(...args),
+  embedBook: (bookId: string, filePath: string, format: string, onProgress?: (p: number) => void) =>
+    embedBookSpy(bookId, filePath, format, onProgress),
 }))
 
 jest.mock('@/hooks/useRAGQuery', () => ({

--- a/apps/mobile/__tests__/chat/failed-message-row.test.tsx
+++ b/apps/mobile/__tests__/chat/failed-message-row.test.tsx
@@ -1,0 +1,318 @@
+/**
+ * STA-018 (#94) — Failed sends MUST mark the offending message row.
+ *
+ * Pre-fix, the user's message was optimistically appended to the list
+ * before the network call. When `askQuestion` rejected, only a global
+ * inline-error banner appeared at the top of the list — the failed
+ * user-message row itself looked indistinguishable from a successful
+ * one. There was no per-row affordance to retry.
+ *
+ * Red signal: when `askQuestion` rejects, the user-message row that
+ * triggered the failed send must render with a failure indicator (we
+ * pin to a testID — `chat-message-failed-{messageId}`) and expose a
+ * tappable retry control (`chat-message-failed-retry-{messageId}`).
+ */
+
+jest.mock('react-native', () => {
+  const React = require('react')
+  const mk = (name: string) =>
+    React.forwardRef((p: any, r: unknown) =>
+      React.createElement(name, { ...p, ref: r }, p.children),
+    )
+  const FlatList = React.forwardRef((p: any, r: unknown) => {
+    const {
+      data = [],
+      renderItem,
+      keyExtractor,
+      ListHeaderComponent,
+      ListFooterComponent,
+      ListEmptyComponent,
+    } = p
+    const items = (data as unknown[]).map((item, index) => {
+      const key = keyExtractor ? keyExtractor(item, index) : String(index)
+      const rendered = renderItem ? renderItem({ item, index }) : null
+      return React.createElement(React.Fragment, { key }, rendered)
+    })
+    return React.createElement(
+      'FlatList',
+      { ...p, ref: r },
+      ListHeaderComponent ?? null,
+      items.length === 0 ? ListEmptyComponent ?? null : items,
+      ListFooterComponent ?? null,
+    )
+  })
+  return {
+    View: mk('View'),
+    Text: mk('Text'),
+    Pressable: mk('Pressable'),
+    TouchableOpacity: mk('TouchableOpacity'),
+    TextInput: mk('TextInput'),
+    Image: mk('Image'),
+    ActivityIndicator: mk('ActivityIndicator'),
+    KeyboardAvoidingView: mk('KeyboardAvoidingView'),
+    ScrollView: mk('ScrollView'),
+    FlatList,
+    Alert: { alert: jest.fn() },
+    StyleSheet: { create: (s: Record<string, unknown>) => s, hairlineWidth: 0.5 },
+    Platform: {
+      OS: 'ios',
+      select: <T,>(spec: Record<string, T>): T | undefined =>
+        spec.ios ?? spec.default,
+    },
+    useColorScheme: () => 'light',
+    AccessibilityInfo: {
+      isReduceMotionEnabled: jest.fn(() => new Promise(() => {})),
+      addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+    },
+  }
+})
+
+jest.mock('react-native-reanimated', () => {
+  const React = require('react')
+  const View = React.forwardRef((p: any, r: unknown) =>
+    React.createElement('Animated.View', { ...p, ref: r }, p.children),
+  )
+  return {
+    __esModule: true,
+    default: { View, createAnimatedComponent: (c: unknown) => c },
+    View,
+    FadeIn: { duration: () => ({ withInitialValues: () => ({}) }) },
+    FadeOut: { duration: () => ({}) },
+    SlideInLeft: { duration: () => ({}) },
+    SlideInRight: { duration: () => ({}) },
+    useSharedValue: (v: unknown) => ({ value: v }),
+    useAnimatedStyle: () => ({}),
+    withTiming: (v: unknown) => v,
+    withSpring: (v: unknown) => v,
+    Easing: { out: () => null, quad: null, inOut: () => null },
+  }
+})
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react')
+  const SafeAreaView = (p: any) =>
+    React.createElement('SafeAreaView', p, p.children)
+  return {
+    SafeAreaView,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  }
+})
+
+const pushSpy = jest.fn()
+const localParams: { current: Record<string, string | undefined> } = {
+  current: {},
+}
+jest.mock('expo-router', () => {
+  const React = require('react')
+  return {
+    useRouter: () => ({ push: pushSpy, replace: jest.fn(), back: jest.fn() }),
+    useLocalSearchParams: () => localParams.current,
+    useFocusEffect: (cb: () => void) => {
+      React.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [cb])
+    },
+  }
+})
+
+jest.mock('@/components/ui/icon-symbol', () => {
+  const React = require('react')
+  return {
+    IconSymbol: (p: any) =>
+      React.createElement('IconSymbol', { testID: `icon-${p.name}`, ...p }),
+  }
+})
+
+jest.mock('@/lib/stores/authStore', () => ({
+  __esModule: true,
+  useAuthStore: Object.assign(
+    <T,>(selector: (s: { isAuthenticated: boolean }) => T) =>
+      selector({ isAuthenticated: true }),
+    {
+      getState: () => ({
+        isAuthenticated: true,
+        authHydrated: true,
+        openPremiumGate: jest.fn(),
+      }),
+    },
+  ),
+}))
+
+jest.mock('@/components/auth/useRequireAuth', () => ({
+  useRequireAuth: () => (action: () => void) => action(),
+}))
+
+let msgCounter = 0
+jest.mock('@/lib/conversation-storage', () => ({
+  getAllConversations: () => [],
+  getConversationsForBook: (bookId: string) => [
+    { id: `conv-${bookId}`, bookId, title: 'T', createdAt: 1, updatedAt: 2 },
+  ],
+  getMessages: () => [],
+  addMessage: jest.fn(
+    (conversationId: string, role: string, content: string) => {
+      const msg = {
+        id: `msg-${++msgCounter}`,
+        conversationId,
+        role: role as 'user' | 'assistant',
+        content,
+        sourceChunks: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }
+      return msg
+    },
+  ),
+  softDeleteConversation: jest.fn(),
+  createConversation: jest.fn(),
+}))
+
+jest.mock('@/lib/book-storage', () => ({
+  getBookById: () => ({ id: 'book-1', title: 'Book', format: 'epub' }),
+  getBooks: () => [],
+  getBookForReading: jest.fn(async () => ({
+    id: 'book-1',
+    title: 'Book',
+    format: 'epub',
+    filePath: '/tmp/book.epub',
+  })),
+}))
+
+jest.mock('@/lib/rag/vector-store', () => ({
+  isBookEmbedded: () => true,
+  searchSimilarChunks: jest.fn(),
+}))
+jest.mock('@/lib/rag/pipeline', () => ({
+  embedBook: jest.fn(async () => undefined),
+}))
+
+const askQuestionSpy = jest.fn()
+jest.mock('@/hooks/useRAGQuery', () => ({
+  useRAGQuery: () => ({
+    askQuestion: askQuestionSpy,
+    isLoading: false,
+  }),
+}))
+jest.mock('@/hooks/useEmbeddingModel', () => ({
+  useEmbeddingModel: () => ({ isReady: true, downloadProgress: 1 }),
+}))
+jest.mock('@/hooks/useVoiceInput', () => ({
+  useVoiceInput: () => ({
+    isRecording: false,
+    isTranscribing: false,
+    error: null,
+    permissionDenied: false,
+    startRecording: jest.fn(),
+    stopAndTranscribe: jest.fn(),
+  }),
+}))
+
+jest.mock('@/components/ChatMessage', () => {
+  const React = require('react')
+  return {
+    ChatMessage: (p: any) =>
+      React.createElement('ChatMessage', {
+        testID: p.testID,
+        content: p.message?.content,
+      }),
+  }
+})
+
+const chatInputRegistry: {
+  onSend: ((text: string) => void) | null
+} = { onSend: null }
+jest.mock('@/components/ChatInput', () => {
+  const React = require('react')
+  return {
+    ChatInput: (p: any) => {
+      chatInputRegistry.onSend = p.onSend
+      return React.createElement('ChatInput', { testID: 'chat-input' })
+    },
+  }
+})
+jest.mock('@/components/ModelDownloadCard', () => {
+  const React = require('react')
+  return {
+    ModelDownloadCard: (p: any) => React.createElement('ModelDownloadCard', p),
+  }
+})
+jest.mock('@/components/EmbeddingProgress', () => {
+  const React = require('react')
+  return {
+    EmbeddingProgress: (p: any) => React.createElement('EmbeddingProgress', p),
+  }
+})
+
+import React, { act } from 'react'
+import TestRenderer from 'react-test-renderer'
+
+function findByTestID(
+  tree: TestRenderer.ReactTestRenderer,
+  testID: string,
+): TestRenderer.ReactTestInstance | null {
+  const matches = tree.root.findAll(
+    (n) => (n.props as { testID?: string } | null)?.testID === testID,
+  )
+  return matches[0] ?? null
+}
+
+describe('STA-018 — failed message rows are marked + retryable (#94)', () => {
+  beforeEach(() => {
+    askQuestionSpy.mockReset()
+    chatInputRegistry.onSend = null
+    pushSpy.mockClear()
+    msgCounter = 0
+    localParams.current = { bookId: 'book-1' }
+  })
+
+  it('marks the user-message row when askQuestion rejects, and exposes a per-row retry', async () => {
+    // First send rejects (network), second send (the retry) resolves.
+    askQuestionSpy
+      .mockImplementationOnce(async () => {
+        throw new Error('network')
+      })
+      .mockImplementationOnce(async () => ({ answer: 'ok', sources: [] }))
+
+    const BookChatScreen = require('@/app/chat/[bookId]').default
+    let tree!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      tree = TestRenderer.create(<BookChatScreen />)
+    })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(chatInputRegistry.onSend).toBeTruthy()
+
+    // Send the message that will fail.
+    await act(async () => {
+      chatInputRegistry.onSend!('why does this break?')
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(askQuestionSpy).toHaveBeenCalledTimes(1)
+
+    // The user message id is `msg-1` (counter increments inside addMessage).
+    const failedMarker = findByTestID(tree, 'chat-message-failed-msg-1')
+    expect(failedMarker).not.toBeNull()
+
+    const retryBtn = findByTestID(tree, 'chat-message-failed-retry-msg-1')
+    expect(retryBtn).not.toBeNull()
+
+    // Tap retry — askQuestion is called again.
+    await act(async () => {
+      ;(retryBtn!.props as { onPress: () => void }).onPress()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(askQuestionSpy).toHaveBeenCalledTimes(2)
+    // After successful retry, the failed marker should no longer render.
+    expect(findByTestID(tree, 'chat-message-failed-msg-1')).toBeNull()
+  })
+})

--- a/apps/mobile/__tests__/chat/signed-out-input-noneditable.test.tsx
+++ b/apps/mobile/__tests__/chat/signed-out-input-noneditable.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * STA-026 (#99) — When the user is signed out, the chat input field
+ * itself must be non-editable. ChatInput's send button is already
+ * disabled via the `disabled` prop, but the TextInput remained editable
+ * — letting the user tap into the field, get a keyboard, and type a
+ * draft that they couldn't actually send. Worse, tapping the
+ * still-editable field could re-fire the auth gate.
+ *
+ * Red signal: with `useAuthStore.isAuthenticated === false`, the
+ * rendered TextInput inside the real ChatInput component MUST receive
+ * `editable={false}`. We do NOT mock ChatInput here — we exercise the
+ * full child tree so the assertion proves the chat detail screen
+ * passes a `disabled` prop that ChatInput actually honors on the
+ * underlying TextInput.
+ */
+
+jest.mock('react-native', () => {
+  const React = require('react')
+  const mk = (name: string) =>
+    React.forwardRef((p: any, r: unknown) =>
+      React.createElement(name, { ...p, ref: r }, p.children),
+    )
+  const FlatList = React.forwardRef((p: any, r: unknown) => {
+    const {
+      data = [],
+      renderItem,
+      keyExtractor,
+      ListHeaderComponent,
+      ListFooterComponent,
+      ListEmptyComponent,
+    } = p
+    const items = (data as unknown[]).map((item, index) => {
+      const key = keyExtractor ? keyExtractor(item, index) : String(index)
+      const rendered = renderItem ? renderItem({ item, index }) : null
+      return React.createElement(React.Fragment, { key }, rendered)
+    })
+    return React.createElement(
+      'FlatList',
+      { ...p, ref: r },
+      ListHeaderComponent ?? null,
+      items.length === 0 ? ListEmptyComponent ?? null : items,
+      ListFooterComponent ?? null,
+    )
+  })
+  return {
+    View: mk('View'),
+    Text: mk('Text'),
+    Pressable: mk('Pressable'),
+    TouchableOpacity: mk('TouchableOpacity'),
+    TextInput: mk('TextInput'),
+    Image: mk('Image'),
+    ActivityIndicator: mk('ActivityIndicator'),
+    KeyboardAvoidingView: mk('KeyboardAvoidingView'),
+    ScrollView: mk('ScrollView'),
+    FlatList,
+    Linking: { openSettings: jest.fn() },
+    Alert: { alert: jest.fn() },
+    StyleSheet: { create: (s: Record<string, unknown>) => s, hairlineWidth: 0.5 },
+    Platform: {
+      OS: 'ios',
+      select: <T,>(spec: Record<string, T>): T | undefined =>
+        spec.ios ?? spec.default,
+    },
+    useColorScheme: () => 'light',
+    AccessibilityInfo: {
+      isReduceMotionEnabled: jest.fn(() => new Promise(() => {})),
+      addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+    },
+  }
+})
+
+jest.mock('react-native-reanimated', () => {
+  const React = require('react')
+  const View = React.forwardRef((p: any, r: unknown) =>
+    React.createElement('Animated.View', { ...p, ref: r }, p.children),
+  )
+  return {
+    __esModule: true,
+    default: { View, createAnimatedComponent: (c: unknown) => c },
+    View,
+    FadeIn: { duration: () => ({ withInitialValues: () => ({}) }) },
+    FadeOut: { duration: () => ({}) },
+    SlideInLeft: { duration: () => ({}) },
+    SlideInRight: { duration: () => ({}) },
+    useSharedValue: (v: unknown) => ({ value: v }),
+    useAnimatedStyle: () => ({}),
+    withTiming: (v: unknown) => v,
+    withSpring: (v: unknown) => v,
+    Easing: { out: () => null, quad: null, inOut: () => null },
+  }
+})
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react')
+  const SafeAreaView = (p: any) =>
+    React.createElement('SafeAreaView', p, p.children)
+  return {
+    SafeAreaView,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  }
+})
+
+const pushSpy = jest.fn()
+const localParams: { current: Record<string, string | undefined> } = {
+  current: {},
+}
+jest.mock('expo-router', () => {
+  const React = require('react')
+  return {
+    useRouter: () => ({ push: pushSpy, replace: jest.fn(), back: jest.fn() }),
+    useLocalSearchParams: () => localParams.current,
+    useFocusEffect: (cb: () => void) => {
+      React.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [cb])
+    },
+  }
+})
+
+jest.mock('@/components/ui/icon-symbol', () => {
+  const React = require('react')
+  return {
+    IconSymbol: (p: any) =>
+      React.createElement('IconSymbol', { testID: `icon-${p.name}`, ...p }),
+  }
+})
+
+// Signed-OUT auth state.
+const authState: { isAuthenticated: boolean; authHydrated: boolean } = {
+  isAuthenticated: false,
+  authHydrated: true,
+}
+jest.mock('@/lib/stores/authStore', () => ({
+  __esModule: true,
+  useAuthStore: Object.assign(
+    <T,>(selector: (s: typeof authState) => T) => selector(authState),
+    {
+      getState: () => ({ ...authState, openPremiumGate: jest.fn() }),
+    },
+  ),
+}))
+
+jest.mock('@/components/auth/useRequireAuth', () => ({
+  useRequireAuth: () => (action: () => void) => {
+    if (authState.isAuthenticated) action()
+  },
+}))
+
+jest.mock('@/lib/conversation-storage', () => ({
+  getAllConversations: () => [],
+  getConversationsForBook: (bookId: string) => [
+    { id: `conv-${bookId}`, bookId, title: 'T', createdAt: 1, updatedAt: 2 },
+  ],
+  getMessages: () => [],
+  addMessage: jest.fn(),
+  softDeleteConversation: jest.fn(),
+  createConversation: jest.fn(),
+}))
+
+jest.mock('@/lib/book-storage', () => ({
+  getBookById: () => ({ id: 'book-1', title: 'Book', format: 'epub' }),
+  getBooks: () => [],
+  getBookForReading: jest.fn(async () => ({
+    id: 'book-1',
+    title: 'Book',
+    format: 'epub',
+    filePath: '/tmp/book.epub',
+  })),
+}))
+
+jest.mock('@/lib/rag/vector-store', () => ({
+  isBookEmbedded: () => false,
+  searchSimilarChunks: jest.fn(),
+}))
+jest.mock('@/lib/rag/pipeline', () => ({
+  embedBook: jest.fn(async () => undefined),
+}))
+
+jest.mock('@/hooks/useRAGQuery', () => ({
+  useRAGQuery: () => ({
+    askQuestion: jest.fn(async () => ({ answer: '', sources: [] })),
+    isLoading: false,
+  }),
+}))
+jest.mock('@/hooks/useEmbeddingModel', () => ({
+  useEmbeddingModel: () => ({ isReady: true, downloadProgress: 1 }),
+}))
+jest.mock('@/hooks/useVoiceInput', () => ({
+  useVoiceInput: () => ({
+    isRecording: false,
+    isTranscribing: false,
+    error: null,
+    permissionDenied: false,
+    startRecording: jest.fn(),
+    stopAndTranscribe: jest.fn(),
+  }),
+}))
+
+jest.mock('@/components/ChatMessage', () => {
+  const React = require('react')
+  return { ChatMessage: (p: any) => React.createElement('ChatMessage', p) }
+})
+
+// VoiceMicButton is rendered inside the real ChatInput; stub it so the
+// test doesn't have to satisfy its full prop surface.
+jest.mock('@/components/VoiceMicButton', () => {
+  const React = require('react')
+  return {
+    VoiceMicButton: (p: any) =>
+      React.createElement('VoiceMicButton', { ...p, testID: 'voice-mic' }),
+  }
+})
+
+jest.mock('@/components/ModelDownloadCard', () => {
+  const React = require('react')
+  return {
+    ModelDownloadCard: (p: any) => React.createElement('ModelDownloadCard', p),
+  }
+})
+jest.mock('@/components/EmbeddingProgress', () => {
+  const React = require('react')
+  return {
+    EmbeddingProgress: (p: any) => React.createElement('EmbeddingProgress', p),
+  }
+})
+
+// NOTE: ChatInput is intentionally NOT mocked — the assertion below
+// inspects the props of the TextInput that the real ChatInput renders.
+
+import React, { act } from 'react'
+import TestRenderer from 'react-test-renderer'
+
+function findByTestID(
+  tree: TestRenderer.ReactTestRenderer,
+  testID: string,
+): TestRenderer.ReactTestInstance | null {
+  const matches = tree.root.findAll(
+    (n) => (n.props as { testID?: string } | null)?.testID === testID,
+  )
+  return matches[0] ?? null
+}
+
+describe('STA-026 — signed-out chat input is non-editable (#99)', () => {
+  beforeEach(() => {
+    pushSpy.mockClear()
+    authState.isAuthenticated = false
+    authState.authHydrated = true
+    localParams.current = { bookId: 'book-1' }
+  })
+
+  it('renders the TextInput with editable=false while signed out', async () => {
+    const BookChatScreen = require('@/app/chat/[bookId]').default
+    let tree!: TestRenderer.ReactTestRenderer
+    await act(async () => {
+      tree = TestRenderer.create(<BookChatScreen />)
+    })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const textInput = findByTestID(tree, 'chat-input')
+    expect(textInput).not.toBeNull()
+    expect((textInput!.props as { editable?: boolean }).editable).toBe(false)
+  })
+})

--- a/apps/mobile/__tests__/hooks/useRequireAuth-stale-closure.test.ts
+++ b/apps/mobile/__tests__/hooks/useRequireAuth-stale-closure.test.ts
@@ -1,0 +1,135 @@
+/**
+ * CHT-008 / #58 — `useRequireAuth` must read auth state on each replay, not
+ * via the closure snapshot.
+ *
+ * Pre-fix, the returned gate function captured `isAuthenticated` at hook
+ * call time. If the store flipped between hook construction and gate
+ * invocation (e.g. the user signed in via another surface, then tapped
+ * the still-mounted gated control before the consuming component
+ * re-rendered), the gate would observe the stale snapshot.
+ *
+ * Red signal: prime the mock store as signed-OUT, render the harness,
+ * grab the returned gate, flip the store to signed-IN *without
+ * re-rendering*, then call the gate. The action MUST run, NOT the gate.
+ */
+
+jest.mock('react-native', () => {
+  const React = require('react')
+  return {
+    View: React.forwardRef((p: any, r: unknown) =>
+      React.createElement('View', { ...p, ref: r }),
+    ),
+    Text: React.forwardRef((p: any, r: unknown) =>
+      React.createElement('Text', { ...p, ref: r }),
+    ),
+    StyleSheet: { create: (s: Record<string, unknown>) => s },
+  }
+})
+
+jest.mock('react-native-mmkv', () => ({
+  createMMKV: () => ({
+    set: jest.fn(),
+    getString: jest.fn(() => undefined),
+    remove: jest.fn(),
+    getAllKeys: jest.fn(() => []),
+    clearAll: jest.fn(),
+  }),
+}))
+
+jest.mock('@/lib/auth', () => ({
+  getSessionToken: jest.fn(async () => null),
+}))
+
+// authStore mock — exposes a mutable state object, a getState() that
+// returns the LIVE object, and a selector-based useAuthStore. The hook
+// MUST read `isAuthenticated` via getState() at invocation time for the
+// fix to land — selectors alone would still capture the snapshot value
+// because the hook's returned callback closes over the slice value.
+const openPremiumGate = jest.fn()
+const storeState: {
+  isAuthenticated: boolean
+  authHydrated: boolean
+  openPremiumGate: typeof openPremiumGate
+} = {
+  isAuthenticated: false,
+  authHydrated: true,
+  openPremiumGate,
+}
+
+jest.mock('@/lib/stores/authStore', () => ({
+  useAuthStore: Object.assign(
+    <T,>(selector: (s: typeof storeState) => T) => selector(storeState),
+    {
+      getState: () => storeState,
+    },
+  ),
+}))
+
+import React, { act } from 'react'
+import TestRenderer from 'react-test-renderer'
+import { useRequireAuth } from '@/components/auth/useRequireAuth'
+
+function Harness(props: { onReady: (gate: (action: () => void) => void) => void }) {
+  const gate = useRequireAuth('ai-chat')
+  React.useEffect(() => {
+    props.onReady(gate)
+  })
+  return null
+}
+
+beforeEach(() => {
+  openPremiumGate.mockClear()
+  storeState.isAuthenticated = false
+  storeState.authHydrated = true
+})
+
+describe('CHT-008 — useRequireAuth resists stale closure capture (#58)', () => {
+  it('reads CURRENT auth state on each gate invocation, not the snapshot at hook time', () => {
+    // Prime: render with isAuthenticated=false. The hook's returned gate
+    // is captured before the store flips. Pre-fix, this gate would treat
+    // the user as signed-out forever.
+    let gate!: (a: () => void) => void
+    act(() => {
+      TestRenderer.create(
+        React.createElement(Harness, { onReady: (g) => (gate = g) }),
+      )
+    })
+
+    // Flip the store WITHOUT re-rendering the harness. The hook is still
+    // mounted with its (stale) closure values from the previous render.
+    storeState.isAuthenticated = true
+
+    const action = jest.fn()
+    act(() => {
+      gate(action)
+    })
+
+    // Post-fix: gate observes the live store, runs the action.
+    expect(action).toHaveBeenCalledTimes(1)
+    expect(openPremiumGate).not.toHaveBeenCalled()
+  })
+
+  it('still opens the gate when the live store is signed-OUT (parity with existing tests)', () => {
+    let gate!: (a: () => void) => void
+    // Hook constructed while signed-in — old closure would let any action
+    // through forever. Post-fix, flipping the store to signed-out below
+    // must cause the gate to open instead of running the action.
+    storeState.isAuthenticated = true
+    act(() => {
+      TestRenderer.create(
+        React.createElement(Harness, { onReady: (g) => (gate = g) }),
+      )
+    })
+
+    storeState.isAuthenticated = false
+
+    const action = jest.fn()
+    act(() => {
+      gate(action)
+    })
+
+    expect(action).not.toHaveBeenCalled()
+    expect(openPremiumGate).toHaveBeenCalledTimes(1)
+    expect(openPremiumGate).toHaveBeenCalledWith('ai-chat', action)
+  })
+})

--- a/apps/mobile/__tests__/hooks/useRequireAuth.test.ts
+++ b/apps/mobile/__tests__/hooks/useRequireAuth.test.ts
@@ -70,7 +70,13 @@ let storeState: {
 }
 
 jest.mock('@/lib/stores/authStore', () => ({
-  useAuthStore: <T,>(selector: (s: typeof storeState) => T) => selector(storeState),
+  // CHT-008 (#58): the hook now reads via `useAuthStore.getState()` on
+  // invocation. The mock therefore exposes both the selector-callable
+  // shape AND a `.getState()` accessor that returns the live state object.
+  useAuthStore: Object.assign(
+    <T,>(selector: (s: typeof storeState) => T) => selector(storeState),
+    { getState: () => storeState },
+  ),
 }))
 
 import React, { act } from 'react'

--- a/apps/mobile/app/chat/[bookId].tsx
+++ b/apps/mobile/app/chat/[bookId].tsx
@@ -11,7 +11,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated'
 
-import { getBookForReading } from '@/lib/book-storage'
+import { getBookById, getBookForReading } from '@/lib/book-storage'
 import {
   createConversation,
   getConversationsForBook,
@@ -53,6 +53,17 @@ export default function BookChatScreen() {
 
   // Book data
   const [book, setBook] = useState<Book | null>(null)
+  // DAT-018 (#130): tri-state load status for the book row. We can't
+  // use `book === null` as the "deleted" signal because that's also the
+  // initial pre-load state — they look identical until the async
+  // `getBookForReading` resolves. `bookStatus` distinguishes:
+  //   - 'loading' — initial state, waiting on the async DB read.
+  //   - 'present' — found a row.
+  //   - 'missing' — DB returned null (deleted / never existed).
+  // The embedBook effect and the render branch both gate on this.
+  const [bookStatus, setBookStatus] = useState<'loading' | 'present' | 'missing'>(
+    'loading',
+  )
 
   // Embedding model
   const { isReady: modelReady, downloadProgress } = useEmbeddingModel()
@@ -125,12 +136,35 @@ export default function BookChatScreen() {
     }
   }, [voice, requireVoiceInput])
 
-  // Load book (async -- triggers R2 download for synced books)
+  // Load book (async -- triggers R2 download for synced books).
+  //
+  // DAT-018 (#130): if the row is missing the book was deleted (or never
+  // existed). Set `bookStatus = 'missing'` so the render branch shows a
+  // "Book was deleted" screen and the embed effect short-circuits.
   useEffect(() => {
-    if (bookId) {
-      getBookForReading(bookId).then(setBook).catch(err => {
-        console.error('Failed to load book for chat:', err)
+    if (!bookId) return
+    let cancelled = false
+    getBookForReading(bookId)
+      .then((result) => {
+        if (cancelled) return
+        if (result) {
+          setBook(result)
+          setBookStatus('present')
+        } else {
+          setBook(null)
+          setBookStatus('missing')
+        }
       })
+      .catch((err) => {
+        console.error('Failed to load book for chat:', err)
+        if (cancelled) return
+        // Surface a missing-book screen on hard-failure too — the user
+        // can navigate away rather than stare at an empty chat.
+        setBook(null)
+        setBookStatus('missing')
+      })
+    return () => {
+      cancelled = true
     }
   }, [bookId])
 
@@ -170,6 +204,13 @@ export default function BookChatScreen() {
     // P1-AL: gate behind authentication. Signed-out users see the
     // sign-in banner below and can opt in via the ai-chat premium gate.
     if (!isAuthenticated) return
+    // DAT-018 (#130): re-verify the book row right before firing — the
+    // async load races against library bulk-delete. `getBookById` is
+    // synchronous against the local DB so it's cheap to call here.
+    if (getBookById(bookId) == null) {
+      setBookStatus('missing')
+      return
+    }
 
     setIsEmbedding(true)
     setEmbeddingTotal(100)
@@ -362,6 +403,66 @@ export default function BookChatScreen() {
     for (const m of messageList) {
       messageIndexById.set(m.id, m.role === 'user' ? userIdx++ : assistantIdx++)
     }
+  }
+
+  // DAT-018 (#130): book row vanished — render a dedicated error screen
+  // so the user knows the book is gone and can navigate away. We render
+  // BEFORE the main content branch so none of the embedding /
+  // conversation effects produce visible UI.
+  if (bookStatus === 'missing') {
+    return (
+      <SafeAreaView
+        testID="screen-chat-detail"
+        className="flex-1 bg-white dark:bg-[#151718]"
+        edges={['top']}
+      >
+        <View className="flex-row items-center justify-between h-12 px-4 border-b border-gray-200 dark:border-gray-700">
+          <TouchableOpacity
+            onPress={() => safeBack(router)}
+            className="flex-row items-center h-11 pl-1 pr-2"
+            accessibilityLabel={from ? `Back to ${from}` : 'Back'}
+            accessibilityRole="button"
+          >
+            <IconSymbol name="chevron.left" size={22} color="#0a7ea4" />
+            {from ? (
+              <Text
+                testID="chat-detail-back-label"
+                className="text-base text-[#0a7ea4] ml-0.5"
+                numberOfLines={1}
+              >
+                {from}
+              </Text>
+            ) : null}
+          </TouchableOpacity>
+          <Text className="flex-1 text-base font-semibold text-gray-900 dark:text-white text-center mx-2">
+            Chat
+          </Text>
+          <View className="w-11 h-11" />
+        </View>
+        <View
+          testID="chat-deleted-book-error"
+          className="flex-1 items-center justify-center p-8"
+        >
+          <IconSymbol name="exclamationmark.triangle" size={40} color="#9CA3AF" />
+          <Text className="text-base font-semibold text-gray-900 dark:text-white mt-4 text-center">
+            Book was deleted
+          </Text>
+          <Text className="text-sm text-gray-500 dark:text-gray-400 mt-1 text-center">
+            This book is no longer in your library. Start a new chat from another
+            book to continue.
+          </Text>
+          <TouchableOpacity
+            testID="chat-deleted-book-back"
+            onPress={() => safeBack(router)}
+            className="mt-6 px-4 py-2 rounded-md bg-[#0a7ea4]"
+            accessibilityRole="button"
+            accessibilityLabel="Go back"
+          >
+            <Text className="text-white font-semibold">Go back</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    )
   }
 
   return (

--- a/apps/mobile/app/chat/[bookId].tsx
+++ b/apps/mobile/app/chat/[bookId].tsx
@@ -71,6 +71,18 @@ export default function BookChatScreen() {
   const [inlineError, setInlineError] = useState<string | null>(null)
   const [retryQuestion, setRetryQuestion] = useState<string | null>(null)
 
+  // STA-018 (#94): per-message failure status. When a send rejects, the
+  // user-message row that triggered it lands in this set. The renderer
+  // decorates the row with a tappable "Failed — Tap to retry" badge and
+  // a red outline so the user can recover without scrolling up to a
+  // global banner. Successful retries clear the entry.
+  // We track this in component state rather than the DB row because the
+  // status is an in-flight UI concept — the persisted message is still
+  // a valid record of "what the user typed".
+  const [failedMessageIds, setFailedMessageIds] = useState<Set<string>>(
+    () => new Set<string>(),
+  )
+
   // P1-AA: embedding error state. When non-null, an inline banner renders
   // above ChatInput offering Retry. While set, the chat input stays
   // disabled so the user can't send a question against an unprepared book.
@@ -189,6 +201,75 @@ export default function BookChatScreen() {
   // hook flips `isLoading` back to false via its catch+finally.
   const abortRef = useRef<AbortController | null>(null)
 
+  // Drive a RAG turn for an already-persisted user message. Extracted so
+  // both the initial send and the per-row retry (STA-018 / #94) share the
+  // exact same code path — only the source of the user-message row
+  // differs.
+  const runTurnForUserMessage = useCallback(
+    async (userMsg: Message, currentList: Message[]) => {
+      if (!conversationId) return
+
+      const history = [...currentList, userMsg].map((m) => ({
+        role: m.role,
+        content: m.content,
+      }))
+
+      // Fresh controller for THIS turn — abort any prior in-flight
+      // controller before swapping so a quick second send doesn't leave
+      // a dangling abort handle.
+      abortRef.current?.abort()
+      const controller = new AbortController()
+      abortRef.current = controller
+
+      try {
+        const { answer, sources } = await askQuestion(
+          userMsg.content,
+          history,
+          controller.signal,
+        )
+        const assistantMsg = addMessage(
+          conversationId,
+          'assistant',
+          answer,
+          sources,
+        )
+        setMessageList((prev) => [...prev, assistantMsg])
+        // STA-018 (#94): clear the failed-status if this was a retry.
+        setFailedMessageIds((prev) => {
+          if (!prev.has(userMsg.id)) return prev
+          const next = new Set(prev)
+          next.delete(userMsg.id)
+          return next
+        })
+      } catch (err) {
+        const isAbort =
+          (err instanceof Error && err.name === 'AbortError') ||
+          controller.signal.aborted
+        if (!isAbort) {
+          // STA-018 (#94): mark the offending user message so the row
+          // itself shows a failed indicator. The global banner stays
+          // (for users who don't notice the per-row affordance) but the
+          // row is now the primary recovery surface.
+          setFailedMessageIds((prev) => {
+            if (prev.has(userMsg.id)) return prev
+            const next = new Set(prev)
+            next.add(userMsg.id)
+            return next
+          })
+          setInlineError(
+            'Could not get a response. Check your connection and try again.',
+          )
+          setRetryQuestion(userMsg.content)
+        }
+      } finally {
+        if (abortRef.current === controller) {
+          abortRef.current = null
+        }
+      }
+    },
+    [conversationId, askQuestion],
+  )
+
   // Send a message
   const handleSend = useCallback(
     async (text: string) => {
@@ -205,42 +286,27 @@ export default function BookChatScreen() {
       // just-typed user turn — the previous `messageList.map(...)`
       // read the stale closure snapshot, so the LLM was one message
       // behind. Always synthesise the full transcript at call time.
-      const history = [...messageList, userMsg].map((m) => ({
-        role: m.role,
-        content: m.content,
-      }))
-
-      // Fresh controller for THIS turn — abort any prior in-flight
-      // controller before swapping so a quick second send doesn't leave
-      // a dangling abort handle.
-      abortRef.current?.abort()
-      const controller = new AbortController()
-      abortRef.current = controller
-
-      try {
-        const { answer, sources } = await askQuestion(text, history, controller.signal)
-        const assistantMsg = addMessage(conversationId, 'assistant', answer, sources)
-        setMessageList((prev) => [...prev, assistantMsg])
-      } catch (err) {
-        // User-initiated abort: don't surface a banner — the message row
-        // already conveys what happened, and the user explicitly asked
-        // to stop. Only show the inline retry banner for real failures.
-        const isAbort =
-          (err instanceof Error && err.name === 'AbortError') ||
-          controller.signal.aborted
-        if (!isAbort) {
-          setInlineError('Could not get a response. Check your connection and try again.')
-          setRetryQuestion(text)
-        }
-      } finally {
-        // Only clear the ref if this is still the active controller —
-        // a follow-up send may have swapped it.
-        if (abortRef.current === controller) {
-          abortRef.current = null
-        }
-      }
+      await runTurnForUserMessage(userMsg, messageList)
     },
-    [conversationId, bookId, messageList, askQuestion]
+    [conversationId, bookId, messageList, runTurnForUserMessage]
+  )
+
+  // STA-018 (#94): per-row retry. Re-runs the RAG turn for a previously
+  // failed user message without re-adding it to the conversation.
+  const handleRetryFailedMessage = useCallback(
+    (userMsg: Message) => {
+      // Hide any global banner — the per-row UI is the source of truth
+      // now.
+      setInlineError(null)
+      setRetryQuestion(null)
+      // History is everything BEFORE the failed turn (the failed user
+      // message is appended inside runTurnForUserMessage's history call).
+      const indexInList = messageList.findIndex((m) => m.id === userMsg.id)
+      const historyBefore =
+        indexInList >= 0 ? messageList.slice(0, indexInList) : messageList
+      void runTurnForUserMessage(userMsg, historyBefore)
+    },
+    [messageList, runTurnForUserMessage],
   )
 
   const handleAbort = useCallback(() => {
@@ -345,13 +411,43 @@ export default function BookChatScreen() {
               data={invertedMessages}
               keyExtractor={(item) => item.id}
               inverted
-              renderItem={({ item }) => (
-                <ChatMessage
-                  message={item}
-                  onSourcePress={handleSourcePress}
-                  testID={`chat-message-${item.role}-${messageIndexById.get(item.id) ?? 0}`}
-                />
-              )}
+              renderItem={({ item }) => {
+                const failed =
+                  item.role === 'user' && failedMessageIds.has(item.id)
+                return (
+                  <View testID={failed ? `chat-message-failed-${item.id}` : undefined}>
+                    <ChatMessage
+                      message={item}
+                      onSourcePress={handleSourcePress}
+                      testID={`chat-message-${item.role}-${messageIndexById.get(item.id) ?? 0}`}
+                    />
+                    {failed && (
+                      // STA-018 (#94): per-row failure badge. Red outline +
+                      // tappable "Failed — Tap to retry" affordance lives
+                      // outside ChatMessage to keep that component's
+                      // contract narrow (it owns bubble rendering only).
+                      <View className="items-end px-4 pb-1">
+                        <TouchableOpacity
+                          testID={`chat-message-failed-retry-${item.id}`}
+                          onPress={() => handleRetryFailedMessage(item)}
+                          accessibilityRole="button"
+                          accessibilityLabel="Retry sending this message"
+                          className="flex-row items-center gap-1 px-2 py-1 rounded-md border border-red-400"
+                        >
+                          <IconSymbol
+                            name="exclamationmark.triangle"
+                            size={12}
+                            color="#dc2626"
+                          />
+                          <Text className="text-xs text-red-600 font-medium">
+                            Failed — Tap to retry
+                          </Text>
+                        </TouchableOpacity>
+                      </View>
+                    )}
+                  </View>
+                )
+              }}
               contentContainerStyle={{ paddingVertical: 8 }}
               ListFooterComponent={
                 <>

--- a/apps/mobile/app/chat/[bookId].tsx
+++ b/apps/mobile/app/chat/[bookId].tsx
@@ -182,6 +182,13 @@ export default function BookChatScreen() {
     setEmbedAttempt((n) => n + 1)
   }, [])
 
+  // CHT-006 (#56) / A11Y-006 (#103): an AbortController bound to the
+  // currently in-flight `askQuestion`. ChatInput's stop icon invokes
+  // `handleAbort`, which calls `.abort()` on this controller; the
+  // underlying fetch in `useRAGQuery` rejects with AbortError and the
+  // hook flips `isLoading` back to false via its catch+finally.
+  const abortRef = useRef<AbortController | null>(null)
+
   // Send a message
   const handleSend = useCallback(
     async (text: string) => {
@@ -203,17 +210,42 @@ export default function BookChatScreen() {
         content: m.content,
       }))
 
+      // Fresh controller for THIS turn — abort any prior in-flight
+      // controller before swapping so a quick second send doesn't leave
+      // a dangling abort handle.
+      abortRef.current?.abort()
+      const controller = new AbortController()
+      abortRef.current = controller
+
       try {
-        const { answer, sources } = await askQuestion(text, history)
+        const { answer, sources } = await askQuestion(text, history, controller.signal)
         const assistantMsg = addMessage(conversationId, 'assistant', answer, sources)
         setMessageList((prev) => [...prev, assistantMsg])
-      } catch (_err) {
-        setInlineError('Could not get a response. Check your connection and try again.')
-        setRetryQuestion(text)
+      } catch (err) {
+        // User-initiated abort: don't surface a banner — the message row
+        // already conveys what happened, and the user explicitly asked
+        // to stop. Only show the inline retry banner for real failures.
+        const isAbort =
+          (err instanceof Error && err.name === 'AbortError') ||
+          controller.signal.aborted
+        if (!isAbort) {
+          setInlineError('Could not get a response. Check your connection and try again.')
+          setRetryQuestion(text)
+        }
+      } finally {
+        // Only clear the ref if this is still the active controller —
+        // a follow-up send may have swapped it.
+        if (abortRef.current === controller) {
+          abortRef.current = null
+        }
       }
     },
     [conversationId, bookId, messageList, askQuestion]
   )
+
+  const handleAbort = useCallback(() => {
+    abortRef.current?.abort()
+  }, [])
 
   const handleRetry = useCallback(() => {
     if (retryQuestion) {
@@ -439,6 +471,11 @@ export default function BookChatScreen() {
               voiceError={voice.error}
               permissionDenied={voice.permissionDenied}
               externalText={voiceText}
+              // CHT-006 (#56) / A11Y-006 (#103): wire abort. ChatInput's
+              // send button morphs into a stop-fill icon while
+              // `isLoading` is true; tapping it now calls into our
+              // AbortController and cancels the in-flight LLM fetch.
+              onAbort={handleAbort}
             />
       </KeyboardAvoidingView>
     </SafeAreaView>

--- a/apps/mobile/components/auth/useRequireAuth.ts
+++ b/apps/mobile/components/auth/useRequireAuth.ts
@@ -14,16 +14,36 @@ import { useAuthStore } from '@/lib/stores/authStore'
  * premium gate never opens (P0-T). We also do not open the gate yet
  * because the user may actually be signed in; we just don't know until
  * hydration completes. The correct behavior is to defer until we know.
+ *
+ * CHT-008 (#58): the gate function reads auth state from
+ * `useAuthStore.getState()` at invocation time rather than from a
+ * closure captured at hook construction. The previous implementation
+ * snapshotted `isAuthenticated` / `authHydrated` via selectors and
+ * baked those values into the returned callback's closure — if the
+ * store flipped between the most recent render and the user's tap, the
+ * gate observed the stale snapshot. Reading `getState()` on each call
+ * makes the gate self-healing: even a long-lived callback always sees
+ * the live store.
  */
 export function useRequireAuth(
   feature: PremiumFeature,
 ): (action: () => void) => void {
-  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
-  const authHydrated = useAuthStore((s) => s.authHydrated)
-  const openPremiumGate = useAuthStore((s) => s.openPremiumGate)
+  // Subscribe so the hosting component still re-renders when auth state
+  // changes (downstream consumers like ChatInput's `disabled` prop rely
+  // on this). The values aren't used in the callback body — the
+  // callback reads the live store instead — but keeping the subscription
+  // here means the component still updates when sign-in lands.
+  useAuthStore((s) => s.isAuthenticated)
+  useAuthStore((s) => s.authHydrated)
 
   return useCallback(
     (action) => {
+      // Read the live store on every invocation. The selector
+      // subscriptions above keep the parent in sync; the callback
+      // itself never reads stale closure values.
+      const { isAuthenticated, authHydrated, openPremiumGate } =
+        useAuthStore.getState()
+
       if (!authHydrated) {
         // Auth state not yet known — defer. Do not fire the action and
         // do not open the gate. The user can retry once hydration lands.
@@ -38,6 +58,6 @@ export function useRequireAuth(
         openPremiumGate(feature, action)
       }
     },
-    [authHydrated, isAuthenticated, openPremiumGate, feature],
+    [feature],
   )
 }

--- a/apps/mobile/hooks/useRAGQuery.ts
+++ b/apps/mobile/hooks/useRAGQuery.ts
@@ -38,7 +38,12 @@ export function useRAGQuery(bookId: string) {
 
   const askQuestion = useCallback(async (
     question: string,
-    conversationHistory: Array<{ role: 'user' | 'assistant'; content: string }>
+    conversationHistory: Array<{ role: 'user' | 'assistant'; content: string }>,
+    // CHT-006 (#56): an optional AbortSignal threaded by the caller so
+    // tapping the stop button mid-generation can cancel the in-flight
+    // Worker LLM fetch. When omitted the call proceeds uncancellable
+    // (back-compat for any caller that hasn't migrated yet).
+    signal?: AbortSignal,
   ): Promise<{ answer: string; sources: SourceChunk[] }> => {
     setIsLoading(true)
     setError(null)
@@ -77,10 +82,12 @@ export function useRAGQuery(bookId: string) {
         }
       ]
 
-      // 5. Call Worker LLM
+      // 5. Call Worker LLM. Forward the abort signal so a tap on the
+      // stop icon cancels the underlying fetch (CHT-006 / #56).
       const response = await apiClient('/api/text/completions', {
         method: 'POST',
         body: JSON.stringify({ input }),
+        signal,
       })
 
       if (!response.ok) {


### PR DESCRIPTION
Closes #56. Closes #58. Closes #94. Closes #99. Closes #103. Closes #130.

## Per-issue summary

### #56 CHT-006 / #103 A11Y-006 — Wire AbortController to the stop button
ChatInput already morphs its send button into a stop-fill icon while \`isLoading\`, but chat detail never passed an \`onAbort\`. Now the screen holds an \`AbortController\` ref, threads its signal into \`askQuestion\` (forwarded to \`apiClient\`'s fetch as \`signal\`), and exposes \`controller.abort\` as \`onAbort\`. Aborts do not surface the generic "could not get a response" banner since the user explicitly opted out. \`useRAGQuery.askQuestion\` gains an optional \`signal\` parameter (back-compat).

### #58 CHT-008 — \`useRequireAuth\` reads live auth state
The previous gate captured \`isAuthenticated\` / \`authHydrated\` via selector return values, baking them into the returned callback's closure. If the store flipped between render and tap, the gate observed stale values. Now the gate reads \`useAuthStore.getState()\` on every invocation while keeping the selector subscriptions so the host component still re-renders on auth changes.

### #94 STA-018 — Per-row failed-message indicator
A failed send used to show only a global banner; the offending user-message row was indistinguishable from a successful one. Now the screen tracks \`failedMessageIds\` in component state. On non-abort rejection the failing message lands in the set; the row renders with a red "Failed — Tap to retry" badge keyed by message id, and tapping retry re-runs the RAG turn for that specific message. The send path was refactored into a shared \`runTurnForUserMessage\` so initial sends and retries exercise identical code.

### #99 STA-026 — Regression guard for signed-out non-editable input
The chat screen already passes \`disabled=true\` when signed out and ChatInput already maps that to \`editable={false}\`, but no test exercised the full child tree end-to-end. Added a Jest test that renders the chat detail screen with \`isAuthenticated=false\`, mounts the real ChatInput (no mock), and asserts the rendered TextInput receives \`editable={false}\`.

### #130 DAT-018 — Guard chat embed against deleted books
The screen now tracks a tri-state \`bookStatus\` ('loading' | 'present' | 'missing'). The async load sets 'missing' on null/failure; the embed effect also re-verifies via the synchronous \`getBookById\` right before firing (cheap local-DB read). When 'missing', the screen renders a dedicated error screen with title "Book was deleted" and a "Go back" CTA. The header is preserved so users keep their back affordance.

## Verification
- All 6 issue-specific tests pass (\`abort-stop-button\`, \`useRequireAuth-stale-closure\`, \`failed-message-row\`, \`signed-out-input-noneditable\`, \`deleted-book-guard\`).
- Pre-existing chat tests still pass (87 → 90 after additions).
- \`pnpm jest --testPathPatterns="(chat/|stores/chatStore|hooks/useRequireAuth|hooks/useRAGQuery)"\` → 107 passed. The 4 unrelated voice-chat suites fail due to a pre-existing missing \`effect\` module in this worktree's install (slot 3 territory).
- \`tsc --noEmit\` clean on every file touched in this PR (errors limited to pre-existing voice-chat code).

## Files
- \`apps/mobile/app/chat/[bookId].tsx\` — AbortController + failed-row badge + deleted-book screen + tri-state bookStatus
- \`apps/mobile/components/auth/useRequireAuth.ts\` — live \`getState()\` read
- \`apps/mobile/hooks/useRAGQuery.ts\` — optional \`signal\` arg forwarded to fetch
- \`apps/mobile/__tests__/chat/abort-stop-button.test.tsx\` (new)
- \`apps/mobile/__tests__/chat/failed-message-row.test.tsx\` (new)
- \`apps/mobile/__tests__/chat/signed-out-input-noneditable.test.tsx\` (new)
- \`apps/mobile/__tests__/chat/deleted-book-guard.test.tsx\` (new)
- \`apps/mobile/__tests__/hooks/useRequireAuth-stale-closure.test.ts\` (new)
- \`apps/mobile/__tests__/hooks/useRequireAuth.test.ts\` (existing mock updated to expose \`getState\`)