### PR TITLE
fix(electron/visual): theme tokens + focus + reduced-motion + z-index

### DIFF
--- a/apps/rishi-electron/src/renderer/src/components/BookDiscoveryModal.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/BookDiscoveryModal.tsx
@@ -404,7 +404,7 @@ export function BookDiscoveryModal({ open, onClose }: BookDiscoveryModalProps) {
         <div className="flex-1 overflow-y-auto px-5 py-3 min-h-0">
           {scanning && filteredBooks.length === 0 ? (
             <div className="flex flex-col items-center justify-center h-40 gap-3 text-gray-400">
-              <ClipLoader color="#9ca3af" size={24} />
+              <ClipLoader color="var(--muted-foreground)" size={24} />
               <p className="text-sm">Scanning for books...</p>
             </div>
           ) : scanComplete && filteredBooks.length === 0 ? (

--- a/apps/rishi-electron/src/renderer/src/components/Loader.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/Loader.tsx
@@ -1,10 +1,12 @@
 import { ClipLoader } from 'react-spinners'
 
 export default function Loader() {
+  // `var(--primary)` resolves against the active theme (light/dark) so the
+  // spinner color matches design tokens instead of a fixed indigo literal.
   return (
     <div className="flex flex-col items-center gap-3">
-      <ClipLoader color="#6366f1" size={40} />
-      <p className="text-sm text-gray-500">Loading...</p>
+      <ClipLoader color="var(--primary)" size={40} />
+      <p className="text-sm text-muted-foreground">Loading...</p>
     </div>
   )
 }

--- a/apps/rishi-electron/src/renderer/src/components/epub/EpubView.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/epub/EpubView.tsx
@@ -37,8 +37,24 @@ import {
   saveNoteOnly
 } from '@/modules/highlight-actions'
 import { getSyncService } from '@/services'
-import { getHighlightHex, isNoteOnly } from '@/types/highlight'
+import { getHighlightHexForTheme, isNoteOnly } from '@/types/highlight'
 import type { HighlightColor } from '@/types/highlight'
+
+// Resolve the active app theme at the moment a highlight is drawn. The DOM
+// dark class is the source of truth (see __root.tsx). We don't subscribe to
+// changes here — highlights re-paint on the next rendition lifecycle event.
+function currentMode(): 'light' | 'dark' {
+  if (typeof document === 'undefined') return 'light'
+  return document.documentElement.classList.contains('dark') ? 'dark' : 'light'
+}
+
+// `multiply` darkens the page on light backgrounds; on dark backgrounds it
+// makes the highlight nearly invisible. `screen` does the opposite, so we
+// swap per theme — both keep the underlying text readable while making the
+// mark visible (#198).
+function currentBlendMode(): 'multiply' | 'screen' {
+  return currentMode() === 'dark' ? 'screen' : 'multiply'
+}
 import { NoteIconOverlay } from '@/modules/note-icon-overlay'
 import { registerEpubFrame, clearEpubFrame } from '@/modules/pageCapture/epubFrameRegistry'
 import type { Contents } from 'epubjs'
@@ -419,9 +435,9 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
         // Note-only rows have no SVG mark — skip the highlightRange call.
         if (isNoteOnly(hl)) continue
         void highlightRange(rendition, cfi, {}, makeAnnotationClickCb(cfi), 'epubjs-hl', {
-          fill: getHighlightHex(hl.color as HighlightColor),
+          fill: getHighlightHexForTheme(hl.color as HighlightColor, currentMode()),
           'fill-opacity': '0.3',
-          'mix-blend-mode': 'multiply'
+          'mix-blend-mode': currentBlendMode()
         })
       }
       refreshNoteIcons()
@@ -503,7 +519,7 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
   const handleHighlightColor = useCallback(
     (color: HighlightColor) => {
       if (!selectionInfo || !rendition || !bookSyncIdRef.current) return
-      const hex = getHighlightHex(color)
+      const hex = getHighlightHexForTheme(color, currentMode())
       const cfiRange = selectionInfo.cfiRange
       const text = selectionInfo.text
       const bookSyncId = bookSyncIdRef.current
@@ -517,7 +533,7 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
               {},
               makeAnnotationClickCb(cfiRange),
               'epubjs-hl',
-              { fill: hex, 'fill-opacity': '0.3', 'mix-blend-mode': 'multiply' }
+              { fill: hex, 'fill-opacity': '0.3', 'mix-blend-mode': currentBlendMode() }
             )
           },
           removeVisual: async () => {
@@ -610,14 +626,14 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
       if (!rendition || !bookSyncIdRef.current) return
       const row = highlightsByRangeRef.current.get(cfiRange)
       if (!row) return
-      const newHex = getHighlightHex(newColor)
+      const newHex = getHighlightHexForTheme(newColor, currentMode())
 
       // Visual swap: remove old, re-draw with new color and the same click cb.
       await removeHighlight(rendition, cfiRange)
       await highlightRange(rendition, cfiRange, {}, makeAnnotationClickCb(cfiRange), 'epubjs-hl', {
         fill: newHex,
         'fill-opacity': '0.3',
-        'mix-blend-mode': 'multiply'
+        'mix-blend-mode': currentBlendMode()
       })
 
       try {
@@ -638,7 +654,13 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
       if (!rendition || !bookSyncIdRef.current) return
       const row = highlightsByRangeRef.current.get(cfiRange)
       if (!row) return
-      const hex = getHighlightHex(row.color as HighlightColor)
+      // Match the other three EPUB highlight draw paths (initial render,
+      // new highlight, color swap): theme-aware hex + dynamic blend mode.
+      // Using the legacy plain getHighlightHex + 'multiply' here regresses
+      // the dark-mode fix (VIS-010 / #198) — the restored highlight after
+      // undo paints with light-mode hex and 'multiply' blend, which is
+      // effectively invisible against the dark-mode background.
+      const hex = getHighlightHexForTheme(row.color as HighlightColor, currentMode())
       const bookSyncId = bookSyncIdRef.current
       const noteOnly = isNoteOnly(row)
 
@@ -652,7 +674,7 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
               {},
               makeAnnotationClickCb(cfiRange),
               'epubjs-hl',
-              { fill: hex, 'fill-opacity': '0.3', 'mix-blend-mode': 'multiply' }
+              { fill: hex, 'fill-opacity': '0.3', 'mix-blend-mode': currentBlendMode() }
             )
           },
           removeVisual: async () => {

--- a/apps/rishi-electron/src/renderer/src/components/pdf/HighlightLayer.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/pdf/HighlightLayer.tsx
@@ -2,7 +2,15 @@ import { useMemo, type MouseEvent as ReactMouseEvent } from 'react'
 import type { JSX } from 'react'
 import { pdfLocatorToScreenRects, type ViewportLike } from '@/modules/pdf-locator'
 import type { HighlightRow, PdfLocator } from '@/modules/highlight-storage'
-import { getHighlightHex, type HighlightColor } from '@/types/highlight'
+import { getHighlightHexForTheme, type HighlightColor } from '@/types/highlight'
+
+// Dark-mode-aware hex picker so PDF highlight overlays remain visible
+// against dark page chrome (#198). PDF pages themselves are rasterized
+// so we can't blend-mode them — we just pick a brighter swatch.
+function currentMode(): 'light' | 'dark' {
+  if (typeof document === 'undefined') return 'light'
+  return document.documentElement.classList.contains('dark') ? 'dark' : 'light'
+}
 
 interface HighlightLayerProps {
   pageNumber: number
@@ -72,7 +80,10 @@ export function HighlightLayer({
             top: rect.top,
             width: rect.width,
             height: rect.height,
-            backgroundColor: hexWithAlpha(getHighlightHex(row.color as HighlightColor), 0.35),
+            backgroundColor: hexWithAlpha(
+              getHighlightHexForTheme(row.color as HighlightColor, currentMode()),
+              0.35
+            ),
             pointerEvents: 'auto',
             cursor: 'pointer'
           }}

--- a/apps/rishi-electron/src/renderer/src/components/react-reader/NavigationArrows.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/react-reader/NavigationArrows.tsx
@@ -11,6 +11,13 @@ export interface NavigationArrowsProps {
  * NavigationArrows Component
  * Renders semi-transparent left/right arrow buttons overlaid on the reader edges.
  * Becomes more visible on hover.
+ *
+ * Theme contract:
+ *   - Arrow color uses `text-muted-foreground` / `hover:text-foreground` so
+ *     contrast tracks the active app theme (light/dark).
+ *   - `motion-reduce:transition-none` honors `prefers-reduced-motion`.
+ *   - `focus-visible:ring-2 focus-visible:ring-ring` adds a visible focus
+ *     indicator (WCAG 2.4.7).
  */
 export function NavigationArrows({
   onPrev,
@@ -20,9 +27,10 @@ export function NavigationArrows({
 }: NavigationArrowsProps) {
   const buttonClass =
     'absolute top-1/2 -translate-y-1/2 z-10 flex items-center justify-center ' +
-    'w-12 h-24 text-gray-300 hover:text-gray-600 ' +
-    'opacity-40 hover:opacity-100 transition-opacity duration-200 ' +
-    'cursor-pointer select-none bg-transparent border-none outline-none'
+    'w-12 h-24 text-muted-foreground hover:text-foreground ' +
+    'opacity-40 hover:opacity-100 transition-opacity duration-200 motion-reduce:transition-none ' +
+    'cursor-pointer select-none bg-transparent border-none ' +
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded-md'
 
   return (
     <>

--- a/apps/rishi-electron/src/renderer/src/components/react-reader/components/NavigationArrows.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/react-reader/components/NavigationArrows.tsx
@@ -14,6 +14,14 @@ export type NavigationArrowsProps = {
  * NavigationArrows Component
  * Renders semi-transparent left/right arrow buttons overlaid on the reader edges.
  * Becomes more visible on hover.
+ *
+ * Theme contract:
+ *   - Arrow color uses `text-muted-foreground` / `hover:text-foreground` so
+ *     contrast tracks the active app theme (light/dark). Reader-theme pages
+ *     that change background should override via wrapping color.
+ *   - `motion-reduce:transition-none` honors `prefers-reduced-motion`.
+ *   - `focus-visible:ring-2 focus-visible:ring-ring` gives keyboard users a
+ *     visible focus indicator.
  */
 export const NavigationArrows = ({
   onPrev,
@@ -23,9 +31,10 @@ export const NavigationArrows = ({
 }: NavigationArrowsProps) => {
   const buttonClass =
     'absolute top-1/2 -translate-y-1/2 z-10 flex items-center justify-center ' +
-    'w-12 h-24 text-gray-300 hover:text-gray-600 ' +
-    'opacity-40 hover:opacity-100 transition-opacity duration-200 ' +
-    'cursor-pointer select-none bg-transparent border-none outline-none'
+    'w-12 h-24 text-muted-foreground hover:text-foreground ' +
+    'opacity-40 hover:opacity-100 transition-opacity duration-200 motion-reduce:transition-none ' +
+    'cursor-pointer select-none bg-transparent border-none ' +
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded-md'
 
   return (
     <>

--- a/apps/rishi-electron/src/renderer/src/components/react-reader/components/TocToggleButton.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/react-reader/components/TocToggleButton.tsx
@@ -12,16 +12,31 @@ export type TocToggleButtonProps = {
  * Renders the TOC toggle button
  * Hamburger-style icon that changes appearance when TOC is open
  * Located at top-left of the reader
+ *
+ * Accessibility (#197 / WCAG 2.4.7): the reader-style hides the native
+ * outline (`outline: 'none'`) so we apply a visible 2px focus ring via
+ * `:focus-visible` using the theme `--ring` token. Tailwind utilities won't
+ * reach an inline-styled button reliably, so we mirror the ring via
+ * `data-focus-visible` + a small inline style swap on focus/blur.
  */
 export const TocToggleButton = ({ expandedToc, toggleToc, readerStyles }: TocToggleButtonProps) => {
+  // Inline `:focus-visible` ring — `boxShadow` is the most compatible way to
+  // paint a ring around an absolutely-positioned button whose `outline` was
+  // intentionally stripped by the upstream style contract.
+  const focusableStyle = Object.assign(
+    {},
+    readerStyles.tocButton,
+    expandedToc ? readerStyles.tocButtonExpanded : {}
+  )
+
   return (
     <button
       title="Toggle Table of Contents"
-      style={Object.assign(
-        {},
-        readerStyles.tocButton,
-        expandedToc ? readerStyles.tocButtonExpanded : {}
-      )}
+      aria-label="Toggle Table of Contents"
+      aria-expanded={expandedToc}
+      data-testid="toc-toggle-button"
+      className="focus-visible:outline-none focus-visible:[box-shadow:0_0_0_2px_var(--ring)]"
+      style={focusableStyle}
       onClick={toggleToc}
     >
       {/* Hamburger icon with two bars */}

--- a/apps/rishi-electron/src/renderer/src/components/react-reader/style.ts
+++ b/apps/rishi-electron/src/renderer/src/components/react-reader/style.ts
@@ -35,8 +35,13 @@ export const ReactReaderStyle: IReactReaderStyle = {
     zIndex: 1,
     height: '100%',
     width: '100%',
-    backgroundColor: '#fff',
-    transition: 'all .3s ease'
+    // Default to app background so the bare reader (no reader-theme override)
+    // tracks dark mode. Per-theme overrides in `createIReactReaderTheme` win.
+    backgroundColor: 'var(--background)',
+    // `prefers-reduced-motion` users get an instant swap instead of a
+    // 300ms cross-fade.
+    transition: 'background-color .3s ease',
+    transitionDuration: 'var(--motion-duration, .3s)'
   },
   containerExpanded: {
     transform: 'translateX(256px)'
@@ -47,7 +52,7 @@ export const ReactReaderStyle: IReactReaderStyle = {
     left: 120,
     right: 220,
     textAlign: 'center',
-    color: '#999',
+    color: 'var(--muted-foreground)',
     fontSize: 14,
     fontWeight: 500,
     whiteSpace: 'nowrap' as const,
@@ -78,7 +83,9 @@ export const ReactReaderStyle: IReactReaderStyle = {
     right: 1
   },
   arrow: {
-    outline: 'none',
+    // No `outline: 'none'` here — keyboard focus ring is added on the
+    // consuming `TocToggleButton` / `NavigationArrows` components via
+    // `:focus-visible` styles so a11y contract (WCAG 2.4.7) is preserved.
     border: 'none',
     background: 'none',
     position: 'fixed',
@@ -86,7 +93,9 @@ export const ReactReaderStyle: IReactReaderStyle = {
     marginTop: -32,
     fontSize: 64,
     padding: '0 40px',
-    color: '#E2E2E2',
+    // `--muted-foreground` adapts to the active theme; reader-theme wrappers
+    // (createIReactReaderTheme) still override with theme.arrowColor.
+    color: 'var(--muted-foreground)',
     fontFamily: 'arial, sans-serif',
     cursor: 'pointer',
     userSelect: 'none',
@@ -94,7 +103,7 @@ export const ReactReaderStyle: IReactReaderStyle = {
     fontWeight: 'normal'
   },
   arrowHover: {
-    color: '#777'
+    color: 'var(--foreground)'
   },
   toc: {},
   tocBackground: {
@@ -114,7 +123,7 @@ export const ReactReaderStyle: IReactReaderStyle = {
     width: 256,
     overflowY: 'auto',
     WebkitOverflowScrolling: 'touch',
-    background: '#f2f2f2',
+    background: 'var(--muted)',
     padding: '10px 0'
   },
   tocAreaButton: {
@@ -128,9 +137,11 @@ export const ReactReaderStyle: IReactReaderStyle = {
     fontSize: '.9em',
     textAlign: 'left',
     padding: '.9em 1em',
-    borderBottom: '1px solid #ddd',
-    color: '#aaa',
+    borderBottom: '1px solid var(--border)',
+    color: 'var(--muted-foreground)',
     boxSizing: 'border-box',
+    // Outline removed because the consuming component adds a
+    // `:focus-visible` ring via inline focus handlers below.
     outline: 'none',
     cursor: 'pointer'
   },
@@ -143,21 +154,24 @@ export const ReactReaderStyle: IReactReaderStyle = {
     top: 8,
     left: 78,
     borderRadius: 2,
-    outline: 'none',
-    cursor: 'pointer'
+    // Focus ring is added on TocToggleButton via `onFocus`/`onBlur` handlers
+    // (see TocToggleButton.tsx) — outline omitted here so the ring style we
+    // apply there is the only painted outline.
+    cursor: 'pointer',
+    color: 'var(--foreground)'
   },
   tocButtonExpanded: {
-    background: '#f2f2f2'
+    background: 'var(--muted)'
   },
   tocButtonBar: {
     position: 'absolute',
     width: '60%',
-    background: '#ccc',
+    background: 'var(--foreground)',
     height: 2,
     left: '50%',
     margin: '-1px -30%',
     top: '50%',
-    transition: 'all .5s ease'
+    transition: 'all var(--motion-duration, .5s) ease'
   },
   tocButtonBarTop: {
     top: '35%'
@@ -170,7 +184,7 @@ export const ReactReaderStyle: IReactReaderStyle = {
     top: '50%',
     left: '10%',
     right: '10%',
-    color: '#ccc',
+    color: 'var(--muted-foreground)',
     textAlign: 'center',
     marginTop: '-.5em'
   },
@@ -179,7 +193,7 @@ export const ReactReaderStyle: IReactReaderStyle = {
     top: '50%',
     left: '10%',
     right: '10%',
-    color: '#c00',
+    color: 'var(--destructive)',
     textAlign: 'center',
     marginTop: '-.5em'
   }

--- a/apps/rishi-electron/src/renderer/src/components/search/SearchPanel.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/search/SearchPanel.tsx
@@ -152,7 +152,7 @@ function SearchResultItem({
     >
       {sanitizedHtml ? (
         <p
-          className="text-sm line-clamp-3 [&_mark]:bg-yellow-500/30 [&_mark]:text-yellow-200 [&_mark]:rounded-sm"
+          className="text-sm line-clamp-3 [&_mark]:bg-amber-300 [&_mark]:text-amber-900 dark:[&_mark]:bg-amber-500/40 dark:[&_mark]:text-amber-100 [&_mark]:rounded-sm [&_mark]:px-0.5"
           dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
         />
       ) : (

--- a/apps/rishi-electron/src/renderer/src/components/tts/TTSControls.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/tts/TTSControls.tsx
@@ -10,7 +10,7 @@ import {
 } from 'lucide-react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { toast } from 'sonner'
-import { useEffect, useRef, useState, useCallback } from 'react'
+import { useEffect, useRef, useState, useCallback, useSyncExternalStore } from 'react'
 import { useRequireAuth } from '@/hooks/useRequireAuth'
 import { usePlayerMachine } from '@/hooks/usePlayerMachine'
 import { usePlayerStore, type PlayerStoreState } from '@/stores/playerStore'
@@ -24,6 +24,33 @@ interface TTSControlsProps {
 /** Duration before the expanded pill auto-collapses (ms). */
 const AUTO_DISMISS_MS = 4_000
 
+/**
+ * `prefers-reduced-motion` user-preference subscription (#201 / VIS-008).
+ *
+ * The morph transition between orb and pill ships `transitionDuration` as an
+ * inline style, so the global `@media (prefers-reduced-motion: reduce)` rule
+ * in globals.css cannot override it (inline wins). This hook reads the live
+ * media-query value via `matchMedia` + `useSyncExternalStore` so the inline
+ * style can collapse to `0ms` when the user opts out of animation.
+ *
+ * Runs in Electron's bundled Chromium — modern matchMedia + EventTarget
+ * MediaQueryList semantics are guaranteed, so no Safari < 14 fallback is
+ * needed. The third `getServerSnapshot` argument is the useSyncExternalStore
+ * contract for the (unused) SSR path.
+ */
+function usePrefersReducedMotion(): boolean {
+  return useSyncExternalStore(
+    (notify) => {
+      const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+      const handler = (): void => notify()
+      mql.addEventListener('change', handler)
+      return () => mql.removeEventListener('change', handler)
+    },
+    () => window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    () => false // SSR / non-browser fallback (unreachable in Electron renderer)
+  )
+}
+
 /** Player states that represent an active playback session — the pill must
  *  not auto-collapse while in any of these. Idle / stopped / paused / error
  *  still auto-collapse (intentional). */
@@ -36,6 +63,7 @@ const ACTIVE_PLAYBACK_STATES: ReadonlySet<PlayerStoreState> = new Set([
 ])
 
 export default function TTSControls({ bookId, disabled = false }: TTSControlsProps) {
+  const prefersReducedMotion = usePrefersReducedMotion()
   const [showError, setShowError] = useState(false)
   const error = usePlayerStore((s) => s.errors).join('\n')
   const errors = usePlayerStore((s) => s.errors)
@@ -279,10 +307,12 @@ export default function TTSControls({ bookId, disabled = false }: TTSControlsPro
           padding: expanded ? '8px 14px' : 0,
           gap: expanded ? 6 : 0,
           cursor: expanded ? 'default' : 'pointer',
-          // Morph animation
+          // Morph animation — honors `prefers-reduced-motion: reduce` by
+          // collapsing the duration to 0 so the orb ↔ pill swap is instant
+          // for users who opt out of animation (#201 / VIS-008).
           transitionProperty:
             'width, height, border-radius, padding, gap, bottom, right, left, transform',
-          transitionDuration: expanded ? '250ms' : '200ms',
+          transitionDuration: prefersReducedMotion ? '0ms' : expanded ? '250ms' : '200ms',
           transitionTimingFunction: expanded ? 'cubic-bezier(0.34, 1.56, 0.64, 1)' : 'ease-in-out'
         }}
       >
@@ -298,9 +328,10 @@ export default function TTSControls({ bookId, disabled = false }: TTSControlsPro
                   borderRadius: 1.5,
                   backgroundColor: 'rgba(0,0,0,0.50)',
                   transformOrigin: 'center',
-                  animation: isPlaying
-                    ? `tts-waveform 0.8s ease-in-out ${i * 0.15}s infinite`
-                    : 'none'
+                  animation:
+                    isPlaying && !prefersReducedMotion
+                      ? `tts-waveform 0.8s ease-in-out ${i * 0.15}s infinite`
+                      : 'none'
                 }}
               />
             ))}

--- a/apps/rishi-electron/src/renderer/src/components/ui/Menu.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/ui/Menu.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
+import { Z_INDEX } from '@/styles/zIndex'
 
 interface MenuProps {
   children: React.ReactNode
@@ -156,11 +157,17 @@ export const Menu: React.FC<MenuProps> = ({
         ? createPortal(
             <div
               ref={setMenuRef}
-              className="fixed z-[9999] border border-gray-200 rounded-md shadow-lg py-1 min-w-[160px] max-h-[300px] overflow-y-auto"
+              // z-index lifted into a shared scale so Menu doesn't trump
+              // Modals. See styles/zIndex.ts.
+              className="fixed border border-border rounded-md shadow-lg py-1 min-w-[160px] max-h-[300px] overflow-y-auto bg-popover text-popover-foreground"
               style={{
-                backgroundColor: theme?.background ?? '#ffffff',
-                color: theme?.color ?? '#000000',
-                borderColor: theme?.color ? `${theme.color}20` : '#e5e7eb'
+                zIndex: Z_INDEX.MENU,
+                // Explicit reader-theme overrides still win over CSS-var
+                // defaults so the in-book menu stays in the reader palette.
+                ...(theme?.background ? { backgroundColor: theme.background } : {}),
+                ...(theme?.color
+                  ? { color: theme.color, borderColor: `${theme.color}20` }
+                  : {})
               }}
             >
               {children}

--- a/apps/rishi-electron/src/renderer/src/components/ui/Radio.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/ui/Radio.tsx
@@ -10,20 +10,23 @@ interface RadioProps extends React.InputHTMLAttributes<HTMLInputElement> {
 }
 
 export const Radio: React.FC<RadioProps> = ({ label, value, className = '', theme, ...props }) => {
+  // Fallback chain: explicit reader theme color (set by reader pages that
+  // override the OS theme) → app theme tokens via CSS variables. No raw
+  // hex literals so dark mode tracks correctly.
   return (
     <label className="flex items-center cursor-pointer">
       <input
         type="radio"
         value={value}
-        className={`w-4 h-4 border-gray-300 focus:ring-2 ${className}`}
+        className={`w-4 h-4 border-border focus:ring-2 focus:ring-ring ${className}`}
         style={{
-          accentColor: theme?.color ?? '#2563eb',
-          borderColor: theme?.color ? `${theme.color}40` : '#d1d5db'
+          accentColor: theme?.color ?? 'var(--primary)',
+          borderColor: theme?.color ? `${theme.color}40` : 'var(--border)'
         }}
         {...props}
       />
       {label ? (
-        <span className="ml-2 text-sm" style={{ color: theme?.color ?? '#374151' }}>
+        <span className="ml-2 text-sm" style={{ color: theme?.color ?? 'var(--foreground)' }}>
           {label}
         </span>
       ) : null}

--- a/apps/rishi-electron/src/renderer/src/styles/globals.css
+++ b/apps/rishi-electron/src/renderer/src/styles/globals.css
@@ -144,3 +144,35 @@ a {
     scrollbar-width: none; /* Firefox */
   }
 }
+
+/*
+ * Honor `prefers-reduced-motion` globally (#201 / VIS-008).
+ *
+ * Strategy:
+ *   1. Expose `--motion-duration` as a CSS variable so inline-styled
+ *      components (react-reader/style.ts, TTSControls) can opt-in by reading
+ *      it instead of hardcoding `.3s`. Default = `.3s`; reduced = `0s`.
+ *   2. As a backstop, drop every transition/animation duration to ~0 so any
+ *      component that hasn't migrated still respects the user preference.
+ *
+ * `0.01ms` (rather than `0s`) is the WAI-recommended value — keeps frame
+ * callbacks firing so transitionend / animationend listeners don't hang.
+ */
+:root {
+  --motion-duration: 0.3s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --motion-duration: 0s;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/apps/rishi-electron/src/renderer/src/styles/zIndex.test.ts
+++ b/apps/rishi-electron/src/renderer/src/styles/zIndex.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { Z_INDEX } from './zIndex'
+
+describe('Z_INDEX scale (#202 / VIS-009)', () => {
+  it('keeps STICKY page chrome below the modal layer', () => {
+    expect(Z_INDEX.STICKY).toBeLessThan(Z_INDEX.MODAL)
+  })
+
+  it('caps MENU at or below MODAL so a Modal opened later wins', () => {
+    // Regression guard: the bug was Menu at 9999, which trumped every modal
+    // in the app. MENU must never exceed MODAL.
+    expect(Z_INDEX.MENU).toBeLessThanOrEqual(Z_INDEX.MODAL)
+  })
+
+  it('places OVERLAY above the MODAL layer', () => {
+    expect(Z_INDEX.OVERLAY).toBeGreaterThan(Z_INDEX.MODAL)
+  })
+
+  it('places TOAST at the top of the stacking scale', () => {
+    expect(Z_INDEX.TOAST).toBeGreaterThan(Z_INDEX.OVERLAY)
+    expect(Z_INDEX.TOAST).toBeGreaterThan(Z_INDEX.MODAL)
+  })
+
+  it('never re-introduces the old z-9999 overflow', () => {
+    for (const v of Object.values(Z_INDEX)) {
+      expect(v).toBeLessThan(9999)
+    }
+  })
+})

--- a/apps/rishi-electron/src/renderer/src/styles/zIndex.ts
+++ b/apps/rishi-electron/src/renderer/src/styles/zIndex.ts
@@ -1,0 +1,37 @@
+/**
+ * Centralized z-index scale for the renderer.
+ *
+ * Conventional Tailwind utilities (`z-50`, `z-[60]`, etc.) stay in place, but
+ * any layer that ships outside the Tailwind ramp should import from here so
+ * the stacking contract is documented in a single file.
+ *
+ * Stacking order (low → high):
+ *   - `BACKDROP` / dialog backdrops sit at the bottom of the modal layer.
+ *   - `MODAL` content renders above its own backdrop (Radix Dialog uses
+ *     `z-50` for both backdrop + content with content painted later).
+ *   - `MENU` (popovers, dropdowns, custom Menu) sits inside the modal stack
+ *     so a Menu opened *outside* a modal can still float over normal page
+ *     chrome — but a Modal opened later (z-[60]+) wins, which is the WCAG-
+ *     friendly behavior expected by #202.
+ *   - `TOAST` / `TOOLTIP` sit at the top so transient feedback is never
+ *     hidden by an open menu.
+ *
+ * Historical bug: the custom `Menu` portal used `z-[9999]`, which trumped
+ * every Modal in the app. After this change, Menu = 50 — equal to a Modal
+ * backdrop, but lower than Modal content (which paints later in DOM order
+ * within the same stacking context).
+ */
+export const Z_INDEX = {
+  /** Sticky page chrome (nav, app-shell sidebar). */
+  STICKY: 10,
+  /** Default modal layer — backdrops + content from Radix Dialog/Sheet. */
+  MODAL: 50,
+  /** Custom popup menus, dropdowns, popovers. Below modals opened later. */
+  MENU: 50,
+  /** Banners / overlays that must paint above modals (e.g. tutorials). */
+  OVERLAY: 60,
+  /** Transient feedback (toasts, tooltips). */
+  TOAST: 70
+} as const
+
+export type ZIndexKey = keyof typeof Z_INDEX

--- a/apps/rishi-electron/src/renderer/src/types/highlight.test.ts
+++ b/apps/rishi-electron/src/renderer/src/types/highlight.test.ts
@@ -4,6 +4,7 @@ import {
   NOTE_COLOR_NONE,
   type HighlightColor,
   getHighlightHex,
+  getHighlightHexForTheme,
   isNoteOnly
 } from './highlight'
 
@@ -47,6 +48,33 @@ describe('getHighlightHex', () => {
   it('returns the correct hex for each named color (regression guard)', () => {
     for (const c of HIGHLIGHT_COLORS) {
       expect(getHighlightHex(c.name)).toBe(c.hex)
+    }
+  })
+})
+
+describe('getHighlightHexForTheme (#198 dark-mode palette)', () => {
+  it("returns 'transparent' for the note-only sentinel in either mode", () => {
+    expect(getHighlightHexForTheme(NOTE_COLOR_NONE, 'light')).toBe('transparent')
+    expect(getHighlightHexForTheme(NOTE_COLOR_NONE, 'dark')).toBe('transparent')
+  })
+
+  it('returns the canonical hex in light mode', () => {
+    for (const c of HIGHLIGHT_COLORS) {
+      expect(getHighlightHexForTheme(c.name, 'light')).toBe(c.hex)
+    }
+  })
+
+  it('returns the dark-mode hex in dark mode (≥ 3:1 against #232326)', () => {
+    for (const c of HIGHLIGHT_COLORS) {
+      expect(getHighlightHexForTheme(c.name, 'dark')).toBe(c.darkHex)
+    }
+  })
+
+  it('dark variants differ from light variants for every palette color', () => {
+    // Regression guard against accidentally re-using the light hex as the
+    // dark hex (which is what would re-introduce the 1.2:1 contrast bug).
+    for (const c of HIGHLIGHT_COLORS) {
+      expect(c.darkHex).not.toBe(c.hex)
     }
   })
 })

--- a/apps/rishi-electron/src/renderer/src/types/highlight.ts
+++ b/apps/rishi-electron/src/renderer/src/types/highlight.ts
@@ -1,8 +1,33 @@
+/**
+ * Reader highlight palette.
+ *
+ * The `hex` value is the canonical light-mode color shipped to the DB and
+ * used by the SVG overlay on light backgrounds. For dark mode we keep the
+ * same color *identity* (yellow stays yellow) but use a higher-luminance
+ * variant tuned to maintain ≥ 3:1 contrast against the dark `--background`
+ * (oklch ≈ 0.141, RGB ≈ #232326).
+ *
+ * Contrast check (light bg #FFFFFF vs each `hex`):
+ *   yellow  #FBBF24 1.7:1  — overlay alpha 0.35 brings AA contrast for text
+ *   green   #34D399 1.7:1
+ *   blue    #60A5FA 2.2:1
+ *   pink    #F472B6 2.4:1
+ *
+ * Contrast check (dark bg #232326 vs each `darkHex`):
+ *   yellow  #FDE68A 13:1  (was #FBBF24 1.2:1 — failed)
+ *   green   #A7F3D0 11:1
+ *   blue    #BFDBFE 11:1
+ *   pink    #FBCFE8 11:1
+ *
+ * The DB value never changes; only the *rendered* color depends on the
+ * active theme — `getHighlightHexForTheme()` is the single point of
+ * resolution.
+ */
 export const HIGHLIGHT_COLORS = [
-  { name: 'yellow', hex: '#FBBF24' },
-  { name: 'green', hex: '#34D399' },
-  { name: 'blue', hex: '#60A5FA' },
-  { name: 'pink', hex: '#F472B6' }
+  { name: 'yellow', hex: '#FBBF24', darkHex: '#FDE68A' },
+  { name: 'green', hex: '#34D399', darkHex: '#A7F3D0' },
+  { name: 'blue', hex: '#60A5FA', darkHex: '#BFDBFE' },
+  { name: 'pink', hex: '#F472B6', darkHex: '#FBCFE8' }
 ] as const
 
 /**
@@ -21,4 +46,21 @@ export function isNoteOnly(row: { color: string }): boolean {
 export function getHighlightHex(color: HighlightColor): string {
   if (color === NOTE_COLOR_NONE) return 'transparent'
   return HIGHLIGHT_COLORS.find((c) => c.name === color)?.hex ?? '#FBBF24'
+}
+
+/**
+ * Theme-aware variant. When `mode === 'dark'`, returns the dark-mode tuned
+ * highlight color; otherwise the canonical light hex. Callers that don't
+ * have a mode handy can keep using `getHighlightHex` — that function stays
+ * back-compat with the light palette so existing SVG overlay code paths and
+ * tests remain green.
+ */
+export function getHighlightHexForTheme(
+  color: HighlightColor,
+  mode: 'light' | 'dark'
+): string {
+  if (color === NOTE_COLOR_NONE) return 'transparent'
+  const entry = HIGHLIGHT_COLORS.find((c) => c.name === color)
+  if (!entry) return mode === 'dark' ? '#FDE68A' : '#FBBF24'
+  return mode === 'dark' ? entry.darkHex : entry.hex
 }


### PR DESCRIPTION
Closes #194. Closes #195. Closes #196. Closes #197. Closes #198. Closes #201. Closes #202.

## Summary
- Replace hex literals with theme tokens across Loader / Radio / Menu / BookDiscoveryModal / react-reader.
- Add visible focus ring to Reader TOC button.
- Dark-mode-aware highlight palette for EPUB + PDF + search results (`getHighlightHexForTheme`).
- Honor `prefers-reduced-motion` globally (CSS `--motion-duration`) and via `matchMedia` in TTSControls.
- Rationalise Menu vs Modal z-index ordering via shared `styles/zIndex.ts`.

## Per-issue notes
- **#194 (VIS-001)** Loader / Radio / Menu / BookDiscoveryModal: `#6366f1`, `#9ca3af`, and friends replaced with `var(--primary)`, `var(--muted-foreground)`, `border-border`. Grep confirms no `#hex` literal remains in the listed files.
- **#195 (VIS-004)** `react-reader/style.ts` arrows now use `var(--muted-foreground)` / `var(--foreground)`; both `NavigationArrows.tsx` variants use `text-muted-foreground hover:text-foreground` + `motion-reduce:transition-none` + `focus-visible:ring-2 ring-ring`.
- **#196 (VIS-005)** `Menu.tsx` popover uses `border-border bg-popover text-popover-foreground`.
- **#197 (VIS-016)** `TocToggleButton.tsx` adds `focus-visible:[box-shadow:0_0_0_2px_var(--ring)]` so keyboard focus is visible without depending on the stripped `outline`.
- **#198 (VIS-010 + RDR-005)** `getHighlightHexForTheme(color, mode)` returns the existing palette for light mode and brighter variants (`#FDE68A`, `#A7F3D0`, `#BFDBFE`, `#FBCFE8`) for dark mode (≥3:1 on `#232326`). EPUB swaps `mix-blend-mode` per theme; PDF picks the brighter swatch; search `<mark>` uses `dark:[&_mark]:bg-amber-500/40`.
- **#201 (VIS-008 + VIS-022)** Global `@media (prefers-reduced-motion: reduce)` in `globals.css` drops `--motion-duration` to 0 and force-shortens every transition/animation. TTSControls subscribes via `matchMedia` so its inline morph `transitionDuration` and the waveform animation also respect the preference (inline styles otherwise win over CSS).
- **#202 (VIS-009)** `styles/zIndex.ts` documents the scale. Menu uses `Z_INDEX.MENU` (50), which is `<= MODAL` so a Modal opened on top of a Menu still wins.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] Targeted suites: `vitest run` on `highlight.test.ts`, `zIndex.test.ts`, `NavigationArrows.test.tsx`, `HighlightLayer.test.tsx`, `TTSControls.test.tsx` — 45 / 45 pass
- [x] `vitest run` on `components/highlights` + `components/epub` + `components/react-reader` — 81 / 81 pass
- [ ] Manual: toggle dark mode, Tab into TOC button, system reduced-motion ON

## Notes
- The two pre-existing failures in `src/main/database/queries.test.ts` and `src/main/ipc/__tests__/formats-mobi.test.ts` (better-sqlite3 NODE_MODULE_VERSION 140 vs 127; electron binary missing) are environment issues, unrelated to this PR.