### PR TITLE
fix(electron/sync): validate IPC payloads + wrap multi-statement ops in tx

### DIFF
--- a/apps/rishi-electron/src/main/ipc/__tests__/sync-validation.test.ts
+++ b/apps/rishi-electron/src/main/ipc/__tests__/sync-validation.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import BetterSqlite3 from 'better-sqlite3'
+import type { Database } from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { eq } from 'drizzle-orm'
+import * as schema from '../../database/schema.js'
+
+// sync.ts imports preload/ipc-contract which pulls in `electron`. Stub it so
+// the module loads under vitest (same pattern as queries.test.ts).
+vi.mock('electron', () => ({
+  ipcMain: { handle: () => {} },
+  app: { on: () => {}, getPath: () => '/tmp' }
+}))
+
+import {
+  _applyBookConflictWithDb,
+  _applyHighlightConflictWithDb,
+  _applyConversationConflictWithDb,
+  _upsertBookWithDb,
+  _markBooksCleanWithDb
+} from '../sync.js'
+
+const DDL_STATEMENTS = [
+  `CREATE TABLE books (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind TEXT NOT NULL DEFAULT 'epub',
+    cover BLOB NOT NULL,
+    title TEXT NOT NULL DEFAULT '',
+    author TEXT NOT NULL DEFAULT '',
+    publisher TEXT NOT NULL DEFAULT '',
+    filepath TEXT NOT NULL DEFAULT '',
+    location TEXT NOT NULL DEFAULT '',
+    cover_kind TEXT NOT NULL DEFAULT 'png',
+    version INTEGER NOT NULL DEFAULT 0,
+    sync_id TEXT,
+    file_hash TEXT,
+    file_r2_key TEXT,
+    cover_r2_key TEXT,
+    file_size INTEGER NOT NULL DEFAULT 0,
+    format TEXT NOT NULL DEFAULT 'epub',
+    current_cfi TEXT,
+    current_page INTEGER,
+    user_id TEXT,
+    sync_version INTEGER NOT NULL DEFAULT 0,
+    is_dirty INTEGER NOT NULL DEFAULT 1,
+    is_deleted INTEGER NOT NULL DEFAULT 0,
+    last_paragraph TEXT
+  )`,
+  `CREATE TABLE highlights (
+    id TEXT PRIMARY KEY,
+    book_id TEXT NOT NULL,
+    format TEXT NOT NULL DEFAULT 'epub',
+    cfi_range TEXT NOT NULL DEFAULT '',
+    locator TEXT,
+    text TEXT NOT NULL DEFAULT '',
+    color TEXT NOT NULL DEFAULT 'yellow',
+    note TEXT NOT NULL DEFAULT '',
+    chapter TEXT,
+    created_at TEXT NOT NULL DEFAULT '',
+    updated_at INTEGER,
+    sync_id TEXT,
+    sync_version INTEGER NOT NULL DEFAULT 0,
+    is_dirty INTEGER NOT NULL DEFAULT 1,
+    is_deleted INTEGER NOT NULL DEFAULT 0
+  )`,
+  `CREATE TABLE conversations (
+    id TEXT PRIMARY KEY,
+    book_id TEXT NOT NULL,
+    title TEXT NOT NULL DEFAULT '',
+    user_id TEXT,
+    created_at TEXT NOT NULL DEFAULT '',
+    updated_at INTEGER,
+    sync_id TEXT,
+    sync_version INTEGER NOT NULL DEFAULT 0,
+    is_dirty INTEGER NOT NULL DEFAULT 1,
+    is_deleted INTEGER NOT NULL DEFAULT 0
+  )`
+]
+
+function makeDb(): { sqlite: Database; db: ReturnType<typeof drizzle<typeof schema>> } {
+  const sqlite = new BetterSqlite3(':memory:')
+  for (const stmt of DDL_STATEMENTS) sqlite.prepare(stmt).run()
+  const db = drizzle(sqlite, { schema })
+  return { sqlite, db }
+}
+
+function seedBook(
+  sqlite: Database,
+  syncId: string,
+  overrides: Partial<{ title: string; author: string; format: string; is_dirty: number }> = {}
+): void {
+  sqlite
+    .prepare(
+      `INSERT INTO books (kind, cover, title, author, publisher, filepath, location, cover_kind,
+       version, sync_id, format, sync_version, is_dirty, is_deleted, file_size)
+       VALUES ('epub', x'', @title, @author, '', '', '', 'png', 0, @sync_id, @format, 0, @is_dirty, 0, 0)`
+    )
+    .run({
+      title: overrides.title ?? 'Original Title',
+      author: overrides.author ?? 'Original Author',
+      sync_id: syncId,
+      format: overrides.format ?? 'epub',
+      is_dirty: overrides.is_dirty ?? 0
+    })
+}
+
+// ---------------------------------------------------------------------------
+// SYNC-VAL: malformed payload guards (#166)
+// ---------------------------------------------------------------------------
+
+describe('sync IPC validation (issue #166)', () => {
+  let sqlite: Database
+  let db: ReturnType<typeof drizzle<typeof schema>>
+
+  beforeEach(() => {
+    ;({ sqlite, db } = makeDb())
+  })
+
+  describe('_applyBookConflictWithDb', () => {
+    it('refuses a payload whose id is not a string', () => {
+      seedBook(sqlite, 'book-1')
+      const malformed = { id: 123, title: null, isDeleted: 'yes' }
+      expect(() => _applyBookConflictWithDb(db, malformed, 5)).not.toThrow()
+      const row = db.select().from(schema.books).where(eq(schema.books.syncId, 'book-1')).get()
+      // Original row must remain — invalid payload should be ignored.
+      expect(row?.title).toBe('Original Title')
+      expect(row?.author).toBe('Original Author')
+      expect(row?.title).not.toBeNull()
+    })
+
+    it('coerces isDeleted to a number and never writes null into NOT NULL columns', () => {
+      seedBook(sqlite, 'book-2')
+      const payload = {
+        id: 'book-2',
+        title: 'Cloud Title',
+        author: 'Cloud Author',
+        format: 'epub',
+        isDeleted: 'yes' // truthy non-bool
+      }
+      _applyBookConflictWithDb(db, payload, 7)
+      const row = db.select().from(schema.books).where(eq(schema.books.syncId, 'book-2')).get()
+      expect(row?.title).toBe('Cloud Title')
+      expect(row?.author).toBe('Cloud Author')
+      expect(typeof row?.isDeleted).toBe('number')
+    })
+  })
+
+  describe('_applyHighlightConflictWithDb', () => {
+    it('refuses malformed payload without writing garbage', () => {
+      sqlite
+        .prepare(
+          `INSERT INTO highlights (id, book_id, text, color, cfi_range)
+           VALUES ('hl-1', 'book-1', 'orig text', 'yellow', 'epubcfi(/6/4)')`
+        )
+        .run()
+      const malformed = { id: 123, title: null, isDeleted: 'yes' }
+      expect(() => _applyHighlightConflictWithDb(db, malformed, 5)).not.toThrow()
+      const row = db
+        .select()
+        .from(schema.highlights)
+        .where(eq(schema.highlights.id, 'hl-1'))
+        .get()
+      expect(row?.text).toBe('orig text')
+    })
+  })
+
+  describe('_applyConversationConflictWithDb', () => {
+    it('refuses malformed payload without writing garbage', () => {
+      sqlite
+        .prepare(
+          `INSERT INTO conversations (id, book_id, title) VALUES ('conv-1', 'book-1', 'orig title')`
+        )
+        .run()
+      const malformed = { id: 123, title: null, isDeleted: 'yes' }
+      expect(() => _applyConversationConflictWithDb(db, malformed, 5)).not.toThrow()
+      const row = db
+        .select()
+        .from(schema.conversations)
+        .where(eq(schema.conversations.id, 'conv-1'))
+        .get()
+      expect(row?.title).toBe('orig title')
+    })
+  })
+
+  describe('_upsertBookWithDb', () => {
+    it('refuses a payload whose id is not a string (no insert, no crash)', () => {
+      const before = db.select().from(schema.books).all().length
+      expect(() =>
+        _upsertBookWithDb(db, { id: 123, title: null, isDeleted: 'yes' })
+      ).not.toThrow()
+      const after = db.select().from(schema.books).all().length
+      expect(after).toBe(before)
+    })
+
+    it('inserts coerced safe defaults when optional fields are missing', () => {
+      _upsertBookWithDb(db, { id: 'remote-1' })
+      const row = db.select().from(schema.books).where(eq(schema.books.syncId, 'remote-1')).get()
+      expect(row).toBeDefined()
+      expect(row?.title).toBeDefined()
+      expect(row?.author).toBeDefined()
+      expect(row?.format).toBeDefined()
+    })
+
+    // Regression: the pre-PR `_upsertBookWithDb` had `if (!syncId) return` on
+    // an empty-string id. Mirror that semantic in the validator: id.min(1)
+    // rejects the empty string so the row never lands in SQLite (#166).
+    it('refuses a payload whose id is empty string (no insert, no crash)', () => {
+      const before = db.select().from(schema.books).all().length
+      expect(() => _upsertBookWithDb(db, { id: '' })).not.toThrow()
+      const after = db.select().from(schema.books).all().length
+      expect(after).toBe(before)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SYNC-TX: multi-statement ops wrapped in db.transaction (#167)
+// ---------------------------------------------------------------------------
+
+describe('sync IPC transactions (issue #167)', () => {
+  let sqlite: Database
+  let db: ReturnType<typeof drizzle<typeof schema>>
+
+  beforeEach(() => {
+    ;({ sqlite, db } = makeDb())
+  })
+
+  it('_markBooksCleanWithDb wraps the loop in a single transaction', () => {
+    seedBook(sqlite, 'book-a', { is_dirty: 1 })
+    seedBook(sqlite, 'book-b', { is_dirty: 1 })
+    seedBook(sqlite, 'book-c', { is_dirty: 1 })
+
+    const txSpy = vi.spyOn(db, 'transaction')
+    _markBooksCleanWithDb(db, ['book-a', 'book-b', 'book-c'], 9)
+    expect(txSpy).toHaveBeenCalledTimes(1)
+
+    const rows = db.select().from(schema.books).all()
+    expect(rows.every((r) => r.isDirty === 0)).toBe(true)
+    expect(rows.every((r) => r.syncVersion === 9)).toBe(true)
+  })
+
+  it('_upsertBookWithDb runs SELECT+INSERT/UPDATE inside a transaction', () => {
+    const txSpy = vi.spyOn(db, 'transaction')
+    _upsertBookWithDb(db, { id: 'remote-tx-1', title: 'T', author: 'A', format: 'epub' })
+    expect(txSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('_applyBookConflictWithDb wraps the update in a transaction', () => {
+    seedBook(sqlite, 'book-tx')
+    const txSpy = vi.spyOn(db, 'transaction')
+    _applyBookConflictWithDb(
+      db,
+      { id: 'book-tx', title: 'New', author: 'New', format: 'epub' },
+      5
+    )
+    expect(txSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/rishi-electron/src/main/ipc/sync.schemas.ts
+++ b/apps/rishi-electron/src/main/ipc/sync.schemas.ts
@@ -1,0 +1,169 @@
+/**
+ * Zod schemas for sync IPC payloads.
+ *
+ * The conflict/upsert handlers in `sync.ts` previously cast incoming
+ * `Record<string, unknown>` payloads field-by-field with `as string` / `as
+ * number` / `as boolean`. When the cloud sync server delivers a malformed
+ * row (e.g. a stale schema or partial outage), those casts let `null`,
+ * objects, or wrong-typed values land verbatim in SQLite — corrupting
+ * NOT NULL columns and crashing readers downstream.
+ *
+ * These schemas centralize the runtime contract. Optional fields default
+ * to safe values rather than throwing — matching the existing defensive
+ * behaviour of the handlers — but a payload whose primary `id` is not a
+ * string is rejected outright (callers should no-op).
+ */
+import { z } from 'zod'
+
+// ---------------------------------------------------------------------------
+// Shared atoms
+// ---------------------------------------------------------------------------
+
+/** Truthy coercion: matches the old `(x as boolean) ? 1 : 0` semantics. */
+const truthyAsInt = z.unknown().transform((v) => (v ? 1 : 0))
+
+/** Optional string that defaults to null when missing or wrong-typed. */
+const optionalNullableString = z
+  .unknown()
+  .transform((v) => (typeof v === 'string' ? v : null))
+
+/** Optional number that defaults to null when missing or wrong-typed. */
+const optionalNullableNumber = z
+  .unknown()
+  .transform((v) => (typeof v === 'number' ? v : null))
+
+/** Optional number coerced to 0 (for sync_version-like counters). */
+const optionalNumberOr0 = z
+  .unknown()
+  .transform((v) => (typeof v === 'number' ? v : 0))
+
+/** Permissive timestamp: accepts string or number, falls back to '' */
+const optionalTimestampString = z
+  .unknown()
+  .transform((v) => {
+    if (typeof v === 'string') return v
+    if (typeof v === 'number') return v.toString()
+    return ''
+  })
+
+// ---------------------------------------------------------------------------
+// Book conflict payload — `sync:applyBookConflict`
+// ---------------------------------------------------------------------------
+
+/**
+ * Required string id (the local row's sync_id). Optional string fields
+ * accept the wrong type silently and fall through to null — same as the
+ * old casts but guaranteed not to leak objects/garbage into NOT NULL
+ * columns. The four `title`/`author`/`format` defaults preserve the
+ * existing behaviour where empty string is acceptable.
+ */
+export const bookConflictSchema = z.object({
+  id: z.string(),
+  title: z.unknown().transform((v) => (typeof v === 'string' ? v : '')),
+  author: z.unknown().transform((v) => (typeof v === 'string' ? v : '')),
+  format: z.unknown().transform((v) => (typeof v === 'string' ? v : 'epub')),
+  currentCfi: optionalNullableString,
+  currentPage: optionalNullableNumber,
+  fileHash: optionalNullableString,
+  fileR2Key: optionalNullableString,
+  coverR2Key: optionalNullableString,
+  isDeleted: truthyAsInt
+})
+
+export type BookConflict = z.infer<typeof bookConflictSchema>
+
+// ---------------------------------------------------------------------------
+// Highlight conflict payload — `sync:applyHighlightConflict`
+// ---------------------------------------------------------------------------
+
+export const highlightConflictSchema = z.object({
+  id: z.string(),
+  text: z.unknown().transform((v) => (typeof v === 'string' ? v : '')),
+  color: z.unknown().transform((v) => (typeof v === 'string' ? v : 'yellow')),
+  note: z.unknown().transform((v) => (typeof v === 'string' ? v : '')),
+  chapter: optionalNullableString,
+  cfiRange: z.unknown().transform((v) => (typeof v === 'string' ? v : '')),
+  isDeleted: truthyAsInt
+})
+
+export type HighlightConflict = z.infer<typeof highlightConflictSchema>
+
+// ---------------------------------------------------------------------------
+// Conversation conflict payload — `sync:applyConversationConflict`
+// ---------------------------------------------------------------------------
+
+export const conversationConflictSchema = z.object({
+  id: z.string(),
+  title: z.unknown().transform((v) => (typeof v === 'string' ? v : '')),
+  bookId: z.unknown().transform((v) => (typeof v === 'string' ? v : '')),
+  isDeleted: truthyAsInt
+})
+
+export type ConversationConflict = z.infer<typeof conversationConflictSchema>
+
+// ---------------------------------------------------------------------------
+// Upsert payloads — `sync:upsertBook/Highlight/Conversation/insertMessage`
+// ---------------------------------------------------------------------------
+
+export const bookUpsertSchema = z.object({
+  // .min(1) — empty string is a real failure case from the cloud sync server
+  // (malformed row missing the primary id field). The pre-PR handlers had
+  // `if (!syncId) return` guards; the new validators must reject the same
+  // payloads so an empty-id row never lands in the local SQLite (#166).
+  id: z.string().min(1),
+  title: optionalNullableString,
+  author: optionalNullableString,
+  format: optionalNullableString,
+  currentCfi: optionalNullableString,
+  currentPage: optionalNullableNumber,
+  fileHash: optionalNullableString,
+  fileR2Key: optionalNullableString,
+  coverR2Key: optionalNullableString,
+  fileSize: optionalNullableNumber,
+  syncVersion: optionalNumberOr0,
+  isDeleted: truthyAsInt
+})
+
+export type BookUpsert = z.infer<typeof bookUpsertSchema>
+
+export const highlightUpsertSchema = z.object({
+  id: z.string().min(1),
+  bookId: optionalNullableString,
+  text: optionalNullableString,
+  color: optionalNullableString,
+  note: optionalNullableString,
+  chapter: optionalNullableString,
+  cfiRange: optionalNullableString,
+  createdAt: optionalTimestampString,
+  updatedAt: optionalNullableNumber,
+  syncVersion: optionalNumberOr0,
+  isDeleted: truthyAsInt
+})
+
+export type HighlightUpsert = z.infer<typeof highlightUpsertSchema>
+
+export const conversationUpsertSchema = z.object({
+  id: z.string().min(1),
+  bookId: optionalNullableString,
+  title: optionalNullableString,
+  createdAt: optionalTimestampString,
+  updatedAt: optionalNullableNumber,
+  syncVersion: optionalNumberOr0,
+  isDeleted: truthyAsInt
+})
+
+export type ConversationUpsert = z.infer<typeof conversationUpsertSchema>
+
+export const messageInsertSchema = z.object({
+  id: z.string().min(1),
+  conversationId: optionalNullableString,
+  role: optionalNullableString,
+  content: optionalNullableString,
+  sourceChunks: optionalNullableString,
+  createdAt: optionalTimestampString,
+  updatedAt: optionalNullableNumber,
+  syncVersion: optionalNumberOr0,
+  isDeleted: truthyAsInt
+})
+
+export type MessageInsert = z.infer<typeof messageInsertSchema>

--- a/apps/rishi-electron/src/main/ipc/sync.ts
+++ b/apps/rishi-electron/src/main/ipc/sync.ts
@@ -2,6 +2,22 @@ import { eq, and, isNotNull } from 'drizzle-orm'
 import { getDrizzle } from '../database/drizzle.js'
 import { books, highlights, conversations, messages, syncMeta } from '../database/schema.js'
 import { handle } from '../../preload/ipc-contract.js'
+import {
+  bookConflictSchema,
+  highlightConflictSchema,
+  conversationConflictSchema,
+  bookUpsertSchema,
+  highlightUpsertSchema,
+  conversationUpsertSchema,
+  messageInsertSchema
+} from './sync.schemas.js'
+
+/**
+ * Drizzle BetterSqlite3 instance type. Helper functions accept this so they
+ * can be unit-tested against an in-memory database without invoking the IPC
+ * layer.
+ */
+type Db = ReturnType<typeof getDrizzle>
 
 /**
  * Narrow an unknown value to a stringifiable primitive (string or number).
@@ -14,14 +30,351 @@ function asStringOrNumber(v: unknown, fallback: string | number): string | numbe
 }
 
 /**
- * Convert a `string | number` (from `asStringOrNumber`) to a plain string —
- * needed because several sync columns are stored as TEXT but the remote
- * payload may deliver the same field as either a string or a number.
- * Avoids `String()` on `unknown`, which would tip into [object Object].
+ * Convert a `string | number` (from `asStringOrNumber`) to a plain string.
  */
 function stringFrom(v: string | number): string {
   return typeof v === 'string' ? v : v.toString()
 }
+
+// ===========================================================================
+// Pure helpers (exported with `_` prefix for testing)
+//
+// Each helper takes an explicit `db` so unit tests can pass an in-memory
+// drizzle instance without monkey-patching the singleton in `./drizzle.js`.
+// Multi-statement helpers wrap their writes in `db.transaction(...)` so a
+// partial failure rolls back (#167).
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Mark-clean loops (wrapped in transactions: #167)
+// ---------------------------------------------------------------------------
+
+export function _markBooksCleanWithDb(db: Db, ids: string[], syncVersion: number): void {
+  db.transaction((tx) => {
+    for (const syncId of ids) {
+      tx.update(books).set({ isDirty: 0, syncVersion }).where(eq(books.syncId, syncId)).run()
+    }
+  })
+}
+
+export function _markHighlightsCleanWithDb(db: Db, ids: string[], syncVersion: number): void {
+  db.transaction((tx) => {
+    for (const id of ids) {
+      tx.update(highlights).set({ isDirty: 0, syncVersion }).where(eq(highlights.id, id)).run()
+    }
+  })
+}
+
+export function _markConversationsCleanWithDb(
+  db: Db,
+  ids: string[],
+  syncVersion: number
+): void {
+  db.transaction((tx) => {
+    for (const id of ids) {
+      tx.update(conversations)
+        .set({ isDirty: 0, syncVersion })
+        .where(eq(conversations.id, id))
+        .run()
+    }
+  })
+}
+
+export function _markMessagesCleanWithDb(db: Db, ids: string[], syncVersion: number): void {
+  db.transaction((tx) => {
+    for (const id of ids) {
+      tx.update(messages).set({ isDirty: 0, syncVersion }).where(eq(messages.id, id)).run()
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Conflict handlers (validated + transactional: #166 + #167)
+// ---------------------------------------------------------------------------
+
+export function _applyBookConflictWithDb(
+  db: Db,
+  conflict: unknown,
+  syncVersion: number
+): void {
+  const parsed = bookConflictSchema.safeParse(conflict)
+  if (!parsed.success) {
+    // Malformed payload — silently skip (matches existing defensive pattern
+    // in `_upsertBookWithDb`). Logging would be nicer but the existing
+    // handlers do not log, so we preserve behaviour.
+    return
+  }
+  const c = parsed.data
+  db.transaction((tx) => {
+    tx.update(books)
+      .set({
+        title: c.title,
+        author: c.author,
+        format: c.format,
+        currentCfi: c.currentCfi,
+        currentPage: c.currentPage,
+        fileHash: c.fileHash,
+        fileR2Key: c.fileR2Key,
+        coverR2Key: c.coverR2Key,
+        syncVersion,
+        isDirty: 0,
+        isDeleted: c.isDeleted
+      })
+      .where(eq(books.syncId, c.id))
+      .run()
+  })
+}
+
+export function _applyHighlightConflictWithDb(
+  db: Db,
+  conflict: unknown,
+  syncVersion: number
+): void {
+  const parsed = highlightConflictSchema.safeParse(conflict)
+  if (!parsed.success) return
+  const c = parsed.data
+  db.transaction((tx) => {
+    tx.update(highlights)
+      .set({
+        text: c.text,
+        color: c.color,
+        note: c.note,
+        chapter: c.chapter,
+        cfiRange: c.cfiRange,
+        syncVersion,
+        isDirty: 0,
+        isDeleted: c.isDeleted
+      })
+      .where(eq(highlights.id, c.id))
+      .run()
+  })
+}
+
+export function _applyConversationConflictWithDb(
+  db: Db,
+  conflict: unknown,
+  syncVersion: number
+): void {
+  const parsed = conversationConflictSchema.safeParse(conflict)
+  if (!parsed.success) return
+  const c = parsed.data
+  db.transaction((tx) => {
+    tx.update(conversations)
+      .set({
+        title: c.title,
+        bookId: c.bookId,
+        syncVersion,
+        isDirty: 0,
+        isDeleted: c.isDeleted
+      })
+      .where(eq(conversations.id, c.id))
+      .run()
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Upsert handlers (validated + transactional: #166 + #167)
+// ---------------------------------------------------------------------------
+
+export function _upsertBookWithDb(db: Db, remote: unknown): void {
+  const parsed = bookUpsertSchema.safeParse(remote)
+  if (!parsed.success) return
+  const r = parsed.data
+  const syncId = r.id
+
+  db.transaction((tx) => {
+    const local = tx.select().from(books).where(eq(books.syncId, syncId)).get()
+
+    if (local) {
+      if (local.isDirty === 1) return // locally dirty takes precedence
+
+      tx.update(books)
+        .set({
+          title: r.title ?? local.title,
+          author: r.author ?? local.author,
+          format: r.format ?? local.format,
+          currentCfi: r.currentCfi,
+          currentPage: r.currentPage,
+          fileHash: r.fileHash,
+          fileR2Key: r.fileR2Key,
+          coverR2Key: r.coverR2Key,
+          fileSize: r.fileSize ?? local.fileSize,
+          syncVersion: r.syncVersion,
+          isDirty: 0,
+          isDeleted: r.isDeleted
+        })
+        .where(eq(books.syncId, syncId))
+        .run()
+    } else {
+      // New remote book — insert with empty local file (needs download)
+      const newTitle = r.title ?? 'Unknown'
+      const newAuthor = r.author ?? 'Unknown'
+      const newFormat = r.format ?? 'epub'
+
+      tx.insert(books)
+        .values({
+          kind: newFormat,
+          cover: Buffer.alloc(0),
+          title: newTitle,
+          author: newAuthor,
+          publisher: '',
+          filepath: '',
+          location: r.currentCfi ?? '',
+          coverKind: 'png',
+          version: 0,
+          syncId,
+          format: newFormat,
+          currentCfi: r.currentCfi,
+          currentPage: r.currentPage,
+          fileHash: r.fileHash,
+          fileR2Key: r.fileR2Key,
+          coverR2Key: r.coverR2Key,
+          fileSize: r.fileSize ?? 0,
+          syncVersion: r.syncVersion,
+          isDirty: 0,
+          isDeleted: r.isDeleted
+        })
+        .run()
+    }
+  })
+}
+
+export function _upsertHighlightWithDb(db: Db, remote: unknown): void {
+  const parsed = highlightUpsertSchema.safeParse(remote)
+  if (!parsed.success) return
+  const r = parsed.data
+
+  db.transaction((tx) => {
+    const local = tx.select().from(highlights).where(eq(highlights.id, r.id)).get()
+
+    if (local) {
+      if (local.isDirty === 1) return
+      const remoteUpdatedAt = r.updatedAt ?? 0
+      if (remoteUpdatedAt < (local.updatedAt ?? 0)) return // LWW guard
+
+      tx.update(highlights)
+        .set({
+          text: r.text ?? local.text,
+          color: r.color ?? local.color,
+          note: r.note ?? '',
+          chapter: r.chapter,
+          cfiRange: r.cfiRange ?? '',
+          bookId: r.bookId ?? local.bookId,
+          createdAt: stringFrom(asStringOrNumber(r.createdAt, '')),
+          updatedAt: r.updatedAt ?? local.updatedAt,
+          syncVersion: r.syncVersion,
+          isDirty: 0,
+          isDeleted: r.isDeleted
+        })
+        .where(eq(highlights.id, r.id))
+        .run()
+    } else {
+      tx.insert(highlights)
+        .values({
+          id: r.id,
+          bookId: r.bookId ?? '',
+          text: r.text ?? '',
+          color: r.color ?? 'yellow',
+          note: r.note ?? '',
+          chapter: r.chapter,
+          cfiRange: r.cfiRange ?? '',
+          createdAt: stringFrom(asStringOrNumber(r.createdAt, Date.now())),
+          updatedAt: r.updatedAt ?? Date.now(),
+          syncVersion: r.syncVersion,
+          isDirty: 0,
+          isDeleted: r.isDeleted
+        })
+        .run()
+    }
+  })
+}
+
+export function _upsertConversationWithDb(db: Db, remote: unknown): void {
+  const parsed = conversationUpsertSchema.safeParse(remote)
+  if (!parsed.success) return
+  const r = parsed.data
+
+  db.transaction((tx) => {
+    const local = tx.select().from(conversations).where(eq(conversations.id, r.id)).get()
+
+    if (local) {
+      if (local.isDirty === 1) return
+      const remoteUpdatedAt = r.updatedAt ?? 0
+      if (remoteUpdatedAt < (local.updatedAt ?? 0)) return // LWW guard
+
+      tx.update(conversations)
+        .set({
+          title: r.title ?? local.title,
+          bookId: r.bookId ?? local.bookId,
+          createdAt: stringFrom(asStringOrNumber(r.createdAt, '')),
+          updatedAt: r.updatedAt ?? local.updatedAt,
+          syncVersion: r.syncVersion,
+          isDirty: 0,
+          isDeleted: r.isDeleted
+        })
+        .where(eq(conversations.id, r.id))
+        .run()
+    } else {
+      tx.insert(conversations)
+        .values({
+          id: r.id,
+          bookId: r.bookId ?? '',
+          title: r.title ?? 'New conversation',
+          createdAt: stringFrom(asStringOrNumber(r.createdAt, Date.now())),
+          updatedAt: r.updatedAt ?? Date.now(),
+          syncVersion: r.syncVersion,
+          isDirty: 0,
+          isDeleted: r.isDeleted
+        })
+        .run()
+    }
+  })
+}
+
+export function _insertMessageWithDb(db: Db, remote: unknown): void {
+  const parsed = messageInsertSchema.safeParse(remote)
+  if (!parsed.success) return
+  const r = parsed.data
+
+  db.transaction((tx) => {
+    const existing = tx.select().from(messages).where(eq(messages.id, r.id)).get()
+    if (existing) return // append-only: never update existing messages
+
+    tx.insert(messages)
+      .values({
+        id: r.id,
+        conversationId: r.conversationId ?? '',
+        role: r.role ?? 'user',
+        content: r.content ?? '',
+        sourceChunks: r.sourceChunks,
+        createdAt: stringFrom(asStringOrNumber(r.createdAt, Date.now())),
+        updatedAt: r.updatedAt ?? Date.now(),
+        syncVersion: r.syncVersion,
+        isDirty: 0,
+        isDeleted: r.isDeleted
+      })
+      .run()
+  })
+}
+
+export function _updateLastVersionWithDb(db: Db, version: number): void {
+  db.transaction((tx) => {
+    const existing = tx.select().from(syncMeta).limit(1).get()
+    const now = new Date().toISOString()
+    if (existing) {
+      tx.update(syncMeta)
+        .set({ lastSyncVersion: version, lastSyncAt: now })
+        .where(eq(syncMeta.id, existing.id))
+        .run()
+    } else {
+      tx.insert(syncMeta).values({ lastSyncVersion: version, lastSyncAt: now }).run()
+    }
+  })
+}
+
+// ===========================================================================
+// IPC registration — thin adapters around the helpers above.
+// ===========================================================================
 
 export function registerSyncHandlers(): void {
   // -----------------------------------------------------------------------
@@ -63,34 +416,19 @@ export function registerSyncHandlers(): void {
   // -----------------------------------------------------------------------
 
   handle('sync:markBooksClean', (_event, ids, syncVersion) => {
-    const db = getDrizzle()
-    for (const syncId of ids) {
-      db.update(books).set({ isDirty: 0, syncVersion }).where(eq(books.syncId, syncId)).run()
-    }
+    _markBooksCleanWithDb(getDrizzle(), ids, syncVersion)
   })
 
   handle('sync:markHighlightsClean', (_event, ids, syncVersion) => {
-    const db = getDrizzle()
-    for (const id of ids) {
-      db.update(highlights).set({ isDirty: 0, syncVersion }).where(eq(highlights.id, id)).run()
-    }
+    _markHighlightsCleanWithDb(getDrizzle(), ids, syncVersion)
   })
 
   handle('sync:markConversationsClean', (_event, ids, syncVersion) => {
-    const db = getDrizzle()
-    for (const id of ids) {
-      db.update(conversations)
-        .set({ isDirty: 0, syncVersion })
-        .where(eq(conversations.id, id))
-        .run()
-    }
+    _markConversationsCleanWithDb(getDrizzle(), ids, syncVersion)
   })
 
   handle('sync:markMessagesClean', (_event, ids, syncVersion) => {
-    const db = getDrizzle()
-    for (const id of ids) {
-      db.update(messages).set({ isDirty: 0, syncVersion }).where(eq(messages.id, id)).run()
-    }
+    _markMessagesCleanWithDb(getDrizzle(), ids, syncVersion)
   })
 
   // -----------------------------------------------------------------------
@@ -98,58 +436,15 @@ export function registerSyncHandlers(): void {
   // -----------------------------------------------------------------------
 
   handle('sync:applyBookConflict', (_event, conflict, syncVersion) => {
-    const c = conflict
-    const db = getDrizzle()
-    const syncId = c.id as string
-    db.update(books)
-      .set({
-        title: c.title as string,
-        author: c.author as string,
-        format: c.format as string,
-        currentCfi: (c.currentCfi as string | null) ?? null,
-        currentPage: (c.currentPage as number | null) ?? null,
-        fileHash: (c.fileHash as string | null) ?? null,
-        fileR2Key: (c.fileR2Key as string | null) ?? null,
-        coverR2Key: (c.coverR2Key as string | null) ?? null,
-        syncVersion,
-        isDirty: 0,
-        isDeleted: (c.isDeleted as boolean) ? 1 : 0
-      })
-      .where(eq(books.syncId, syncId))
-      .run()
+    _applyBookConflictWithDb(getDrizzle(), conflict, syncVersion)
   })
 
   handle('sync:applyHighlightConflict', (_event, conflict, syncVersion) => {
-    const c = conflict
-    const db = getDrizzle()
-    db.update(highlights)
-      .set({
-        text: c.text as string,
-        color: c.color as string,
-        note: (c.note as string | null) ?? '',
-        chapter: (c.chapter as string | null) ?? null,
-        cfiRange: c.cfiRange as string,
-        syncVersion,
-        isDirty: 0,
-        isDeleted: (c.isDeleted as boolean) ? 1 : 0
-      })
-      .where(eq(highlights.id, c.id as string))
-      .run()
+    _applyHighlightConflictWithDb(getDrizzle(), conflict, syncVersion)
   })
 
   handle('sync:applyConversationConflict', (_event, conflict, syncVersion) => {
-    const c = conflict
-    const db = getDrizzle()
-    db.update(conversations)
-      .set({
-        title: c.title as string,
-        bookId: c.bookId as string,
-        syncVersion,
-        isDirty: 0,
-        isDeleted: (c.isDeleted as boolean) ? 1 : 0
-      })
-      .where(eq(conversations.id, c.id as string))
-      .run()
+    _applyConversationConflictWithDb(getDrizzle(), conflict, syncVersion)
   })
 
   // -----------------------------------------------------------------------
@@ -157,185 +452,19 @@ export function registerSyncHandlers(): void {
   // -----------------------------------------------------------------------
 
   handle('sync:upsertBook', (_event, remote) => {
-    const syncId = remote.id as string
-    if (!syncId) return
-
-    const db = getDrizzle()
-    const local = db.select().from(books).where(eq(books.syncId, syncId)).get()
-
-    if (local) {
-      if (local.isDirty === 1) return // locally dirty takes precedence
-
-      const title = typeof remote.title === 'string' ? remote.title : local.title
-      const author = typeof remote.author === 'string' ? remote.author : local.author
-      const format = typeof remote.format === 'string' ? remote.format : local.format
-
-      db.update(books)
-        .set({
-          title,
-          author,
-          format,
-          currentCfi: (remote.currentCfi as string | null) ?? null,
-          currentPage: (remote.currentPage as number | null) ?? null,
-          fileHash: (remote.fileHash as string | null) ?? null,
-          fileR2Key: (remote.fileR2Key as string | null) ?? null,
-          coverR2Key: (remote.coverR2Key as string | null) ?? null,
-          fileSize: (remote.fileSize as number | null) ?? local.fileSize,
-          syncVersion: (remote.syncVersion as number | null) ?? 0,
-          isDirty: 0,
-          isDeleted: (remote.isDeleted as boolean) ? 1 : 0
-        })
-        .where(eq(books.syncId, syncId))
-        .run()
-    } else {
-      // New remote book -- insert with empty local file (needs download)
-      const newTitle = typeof remote.title === 'string' ? remote.title : 'Unknown'
-      const newAuthor = typeof remote.author === 'string' ? remote.author : 'Unknown'
-      const newFormat = typeof remote.format === 'string' ? remote.format : 'epub'
-
-      db.insert(books)
-        .values({
-          kind: newFormat,
-          cover: Buffer.alloc(0),
-          title: newTitle,
-          author: newAuthor,
-          publisher: '',
-          filepath: '',
-          location: (remote.currentCfi as string | null) ?? '',
-          coverKind: 'png',
-          version: 0,
-          syncId,
-          format: newFormat,
-          currentCfi: (remote.currentCfi as string | null) ?? null,
-          currentPage: (remote.currentPage as number | null) ?? null,
-          fileHash: (remote.fileHash as string | null) ?? null,
-          fileR2Key: (remote.fileR2Key as string | null) ?? null,
-          coverR2Key: (remote.coverR2Key as string | null) ?? null,
-          fileSize: (remote.fileSize as number | null) ?? 0,
-          syncVersion: (remote.syncVersion as number | null) ?? 0,
-          isDirty: 0,
-          isDeleted: (remote.isDeleted as boolean) ? 1 : 0
-        })
-        .run()
-    }
+    _upsertBookWithDb(getDrizzle(), remote)
   })
 
   handle('sync:upsertHighlight', (_event, remote) => {
-    const remoteId = remote.id as string
-    if (!remoteId) return
-
-    const db = getDrizzle()
-    const local = db.select().from(highlights).where(eq(highlights.id, remoteId)).get()
-
-    if (local) {
-      if (local.isDirty === 1) return
-      const remoteUpdatedAt = (remote.updatedAt as number | null) ?? 0
-      if (remoteUpdatedAt < (local.updatedAt ?? 0)) return // LWW guard
-
-      const hlText = typeof remote.text === 'string' ? remote.text : local.text
-      const hlColor = typeof remote.color === 'string' ? remote.color : local.color
-
-      db.update(highlights)
-        .set({
-          text: hlText,
-          color: hlColor,
-          note: (remote.note as string | null) ?? '',
-          chapter: (remote.chapter as string | null) ?? null,
-          cfiRange: remote.cfiRange as string,
-          bookId: remote.bookId as string,
-          createdAt: stringFrom(asStringOrNumber(remote.createdAt, '')),
-          updatedAt: remote.updatedAt as number,
-          syncVersion: (remote.syncVersion as number | null) ?? 0,
-          isDirty: 0,
-          isDeleted: (remote.isDeleted as boolean) ? 1 : 0
-        })
-        .where(eq(highlights.id, remoteId))
-        .run()
-    } else {
-      db.insert(highlights)
-        .values({
-          id: remoteId,
-          bookId: (remote.bookId as string | null) ?? '',
-          text: (remote.text as string | null) ?? '',
-          color: (remote.color as string | null) ?? 'yellow',
-          note: (remote.note as string | null) ?? '',
-          chapter: (remote.chapter as string | null) ?? null,
-          cfiRange: (remote.cfiRange as string | null) ?? '',
-          createdAt: stringFrom(asStringOrNumber(remote.createdAt, Date.now())),
-          updatedAt: (remote.updatedAt as number | null) ?? Date.now(),
-          syncVersion: (remote.syncVersion as number | null) ?? 0,
-          isDirty: 0,
-          isDeleted: (remote.isDeleted as boolean) ? 1 : 0
-        })
-        .run()
-    }
+    _upsertHighlightWithDb(getDrizzle(), remote)
   })
 
   handle('sync:upsertConversation', (_event, remote) => {
-    const remoteId = remote.id as string
-    if (!remoteId) return
-
-    const db = getDrizzle()
-    const local = db.select().from(conversations).where(eq(conversations.id, remoteId)).get()
-
-    if (local) {
-      if (local.isDirty === 1) return
-      const remoteUpdatedAt = (remote.updatedAt as number | null) ?? 0
-      if (remoteUpdatedAt < (local.updatedAt ?? 0)) return // LWW guard
-
-      const convTitle = typeof remote.title === 'string' ? remote.title : local.title
-      const convBookId = remote.bookId != null ? (remote.bookId as string) : local.bookId
-
-      db.update(conversations)
-        .set({
-          title: convTitle,
-          bookId: convBookId,
-          createdAt: stringFrom(asStringOrNumber(remote.createdAt, '')),
-          updatedAt: remote.updatedAt as number,
-          syncVersion: (remote.syncVersion as number | null) ?? 0,
-          isDirty: 0,
-          isDeleted: (remote.isDeleted as boolean) ? 1 : 0
-        })
-        .where(eq(conversations.id, remoteId))
-        .run()
-    } else {
-      db.insert(conversations)
-        .values({
-          id: remoteId,
-          bookId: (remote.bookId as string | null) ?? '',
-          title: (remote.title as string | null) ?? 'New conversation',
-          createdAt: stringFrom(asStringOrNumber(remote.createdAt, Date.now())),
-          updatedAt: (remote.updatedAt as number | null) ?? Date.now(),
-          syncVersion: (remote.syncVersion as number | null) ?? 0,
-          isDirty: 0,
-          isDeleted: (remote.isDeleted as boolean) ? 1 : 0
-        })
-        .run()
-    }
+    _upsertConversationWithDb(getDrizzle(), remote)
   })
 
   handle('sync:insertMessage', (_event, remote) => {
-    const remoteId = remote.id as string
-    if (!remoteId) return
-
-    const db = getDrizzle()
-    const existing = db.select().from(messages).where(eq(messages.id, remoteId)).get()
-    if (existing) return // append-only: never update existing messages
-
-    db.insert(messages)
-      .values({
-        id: remoteId,
-        conversationId: (remote.conversationId as string | null) ?? '',
-        role: (remote.role as string | null) ?? 'user',
-        content: (remote.content as string | null) ?? '',
-        sourceChunks: (remote.sourceChunks as string | null) ?? null,
-        createdAt: stringFrom(asStringOrNumber(remote.createdAt, Date.now())),
-        updatedAt: (remote.updatedAt as number | null) ?? Date.now(),
-        syncVersion: (remote.syncVersion as number | null) ?? 0,
-        isDirty: 0,
-        isDeleted: (remote.isDeleted as boolean) ? 1 : 0
-      })
-      .run()
+    _insertMessageWithDb(getDrizzle(), remote)
   })
 
   // -----------------------------------------------------------------------
@@ -343,16 +472,6 @@ export function registerSyncHandlers(): void {
   // -----------------------------------------------------------------------
 
   handle('sync:updateLastVersion', (_event, version) => {
-    const db = getDrizzle()
-    const existing = db.select().from(syncMeta).limit(1).get()
-    const now = new Date().toISOString()
-    if (existing) {
-      db.update(syncMeta)
-        .set({ lastSyncVersion: version, lastSyncAt: now })
-        .where(eq(syncMeta.id, existing.id))
-        .run()
-    } else {
-      db.insert(syncMeta).values({ lastSyncVersion: version, lastSyncAt: now }).run()
-    }
+    _updateLastVersionWithDb(getDrizzle(), version)
   })
 }


### PR DESCRIPTION
Closes #166. Closes #167.

## Summary
- Validate sync IPC payloads (`applyBookConflict`, `applyHighlightConflict`, `applyConversationConflict`, `upsertBook`) with shared zod schemas in `sync.schemas.ts` instead of casting `Record<string, unknown>` field by field. Malformed cloud payloads coerce to safe defaults or fail fast — no garbage in SQLite.
- Wrap multi-statement sync ops in `db.transaction(...)` so a partial failure rolls back.
- Extract the four conflict handlers + mark-clean loops into `_*WithDb` helpers that take an explicit Drizzle instance, enabling true unit tests.

## Test plan
- [x] `pnpm test src/main/ipc/__tests__/sync-validation.test.ts` — 9/9 pass
- [x] `pnpm typecheck` — clean