### PR TITLE
fix(electron/store): atomic write + queue for settings store

### DIFF
--- a/apps/rishi-electron/src/main/ipc/store.test.ts
+++ b/apps/rishi-electron/src/main/ipc/store.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// In-memory FS mock — enough fidelity to verify atomic-write + queue semantics.
+// We model two operations:
+//   - writeFile(target, data)   — writes the bytes (immediately, no atomicity).
+//   - rename(src, dst)          — atomic move from src to dst.
+// readFile reads whatever the latest committed bytes for the path are.
+// ---------------------------------------------------------------------------
+
+interface FsState {
+  files: Map<string, string>
+}
+
+const fsState: FsState = { files: new Map() }
+
+const mockHandle = vi.fn()
+const mockGetPath = vi.fn().mockReturnValue('/tmp/test-userdata')
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (...args: unknown[]) => mockHandle(...args) },
+  app: { getPath: (...args: unknown[]) => mockGetPath(...args) }
+}))
+
+// We allow tests to install hooks that fire on each writeFile / rename so we
+// can simulate crashes between the temp-file write and the rename.
+const writeFileHooks: Array<(path: string, data: string) => Promise<void> | void> = []
+const renameHooks: Array<(src: string, dst: string) => Promise<void> | void> = []
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(async (p: string) => {
+    if (!fsState.files.has(p)) {
+      const err = new Error(`ENOENT: ${p}`) as NodeJS.ErrnoException
+      err.code = 'ENOENT'
+      throw err
+    }
+    return fsState.files.get(p)!
+  }),
+  writeFile: vi.fn(async (p: string, data: string) => {
+    for (const hook of writeFileHooks) await hook(p, data)
+    fsState.files.set(p, data)
+  }),
+  rename: vi.fn(async (src: string, dst: string) => {
+    for (const hook of renameHooks) await hook(src, dst)
+    if (!fsState.files.has(src)) {
+      const err = new Error(`ENOENT: ${src}`) as NodeJS.ErrnoException
+      err.code = 'ENOENT'
+      throw err
+    }
+    const data = fsState.files.get(src)!
+    fsState.files.delete(src)
+    fsState.files.set(dst, data)
+  }),
+  unlink: vi.fn(async (p: string) => {
+    fsState.files.delete(p)
+  })
+}))
+
+// Import after mocks.
+import { registerStoreHandlers } from './store.js'
+
+type HandlerFn = (...args: unknown[]) => Promise<unknown>
+
+function getHandler(channel: string): HandlerFn {
+  const call = mockHandle.mock.calls.find((c: unknown[]) => c[0] === channel)
+  if (!call) throw new Error(`No handler registered for channel "${channel}"`)
+  return call[1] as HandlerFn
+}
+
+const STORE_PATH = '/tmp/test-userdata/settings-store.json'
+const TMP_PATH = `${STORE_PATH}.tmp`
+
+describe('store IPC — atomic write + queue', () => {
+  beforeEach(() => {
+    mockHandle.mockReset()
+    fsState.files.clear()
+    writeFileHooks.length = 0
+    renameHooks.length = 0
+    mockGetPath.mockReturnValue('/tmp/test-userdata')
+    registerStoreHandlers()
+  })
+
+  it('writes to a .tmp file then renames over the real file', async () => {
+    const set = getHandler('store:set')
+    const observed: Array<{ op: 'write' | 'rename'; path: string }> = []
+    writeFileHooks.push((p) => {
+      observed.push({ op: 'write', path: p })
+    })
+    renameHooks.push((src, dst) => {
+      observed.push({ op: 'rename', path: `${src}->${dst}` })
+    })
+
+    await set({}, 'theme', 'dark')
+
+    // First op must be a write to the tmp file, then rename to the real file.
+    expect(observed[0]).toEqual({ op: 'write', path: TMP_PATH })
+    expect(observed[1]).toEqual({ op: 'rename', path: `${TMP_PATH}->${STORE_PATH}` })
+    expect(JSON.parse(fsState.files.get(STORE_PATH)!)).toEqual({ theme: 'dark' })
+  })
+
+  it('leaves the original file intact when the process is killed between writeFile and rename', async () => {
+    const set = getHandler('store:set')
+
+    // Seed an existing settings file.
+    fsState.files.set(STORE_PATH, JSON.stringify({ theme: 'light', fontSize: 16 }))
+    const original = fsState.files.get(STORE_PATH)!
+
+    // Simulate a crash AFTER the tmp file is written, BEFORE rename runs.
+    renameHooks.push(() => {
+      throw new Error('process killed')
+    })
+
+    await expect(set({}, 'theme', 'dark')).rejects.toThrow()
+
+    // The real settings file must still be valid JSON matching the original.
+    const after = fsState.files.get(STORE_PATH)
+    expect(after).toBeDefined()
+    expect(after).toBe(original)
+    expect(() => JSON.parse(after!)).not.toThrow()
+  })
+
+  it('serialises 100 parallel store:set calls so no key is lost', async () => {
+    const set = getHandler('store:set')
+
+    const writes: Promise<unknown>[] = []
+    for (let i = 0; i < 100; i++) {
+      writes.push(set({}, `key${i}`, i))
+    }
+    await Promise.all(writes)
+
+    const final = JSON.parse(fsState.files.get(STORE_PATH)!)
+    for (let i = 0; i < 100; i++) {
+      expect(final[`key${i}`]).toBe(i)
+    }
+    expect(Object.keys(final).length).toBe(100)
+  })
+
+  it('serialises concurrent writes against different keys (read-modify-write is queued)', async () => {
+    const set = getHandler('store:set')
+
+    // Two concurrent set()s. Without the queue the second would clobber the first.
+    const [a, b] = await Promise.all([set({}, 'a', 1), set({}, 'b', 2)])
+    void a
+    void b
+
+    const final = JSON.parse(fsState.files.get(STORE_PATH)!)
+    expect(final).toEqual({ a: 1, b: 2 })
+  })
+
+  it('store:get still returns the latest value after queued writes', async () => {
+    const set = getHandler('store:set')
+    const get = getHandler('store:get')
+
+    await Promise.all([set({}, 'a', 'first'), set({}, 'a', 'second'), set({}, 'a', 'third')])
+
+    const value = await get({}, 'a')
+    // The exact last writer wins is implementation detail; what matters is the
+    // value is one of the writes and the file is valid JSON.
+    expect(['first', 'second', 'third']).toContain(value)
+    expect(() => JSON.parse(fsState.files.get(STORE_PATH)!)).not.toThrow()
+  })
+})

--- a/apps/rishi-electron/src/main/ipc/store.ts
+++ b/apps/rishi-electron/src/main/ipc/store.ts
@@ -8,6 +8,10 @@ function getStorePath(): string {
   return path.join(app.getPath('userData'), 'settings-store.json')
 }
 
+function getStoreTmpPath(): string {
+  return `${getStorePath()}.tmp`
+}
+
 async function readStore(): Promise<Record<string, unknown>> {
   try {
     const data = await fs.readFile(getStorePath(), 'utf-8')
@@ -17,8 +21,29 @@ async function readStore(): Promise<Record<string, unknown>> {
   }
 }
 
-async function writeStore(store: Record<string, unknown>): Promise<void> {
-  await fs.writeFile(getStorePath(), JSON.stringify(store, null, 2))
+// Atomic write: write to a sibling .tmp file then rename over the target.
+// POSIX `rename(2)` is atomic on the same filesystem; Windows `MoveFileEx`
+// with the same volume is also atomic for our purposes. If the process
+// crashes before the rename, the original file is untouched.
+async function writeStoreAtomic(store: Record<string, unknown>): Promise<void> {
+  const target = getStorePath()
+  const tmp = getStoreTmpPath()
+  const payload = JSON.stringify(store, null, 2)
+  await fs.writeFile(tmp, payload)
+  await fs.rename(tmp, target)
+}
+
+// All store mutations funnel through this promise chain so concurrent
+// `store:set` calls cannot interleave their read-modify-write cycle.
+// Each task runs after the previous one settles, success or failure.
+let writeQueue: Promise<unknown> = Promise.resolve()
+
+function enqueueWrite<T>(task: () => Promise<T>): Promise<T> {
+  const next = writeQueue.then(task, task)
+  // Swallow rejections on the chain itself so a single failing task does not
+  // poison every subsequent write. Callers still see the error via `next`.
+  writeQueue = next.catch(() => undefined)
+  return next
 }
 
 export function registerStoreHandlers(): void {
@@ -33,9 +58,11 @@ export function registerStoreHandlers(): void {
 
   handle('store:set', async (_event, key, value) => {
     try {
-      const store = await readStore()
-      store[key] = value
-      await writeStore(store)
+      await enqueueWrite(async () => {
+        const store = await readStore()
+        store[key] = value
+        await writeStoreAtomic(store)
+      })
     } catch (error) {
       throw new Error(`Failed to set store key "${key}": ${errorMessage(error)}`)
     }


### PR DESCRIPTION
Closes #168.

## Summary
- Settings writes go through write-tmp-then-rename so a crash mid-write can't truncate the file.
- Concurrent `store:set` calls serialize through a promise queue, eliminating lost-update bugs from interleaved read-modify-write.

## Test plan
- [ ] `pnpm test -- store` — atomic + queue contract tests pass
- [ ] `pnpm typecheck` — clean