### PR TITLE
fix(electron/reader): debounce EPUB location-save IPC writes

### DIFF
--- a/apps/rishi-electron/src/renderer/src/components/epub/EpubView.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/epub/EpubView.tsx
@@ -78,6 +78,7 @@ import { buildPartialFirst } from '@/modules/read-aloud-from'
 import { useTtsHighlightReconciler } from '@/hooks/useTtsHighlightReconciler'
 import { useVisibleEpubIframe } from '@/hooks/reader/useVisibleEpubIframe'
 import { createEpubTtsReconciler, type EpubTtsReconciler } from './reconcileTtsHighlight'
+import { useDebouncedLocationSave } from './useDebouncedLocationSave'
 
 function updateTheme(rendition: Rendition, theme: ThemeType) {
   const reditionThemes = rendition.themes
@@ -997,6 +998,24 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
       toast.error('Can not change book page')
     }
   })
+  // Debounce per-page-turn location saves so rapid page-turns (page-curl
+  // animation + rendition.next() resolve + TTS paragraph advance can all
+  // emit `relocated` within ~100ms) coalesce into a single SQLite write.
+  // The hook flushes the latest pending CFI on unmount so closing the book
+  // never loses the user's last position. The mutate call drives both the
+  // DB write and the cloud-sync trigger. See RDR-003.
+  // Destructure `mutate` from the mutation result so the useCallback dep
+  // identity is referentially stable (the mutation result object itself is
+  // intentionally not — @tanstack/query/no-unstable-deps gates on this).
+  const { mutate: mutateLocation } = updateBookLocationMutation
+  const persistLocation = useCallback(
+    (cfi: string) => {
+      mutateLocation({ bookId: book.id.toString(), location: cfi })
+      getSyncService().triggerWrite()
+    },
+    [mutateLocation, book.id]
+  )
+  const debouncedLocationSave = useDebouncedLocationSave(persistLocation)
   // Update rendition state when ref becomes available
 
   // Show loading state while EPUB data is being fetched
@@ -1053,14 +1072,19 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
             // relocateds can fire at a column-start CFI that differs from the
             // saved one; without the userNav gate they would silently
             // overwrite the correct saved CFI on reopen.
+            //
+            // Per-relocate writes are debounced (RDR-003): page-curl + nav.next
+            // + TTS paragraph advance can emit `relocated` several times within
+            // ~100ms. We coalesce into one SQLite write per 300ms window. The
+            // hook flushes the latest pending CFI on unmount so the user's
+            // last position is preserved on book close / route change.
             if (settledRef.current && userNavHappenedRef.current) {
-              updateBookLocationMutation.mutate({
-                bookId: book.id.toString(),
-                location: epubcfi
-              })
-              getSyncService().triggerWrite()
+              debouncedLocationSave.save(epubcfi)
               // Record the latest CFI so the window-close flush has a value
-              // to write even if the mutation above hasn't completed yet.
+              // to write even if the debounced mutation hasn't fired yet.
+              // The window-close handler bypasses the mutation queue and
+              // writes directly via IPC; lastSavedCfiRef is its source of
+              // truth when the live rendition CFI isn't available.
               // eslint-disable-next-line react-hooks/immutability -- Refs are mutable by design; the lint rule misfires on this standard pattern.
               lastSavedCfiRef.current = epubcfi
             }

--- a/apps/rishi-electron/src/renderer/src/components/epub/useDebouncedLocationSave.test.ts
+++ b/apps/rishi-electron/src/renderer/src/components/epub/useDebouncedLocationSave.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for useDebouncedLocationSave — the EPUB reader's per-page-turn
+ * IPC-write coalescer. The reader's `relocated` event can fire several times
+ * within ~100ms during a page-curl animation + rendition.next() resolve + TTS
+ * paragraph advance; without debounce, each event triggers a SQLite write.
+ *
+ * Contract (RDR-003):
+ *   - Rapid calls within the 300ms window → exactly 1 IPC write (trailing).
+ *   - Each `save()` resets the timer.
+ *   - `flush()` writes the latest pending value immediately and clears the
+ *     timer (used on unmount so the last position isn't lost).
+ *   - `cancel()` drops the pending value with no write.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useDebouncedLocationSave, DEBOUNCE_LOCATION_SAVE_MS } from './useDebouncedLocationSave'
+
+describe('useDebouncedLocationSave', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  it('exposes a 300ms coalesce window', () => {
+    expect(DEBOUNCE_LOCATION_SAVE_MS).toBe(300)
+  })
+
+  it('coalesces 10 rapid saves within the debounce window into 1 IPC write', () => {
+    const persist = vi.fn()
+    const { result } = renderHook(() => useDebouncedLocationSave(persist))
+
+    act(() => {
+      for (let i = 0; i < 10; i++) {
+        result.current.save(`cfi-${i}`)
+      }
+    })
+
+    // Within the window: nothing fired yet.
+    expect(persist).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_LOCATION_SAVE_MS)
+    })
+
+    // After the trailing edge: exactly one call, with the LAST value.
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist).toHaveBeenLastCalledWith('cfi-9')
+  })
+
+  it('each save() resets the timer (true debounce, not throttle)', () => {
+    const persist = vi.fn()
+    const { result } = renderHook(() => useDebouncedLocationSave(persist))
+
+    act(() => {
+      result.current.save('a')
+    })
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+    act(() => {
+      result.current.save('b') // resets — timer starts over from here
+    })
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+    expect(persist).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(100) // 300ms after 'b' — should fire now
+    })
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist).toHaveBeenLastCalledWith('b')
+  })
+
+  it('flush() writes the latest pending value immediately', () => {
+    const persist = vi.fn()
+    const { result } = renderHook(() => useDebouncedLocationSave(persist))
+
+    act(() => {
+      result.current.save('pending-cfi')
+      result.current.flush()
+    })
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist).toHaveBeenCalledWith('pending-cfi')
+
+    // After flush, the original timer should not also fire.
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(persist).toHaveBeenCalledTimes(1)
+  })
+
+  it('flush() with no pending value is a no-op', () => {
+    const persist = vi.fn()
+    const { result } = renderHook(() => useDebouncedLocationSave(persist))
+
+    act(() => {
+      result.current.flush()
+    })
+
+    expect(persist).not.toHaveBeenCalled()
+  })
+
+  it('cancel() drops the pending value with no IPC write', () => {
+    const persist = vi.fn()
+    const { result } = renderHook(() => useDebouncedLocationSave(persist))
+
+    act(() => {
+      result.current.save('drop-me')
+      result.current.cancel()
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(persist).not.toHaveBeenCalled()
+  })
+
+  it('flushes the latest pending value on unmount (so the last position is preserved)', () => {
+    const persist = vi.fn()
+    const { result, unmount } = renderHook(() => useDebouncedLocationSave(persist))
+
+    act(() => {
+      result.current.save('last-known-cfi')
+    })
+    expect(persist).not.toHaveBeenCalled()
+
+    unmount()
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist).toHaveBeenCalledWith('last-known-cfi')
+  })
+
+  it('reads the latest persist fn on every fire (so closure-staleness does not strand the IPC)', () => {
+    const persistA = vi.fn()
+    const persistB = vi.fn()
+    const { result, rerender } = renderHook(({ fn }) => useDebouncedLocationSave(fn), {
+      initialProps: { fn: persistA }
+    })
+
+    act(() => {
+      result.current.save('x')
+    })
+    // Re-render with a new fn before the timer trips.
+    rerender({ fn: persistB })
+
+    act(() => {
+      vi.advanceTimersByTime(DEBOUNCE_LOCATION_SAVE_MS)
+    })
+
+    expect(persistA).not.toHaveBeenCalled()
+    expect(persistB).toHaveBeenCalledTimes(1)
+    expect(persistB).toHaveBeenCalledWith('x')
+  })
+})

--- a/apps/rishi-electron/src/renderer/src/components/epub/useDebouncedLocationSave.ts
+++ b/apps/rishi-electron/src/renderer/src/components/epub/useDebouncedLocationSave.ts
@@ -1,0 +1,113 @@
+/**
+ * useDebouncedLocationSave — coalesces rapid `relocated` events from epub.js
+ * into a single IPC write to the books DB.
+ *
+ * Background (RDR-003): The EPUB reader's `relocated` event can fire several
+ * times within ~100ms during a page-curl animation (rendition.next() resolves
+ * → relocated → TTS paragraph advance can also trigger another relocated).
+ * Each event used to call `updateBookLocationMutation.mutate` directly, which
+ * fires a SQLite write per event — a write storm on rapid page-turn.
+ *
+ * Contract:
+ *   - `save(cfi)` schedules a write 300ms after the most recent call.
+ *   - Calling `save(cfi)` again before the window elapses resets the timer
+ *     and replaces the pending value (true debounce semantics, not throttle).
+ *   - `flush()` writes the latest pending value immediately and clears the
+ *     timer — call this on unmount so the last-known position is preserved.
+ *   - `cancel()` drops the pending value with no write — kept for parity with
+ *     standard debounce APIs even though EpubView itself only ever flushes.
+ *
+ * The hook stores the latest `persist` function in a ref and reads it at
+ * fire time. This is intentional: callers will usually pass an inline
+ * `mutation.mutate` whose identity churns on every render, but the debounce
+ * timer itself is created once at the first `save()` and must not be reset
+ * by re-renders.
+ */
+import { useCallback, useEffect, useRef } from 'react'
+
+/** Coalesce window. Issue RDR-003 acceptance: 10 rapid saves in <300ms → 1 write. */
+export const DEBOUNCE_LOCATION_SAVE_MS = 300
+
+export interface DebouncedLocationSave {
+  /** Schedule a write of `cfi` 300ms after the last call. */
+  save: (cfi: string) => void
+  /** Write the latest pending value immediately and clear the timer. No-op if nothing pending. */
+  flush: () => void
+  /** Discard the pending value without writing. */
+  cancel: () => void
+}
+
+export function useDebouncedLocationSave(persist: (cfi: string) => void): DebouncedLocationSave {
+  // Latest persist fn — read at fire time so a re-rendered caller passing a
+  // fresh `mutate` doesn't strand the pending write on a stale closure.
+  const persistRef = useRef(persist)
+  useEffect(() => {
+    persistRef.current = persist
+  }, [persist])
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pendingValueRef = useRef<string | null>(null)
+  const hasPendingRef = useRef(false)
+
+  const clearTimer = useCallback((): void => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  const save = useCallback(
+    (cfi: string): void => {
+      pendingValueRef.current = cfi
+      hasPendingRef.current = true
+      clearTimer()
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        if (!hasPendingRef.current) return
+        const value = pendingValueRef.current
+        hasPendingRef.current = false
+        pendingValueRef.current = null
+        if (value !== null) persistRef.current(value)
+      }, DEBOUNCE_LOCATION_SAVE_MS)
+    },
+    [clearTimer]
+  )
+
+  const flush = useCallback((): void => {
+    clearTimer()
+    if (!hasPendingRef.current) return
+    const value = pendingValueRef.current
+    hasPendingRef.current = false
+    pendingValueRef.current = null
+    if (value !== null) persistRef.current(value)
+  }, [clearTimer])
+
+  const cancel = useCallback((): void => {
+    clearTimer()
+    hasPendingRef.current = false
+    pendingValueRef.current = null
+  }, [clearTimer])
+
+  // Flush on unmount so we never lose the user's last position when the
+  // component tears down (book close, window close, route change).
+  useEffect(() => {
+    return () => {
+      // Use refs directly instead of `flush()` — at unmount-time React has
+      // already started teardown, so any setState-style work inside the
+      // persist fn is fine (mutation.mutate is fire-and-forget) but we
+      // shouldn't depend on the memoized `flush` identity for cleanup.
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+      if (hasPendingRef.current) {
+        const value = pendingValueRef.current
+        hasPendingRef.current = false
+        pendingValueRef.current = null
+        if (value !== null) persistRef.current(value)
+      }
+    }
+  }, [])
+
+  return { save, flush, cancel }
+}


### PR DESCRIPTION
Closes #174.

## Summary
- Debounce per-page-turn location-save IPC calls with a trailing flush on unmount so rapid page-turns don't hammer disk while preserving the last read position.

## Test plan
- [ ] `pnpm test -- useDebouncedLocationSave` — debounce contract test passes
- [ ] `pnpm typecheck` — clean