### PR TITLE
fix(electron/auth): cancel in-flight polls atomically with signOut

### DIFF
--- a/apps/rishi-electron/src/main/auth/auth-service.test.ts
+++ b/apps/rishi-electron/src/main/auth/auth-service.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// auth-service.ts imports `electron` (shell, BrowserWindow). Stub it so the
+// module loads under vitest. Mirrors `queries.test.ts`.
+vi.mock('electron', () => ({
+  shell: { openExternal: vi.fn().mockResolvedValue(undefined) },
+  BrowserWindow: { getAllWindows: () => [] },
+  ipcMain: { handle: () => {} },
+  app: { on: () => {}, getPath: () => '/tmp' }
+}))
+
+// We stub the session-store so we can observe writes vs clears in tests
+// without touching the filesystem or safeStorage.
+const sessionStoreMock = vi.hoisted(() => ({
+  readSession: vi.fn<() => Promise<string | null>>().mockResolvedValue(null),
+  writeSession: vi.fn<(token: string) => Promise<void>>().mockResolvedValue(undefined),
+  clearSession: vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+}))
+
+vi.mock('./session-store', () => sessionStoreMock)
+
+type FetchArgs = [input: RequestInfo | URL, init?: RequestInit]
+type FetchImpl = (...args: FetchArgs) => Promise<Response>
+
+const originalFetch = global.fetch
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  })
+}
+
+describe('AuthService — signOut cancels in-flight polls atomically', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    sessionStoreMock.readSession.mockReset().mockResolvedValue(null)
+    sessionStoreMock.writeSession.mockReset().mockResolvedValue(undefined)
+    sessionStoreMock.clearSession.mockReset().mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('does not write a token to the session store when signOut runs while a poll is in-flight', async () => {
+    // Resolver lets the test hold the /desktop/poll response open until after signOut.
+    let resolvePoll: (res: Response) => void = () => {}
+    const pollResponsePromise = new Promise<Response>((r) => {
+      resolvePoll = r
+    })
+
+    const fetchImpl: FetchImpl = vi.fn(async (input) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.endsWith('/desktop/start')) {
+        return jsonResponse(200, { state: 'state-1' })
+      }
+      if (url.endsWith('/desktop/poll')) {
+        // Slow response — won't resolve until the test releases it.
+        return pollResponsePromise
+      }
+      if (url.endsWith('/desktop/cancel')) {
+        return new Response('', { status: 200 })
+      }
+      if (url.endsWith('/api/auth/sign-out')) {
+        return new Response('', { status: 200 })
+      }
+      if (url.endsWith('/api/auth/get-session')) {
+        return jsonResponse(200, { user: { id: 'u1', email: 'a@b.c' } })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    })
+    global.fetch = fetchImpl as unknown as typeof fetch
+
+    const { authService } = await import('./auth-service')
+
+    // Kick off the magic-link flow → spawns the polling loop in the background.
+    await authService.startMagicLink('a@b.c')
+
+    // signOut while poll is still pending — should abort the in-flight poll
+    // BEFORE clearSession so no late write races in.
+    await authService.signOut()
+
+    // Now let the slow /desktop/poll respond with a 200 + token. This response
+    // was already in-flight when signOut ran — the fix is that the poll
+    // callback short-circuits and never writes.
+    resolvePoll(jsonResponse(200, { session_token: 'late-arriving-token' }))
+
+    // Give the microtask queue a couple of ticks to run the post-await branch.
+    await new Promise((r) => setTimeout(r, 10))
+
+    expect(sessionStoreMock.writeSession).not.toHaveBeenCalled()
+    expect(sessionStoreMock.clearSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes the in-flight poll AbortSignal as aborted after signOut', async () => {
+    const signals: AbortSignal[] = []
+    let resolvePoll: (res: Response) => void = () => {}
+    const pollResponsePromise = new Promise<Response>((r) => {
+      resolvePoll = r
+    })
+
+    const fetchImpl: FetchImpl = vi.fn(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.endsWith('/desktop/start')) {
+        return jsonResponse(200, { state: 'state-2' })
+      }
+      if (url.endsWith('/desktop/poll')) {
+        if (init?.signal) signals.push(init.signal)
+        return pollResponsePromise
+      }
+      if (url.endsWith('/desktop/cancel')) return new Response('', { status: 200 })
+      if (url.endsWith('/api/auth/sign-out')) return new Response('', { status: 200 })
+      throw new Error(`unexpected fetch: ${url}`)
+    })
+    global.fetch = fetchImpl as unknown as typeof fetch
+
+    const { authService } = await import('./auth-service')
+
+    await authService.startMagicLink('b@b.c')
+    // Yield once so the polling loop actually issues its first fetch and we
+    // capture the signal.
+    await new Promise((r) => setTimeout(r, 0))
+
+    await authService.signOut()
+
+    expect(signals.length).toBeGreaterThan(0)
+    expect(signals.every((s) => s.aborted)).toBe(true)
+
+    // Resolve the held poll so the in-flight loop unwinds cleanly.
+    resolvePoll(jsonResponse(200, { session_token: 'never-applied' }))
+    await new Promise((r) => setTimeout(r, 10))
+  })
+
+  it('calling signOut twice does not throw and remains idempotent', async () => {
+    const fetchImpl: FetchImpl = vi.fn(async (input) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.endsWith('/api/auth/sign-out')) return new Response('', { status: 200 })
+      if (url.endsWith('/desktop/cancel')) return new Response('', { status: 200 })
+      throw new Error(`unexpected fetch: ${url}`)
+    })
+    global.fetch = fetchImpl as unknown as typeof fetch
+
+    const { authService } = await import('./auth-service')
+
+    await expect(authService.signOut()).resolves.not.toThrow()
+    await expect(authService.signOut()).resolves.not.toThrow()
+    // clearSession runs each time but writeSession never does
+    expect(sessionStoreMock.writeSession).not.toHaveBeenCalled()
+  })
+})

--- a/apps/rishi-electron/src/main/auth/auth-service.ts
+++ b/apps/rishi-electron/src/main/auth/auth-service.ts
@@ -11,6 +11,7 @@ interface PollHandle {
   state: string
   code_verifier: string
   startedAt: number
+  abort: AbortController
   cancel: () => void
 }
 
@@ -120,19 +121,35 @@ class AuthService {
    * one succeeds and triggers a global session-changed event.
    */
   private startPolling(state: string, code_verifier: string): void {
-    let cancelled = false
+    const abort = new AbortController()
     const handle: PollHandle = {
       state,
       code_verifier,
       startedAt: Date.now(),
+      abort,
       cancel: () => {
-        cancelled = true
+        abort.abort()
       }
     }
     this.polls.set(state, handle)
 
+    // Read the abort flag through a function call rather than a direct
+    // property read on the signal: TS's control-flow analysis narrows
+    // `signal.aborted` to `false` once any earlier check has run, but in
+    // reality `abort.abort()` is invoked externally via `handle.cancel`
+    // (a closure TS can't trace) AND can fire during any `await` window.
+    // A function call defeats the narrowing because TS treats the return
+    // type as `boolean` at every call site. The `while (true)` form is
+    // explicitly permitted by `allowConstantLoopConditions` in
+    // eslint.config.mjs.
+    const isAborted = (): boolean => abort.signal.aborted
     void (async () => {
-      while (!cancelled) {
+      while (true) {
+        if (isAborted()) {
+          // External abort (signOut/cancelAllPolls) — exit cleanly without
+          // re-emitting the delete (already done by cancelAllPolls).
+          return
+        }
         if (Date.now() - handle.startedAt > POLL_TIMEOUT_MS) {
           console.warn('[auth] poll timeout for state', state)
           this.polls.delete(state)
@@ -145,14 +162,27 @@ class AuthService {
           res = await fetch(`${API_URL}/desktop/poll`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ state, code_verifier })
+            body: JSON.stringify({ state, code_verifier }),
+            signal: abort.signal
           })
         } catch (err) {
+          if (isAborted()) {
+            // signOut/cancelAllPolls aborted us mid-flight — exit cleanly.
+            this.polls.delete(state)
+            return
+          }
           // Transient network error — log and try again next tick
           console.warn('[auth] poll fetch failed (will retry)', err)
           // eslint-disable-next-line no-await-in-loop -- Polling loop: backoff between retries.
           await sleep(POLL_INTERVAL_MS)
           continue
+        }
+
+        // Re-check after every await — a signOut that races with a successful
+        // /desktop/poll response must NOT result in a writeSession.
+        if (isAborted()) {
+          this.polls.delete(state)
+          return
         }
 
         if (res.status === 204) {
@@ -165,6 +195,12 @@ class AuthService {
         if (res.status === 200) {
           // eslint-disable-next-line no-await-in-loop -- Polling loop: parse session_token before persisting and exiting.
           const { session_token } = (await res.json()) as { session_token: string }
+          // Double-check post-await: signOut may have aborted while we were
+          // parsing JSON. If so, do NOT persist — that would un-sign-out.
+          if (isAborted()) {
+            this.polls.delete(state)
+            return
+          }
           this.polls.delete(state)
           // A successful sign-in supersedes any other in-flight attempts
           this.cancelAllPolls()
@@ -192,6 +228,13 @@ class AuthService {
   }
 
   async signOut(): Promise<void> {
+    // ORDERING IS LOAD-BEARING: we abort the in-flight poll's AbortController
+    // synchronously, *before* clearing the session store. If we cleared first,
+    // a poll whose 200 response was already in flight could land its
+    // writeSession AFTER the clear and un-sign-out the user. Cancelling first
+    // ensures the poll callback short-circuits on its post-await
+    // `abort.signal.aborted` check.
+    //
     // Capture in-flight poll states before cancelling so we can clean them up
     // server-side too — otherwise stale state/result records sit in Redis until
     // their TTL expires, and a races-with-old-attempt scenario can hand the


### PR DESCRIPTION
Closes #161.

## Summary
- signOut now aborts the in-flight OAuth poll's AbortController BEFORE clearing the token store, so a late-arriving poll response can't un-sign-out the session.
- Poll callback short-circuits if its AbortSignal is already aborted (checked after every `await`).

## Test plan
- [x] `pnpm test src/main/auth/auth-service` — passes (3 new tests)
- [x] `pnpm typecheck` — clean