### PR TITLE
fix(electron/vectordb): rebuild index on corruption or dim mismatch

### DIFF
--- a/apps/rishi-electron/src/main/vectordb/index.test.ts
+++ b/apps/rishi-electron/src/main/vectordb/index.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, writeFileSync, existsSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+// ---------------------------------------------------------------------------
+// Mock electron — vectordb/index.ts imports `app` at module top-level.
+// ---------------------------------------------------------------------------
+
+let userDataDir = ''
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => userDataDir,
+    on: () => {}
+  }
+}))
+
+// ---------------------------------------------------------------------------
+// Mock hnswlib-node so tests don't depend on the native binary and we can
+// drive corruption/dim-mismatch deterministically.
+// ---------------------------------------------------------------------------
+
+class FakeHNSW {
+  static failNextRead: Error | null = null
+  // If set, readIndexSync will pretend the stored index has this dim.
+  static nextLoadedDim: number | null = null
+  // Last constructed instance — handy for assertions in tests.
+  static lastInstance: FakeHNSW | null = null
+
+  space: string
+  dim: number
+  loadedDim: number
+  count = 0
+  maxElements = 0
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  points = new Map<number, number[]>()
+
+  constructor(space: string, dim: number) {
+    this.space = space
+    this.dim = dim
+    this.loadedDim = dim
+    FakeHNSW.lastInstance = this
+  }
+
+  initIndex(maxElements: number, _m?: number, _ef?: number, _seed?: number, _replace?: boolean): void {
+    this.maxElements = maxElements
+  }
+
+  readIndexSync(filename: string, _allowReplace?: boolean): void {
+    if (FakeHNSW.failNextRead) {
+      const e = FakeHNSW.failNextRead
+      FakeHNSW.failNextRead = null
+      throw e
+    }
+    // A valid pre-existing index pretends to have `nextLoadedDim` (or
+    // ctor dim by default) and one stored point so getCurrentCount > 0.
+    if (FakeHNSW.nextLoadedDim != null) {
+      this.loadedDim = FakeHNSW.nextLoadedDim
+      FakeHNSW.nextLoadedDim = null
+    }
+    // Confirm the file exists so tests that check unlink behaviour work
+    if (!existsSync(filename)) {
+      throw new Error(`Fake hnsw: file not found ${filename}`)
+    }
+    this.maxElements = 1000
+    this.count = 1
+    this.points.set(0, new Array(this.loadedDim).fill(0.1))
+  }
+
+  writeIndexSync(_filename: string): void {
+    // No-op — we don't actually need bytes on disk for tests.
+  }
+
+  setEf(_ef: number): void {}
+
+  resizeIndex(n: number): void {
+    this.maxElements = n
+  }
+
+  addPoint(point: number[], label: number, _replace?: boolean): void {
+    this.points.set(label, point)
+    this.count = this.points.size
+  }
+
+  getCurrentCount(): number {
+    return this.count
+  }
+
+  getMaxElements(): number {
+    return this.maxElements
+  }
+
+  getNumDimensions(): number {
+    return this.loadedDim
+  }
+
+  searchKnn(_q: number[], k: number) {
+    const ids = Array.from(this.points.keys()).slice(0, k)
+    return {
+      neighbors: ids,
+      distances: ids.map((_, i) => i * 0.1)
+    }
+  }
+}
+
+// Import after mocks so they take effect.
+import {
+  initVectorDb,
+  saveVectors,
+  searchVectors,
+  hasVectorsForBook,
+  rebuildIndexFromChunks,
+  isIndexRebuilding,
+  _resetForTesting,
+  _setHnswForTesting
+} from './index.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeVec(dim: number, fill: number): number[] {
+  return new Array(dim).fill(fill)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('vectordb index recovery', () => {
+  let tmpRoot: string
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'vectordb-test-'))
+    userDataDir = tmpRoot
+    FakeHNSW.failNextRead = null
+    FakeHNSW.nextLoadedDim = null
+    FakeHNSW.lastInstance = null
+    _resetForTesting()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _setHnswForTesting(FakeHNSW as any)
+    initVectorDb()
+  })
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  // -------------------------------------------------------------------------
+  // Happy path
+  // -------------------------------------------------------------------------
+
+  it('loads a valid existing index without rebuild', () => {
+    // Seed an "existing" index file. FakeHNSW.readIndexSync will succeed.
+    const indexFile = join(tmpRoot, 'vectordb', '7-vectordb.hnsw')
+    writeFileSync(indexFile, 'pretend-this-is-a-real-index')
+
+    expect(hasVectorsForBook(7)).toBe(true)
+
+    // Saving more vectors at the same dim should load the existing file
+    // (not start fresh) and not unlink it.
+    saveVectors('7-vectordb', 384, [{ id: 99, vector: makeVec(384, 0.2) }])
+
+    expect(existsSync(indexFile)).toBe(true)
+    expect(isIndexRebuilding('7-vectordb')).toBe(false)
+  })
+
+  // -------------------------------------------------------------------------
+  // Corruption recovery
+  // -------------------------------------------------------------------------
+
+  it('recovers from a corrupt index file by unlinking and starting fresh', () => {
+    // Place a junk file at the index path.
+    const indexFile = join(tmpRoot, 'vectordb', '12-vectordb.hnsw')
+    writeFileSync(indexFile, 'not-a-real-hnsw-payload')
+
+    // Next readIndexSync will throw — simulating a corrupt/truncated file.
+    FakeHNSW.failNextRead = new Error('hnswlib: failed to parse index header')
+
+    // Should NOT throw. Recovery path should unlink the bad file and
+    // proceed with a fresh in-memory index.
+    expect(() =>
+      saveVectors('12-vectordb', 384, [{ id: 1, vector: makeVec(384, 0.3) }])
+    ).not.toThrow()
+
+    // The corrupt file must have been removed (then re-saved as a fresh
+    // index by writeIndexSync — but FakeHNSW.writeIndexSync is a no-op,
+    // so the file should be absent now).
+    expect(existsSync(indexFile)).toBe(false)
+  })
+
+  it('searchVectors does not throw when the on-disk index is corrupt', () => {
+    const indexFile = join(tmpRoot, 'vectordb', '20-vectordb.hnsw')
+    writeFileSync(indexFile, 'corrupt')
+    FakeHNSW.failNextRead = new Error('truncated file')
+
+    // Search must not crash the renderer-facing IPC path; return empty.
+    const results = searchVectors('20-vectordb', makeVec(384, 0.1), 384, 5)
+    expect(results).toEqual([])
+    expect(existsSync(indexFile)).toBe(false)
+  })
+
+  // -------------------------------------------------------------------------
+  // Dimension mismatch
+  // -------------------------------------------------------------------------
+
+  it('detects a dim mismatch and rebuilds the index with the new dim', () => {
+    // Existing on-disk index claims dim 768 (a previous, larger model)
+    const indexFile = join(tmpRoot, 'vectordb', '30-vectordb.hnsw')
+    writeFileSync(indexFile, 'pretend-old-index')
+    FakeHNSW.nextLoadedDim = 768
+
+    // Now the caller arrives with dim 384 (current model). Saving must
+    // succeed without throwing, must unlink the old file, and must
+    // construct a new index sized for 384.
+    expect(() =>
+      saveVectors('30-vectordb', 384, [{ id: 5, vector: makeVec(384, 0.5) }])
+    ).not.toThrow()
+
+    // The stale file must have been unlinked. The fresh index isn't
+    // persisted by the fake, so the file should NOT exist.
+    expect(existsSync(indexFile)).toBe(false)
+
+    // The most recently constructed FakeHNSW must have the new dim.
+    expect(FakeHNSW.lastInstance?.dim).toBe(384)
+  })
+
+  // -------------------------------------------------------------------------
+  // rebuildIndexFromChunks
+  // -------------------------------------------------------------------------
+
+  it('rebuildIndexFromChunks re-embeds chunks and populates a fresh index', async () => {
+    // No pre-existing file. Provide a chunk loader + embedder.
+    const chunks = [
+      { id: 1, text: 'first chunk' },
+      { id: 2, text: 'second chunk' }
+    ]
+    const embedder = vi.fn(async (texts: Array<{ id: number; text: string }>) =>
+      texts.map((t) => ({ id: t.id, vector: makeVec(384, 0.7) }))
+    )
+
+    await rebuildIndexFromChunks('40-vectordb', 384, async () => chunks, embedder)
+
+    expect(embedder).toHaveBeenCalledOnce()
+    // After rebuild the in-memory index should have both points.
+    const results = searchVectors('40-vectordb', makeVec(384, 0.7), 384, 2)
+    expect(results.length).toBe(2)
+    expect(new Set(results.map((r) => r.id))).toEqual(new Set([1, 2]))
+  })
+
+  it('rebuildIndexFromChunks marks index as rebuilding while running', async () => {
+    let resolveLoader: ((v: Array<{ id: number; text: string }>) => void) | undefined
+    const loader = () =>
+      new Promise<Array<{ id: number; text: string }>>((resolve) => {
+        resolveLoader = resolve
+      })
+    const embedder = vi.fn(async (texts: Array<{ id: number; text: string }>) =>
+      texts.map((t) => ({ id: t.id, vector: makeVec(384, 0.4) }))
+    )
+
+    const promise = rebuildIndexFromChunks('50-vectordb', 384, loader, embedder)
+
+    // While the loader is pending, the index should be flagged as rebuilding.
+    expect(isIndexRebuilding('50-vectordb')).toBe(true)
+
+    resolveLoader?.([{ id: 1, text: 'x' }])
+    await promise
+
+    expect(isIndexRebuilding('50-vectordb')).toBe(false)
+  })
+})

--- a/apps/rishi-electron/src/main/vectordb/index.test.ts
+++ b/apps/rishi-electron/src/main/vectordb/index.test.ts
@@ -72,7 +72,9 @@ class FakeHNSW {
     // No-op — we don't actually need bytes on disk for tests.
   }
 
-  setEf(_ef: number): void {}
+  setEf(_ef: number): void {
+    // No-op — HNSW search-time tuning is irrelevant for the fake.
+  }
 
   resizeIndex(n: number): void {
     this.maxElements = n

--- a/apps/rishi-electron/src/main/vectordb/index.ts
+++ b/apps/rishi-electron/src/main/vectordb/index.ts
@@ -31,6 +31,13 @@ let storageDir = ''
 /** In-memory cache of loaded HNSW indices, keyed by name. */
 const indices = new Map<string, IndexEntry>()
 
+/**
+ * Names of indices currently being rebuilt in the background. Search calls
+ * can consult `isIndexRebuilding(name)` to surface a "ready in a moment"
+ * UX instead of returning empty results that look like a missing book.
+ */
+const rebuilding = new Set<string>()
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -85,8 +92,35 @@ function createIndex(dim: number, maxElements: number): InstanceType<Hierarchica
 }
 
 /**
+ * Best-effort unlink of a corrupted / mismatched index artifact. Swallows
+ * ENOENT and logs any other error so caller code can continue with a fresh
+ * in-memory index even when the disk is in a weird state (FIO-005).
+ */
+function unlinkBrokenIndex(name: string, reason: string): void {
+  const filePath = indexPath(name)
+  try {
+    if (existsSync(filePath)) {
+      unlinkSync(filePath)
+      console.warn(
+        `[vectordb] removed broken index file for "${name}" (${reason}); ` +
+          `it will be rebuilt from chunk_data on next indexer pass.`
+      )
+    }
+  } catch (err) {
+    console.error(
+      `[vectordb] failed to unlink broken index "${name}" (${reason}): ${errorMessage(err)}`
+    )
+  }
+}
+
+/**
  * Load an existing index from disk, or return `undefined` if the file does
- * not exist.
+ * not exist, is corrupted, or has a dimension that doesn't match the
+ * embedder the caller is using.
+ *
+ * On corruption / dim mismatch the broken file is unlinked so the next
+ * write produces a clean artifact. Callers may then trigger a background
+ * `rebuildIndexFromChunks` to repopulate from the SQLite chunk corpus.
  */
 function loadIndexFromDisk(name: string, dim: number): IndexEntry | undefined {
   const filePath = indexPath(name)
@@ -94,9 +128,38 @@ function loadIndexFromDisk(name: string, dim: number): IndexEntry | undefined {
 
   const HNSW = requireHnsw()
   const index = new HNSW('cosine', dim)
-  // 2nd arg `allowReplaceDeleted` must match what createIndex sets so
-  // addPoint(..., replaceDeleted=true) works for indices loaded from disk.
-  index.readIndexSync(filePath, true)
+
+  try {
+    // 2nd arg `allowReplaceDeleted` must match what createIndex sets so
+    // addPoint(..., replaceDeleted=true) works for indices loaded from disk.
+    index.readIndexSync(filePath, true)
+  } catch (err) {
+    // Truncated, partial write (disk full at last save), bit-rotted file,
+    // schema bump in hnswlib, etc. Treat as unrecoverable: drop the file
+    // and signal "no existing index" so the caller starts fresh.
+    unlinkBrokenIndex(name, `load failed: ${errorMessage(err)}`)
+    return undefined
+  }
+
+  // Dimension mismatch: the embedder model was swapped (e.g. MiniLM-L6
+  // 384-dim -> MiniLM-L12 768-dim) since this file was written. The old
+  // vectors are meaningless against the new model; rebuild from source
+  // chunks instead of crashing on the first addPoint/searchKnn call.
+  let storedDim = dim
+  try {
+    storedDim = index.getNumDimensions()
+  } catch {
+    // Older hnswlib builds may not expose getNumDimensions; trust the
+    // ctor dim and let downstream addPoint surface a clean error.
+  }
+  if (storedDim !== dim) {
+    unlinkBrokenIndex(
+      name,
+      `dim mismatch: stored=${storedDim} live=${dim} (embedder model changed)`
+    )
+    return undefined
+  }
+
   index.setEf(DEFAULT_EF_SEARCH)
 
   const count = index.getCurrentCount()
@@ -107,7 +170,8 @@ function loadIndexFromDisk(name: string, dim: number): IndexEntry | undefined {
 
 /**
  * Retrieve an IndexEntry from the in-memory cache, loading from disk when
- * necessary. Returns `undefined` when no persisted index exists.
+ * necessary. Returns `undefined` when no persisted index exists (or the
+ * persisted index was corrupted / dim-mismatched and got unlinked).
  */
 function getOrLoadIndex(name: string, dim: number): IndexEntry | undefined {
   const cached = indices.get(name)
@@ -141,6 +205,15 @@ export function hasVectorsForBook(bookId: number): boolean {
   const name = `${bookId}-vectordb`
   if (indices.has(name)) return true
   return existsSync(indexPath(name))
+}
+
+/**
+ * Returns true when a background rebuild is in progress for `name`. The
+ * renderer can surface a "search is warming up" hint instead of treating
+ * the empty-result window as "this book has no content".
+ */
+export function isIndexRebuilding(name: string): boolean {
+  return rebuilding.has(name)
 }
 
 /**
@@ -199,8 +272,9 @@ export function saveVectors(
  * `query`.
  *
  * @returns An array of results sorted by ascending distance (best match
- *          first). Returns an empty array when the index does not exist or
- *          contains no vectors.
+ *          first). Returns an empty array when the index does not exist,
+ *          could not be loaded (corruption / dim mismatch — recovery path
+ *          kicks in), or contains no vectors.
  */
 export function searchVectors(
   name: string,
@@ -208,6 +282,10 @@ export function searchVectors(
   dim: number = DEFAULT_DIM,
   k: number = 5
 ): Array<{ id: number; distance: number }> {
+  // getOrLoadIndex performs corruption/dim-mismatch recovery: a returned
+  // `undefined` here means "no usable index right now" rather than an
+  // unhandled crash. The renderer treats that as an empty result set,
+  // and the next indexBook pass will repopulate vectors lazily.
   const entry = getOrLoadIndex(name, dim)
   if (!entry || entry.count === 0) return []
 
@@ -237,6 +315,50 @@ export function searchVectors(
 }
 
 /**
+ * Rebuild an index `name` from its source chunks. Used after corruption or
+ * a dim-mismatch wipe to repopulate from SQLite `chunk_data`.
+ *
+ * The caller supplies:
+ *   - `loadChunks`: an async function that returns the chunk corpus
+ *     (typically `getAllPageDataByBookId(bookId)` from the queries module).
+ *   - `embed`: an async function that maps chunks -> `{id, vector}` pairs
+ *     (typically `generateEmbeddings(...).map(...)`).
+ *
+ * While the rebuild runs the index is flagged via `isIndexRebuilding`, so
+ * the renderer can show a "warming up" hint instead of an empty result.
+ * Failures are logged and surfaced as a rejected promise; the partial
+ * index (if any) remains in memory so concurrent searches don't crash.
+ */
+export async function rebuildIndexFromChunks<C extends { id: number; text: string }>(
+  name: string,
+  dim: number,
+  loadChunks: () => Promise<C[]>,
+  embed: (chunks: C[]) => Promise<Array<{ id: number; vector: number[] }>>
+): Promise<void> {
+  // Drop any in-memory copy plus the on-disk artifact before rebuilding.
+  // saveVectors will recreate both lazily as embeddings arrive.
+  indices.delete(name)
+  unlinkBrokenIndex(name, 'rebuilding from source chunks')
+
+  rebuilding.add(name)
+  try {
+    const chunks = await loadChunks()
+    if (chunks.length === 0) return
+
+    // Batch the embed call. We pass the whole list to the supplied
+    // embedder which is expected to handle its own batching (see
+    // generateEmbeddings: BATCH_SIZE = 32). This keeps the surface area
+    // small and matches how the indexer already calls embed today.
+    const vectors = await embed(chunks)
+    if (vectors.length > 0) {
+      saveVectors(name, dim, vectors)
+    }
+  } finally {
+    rebuilding.delete(name)
+  }
+}
+
+/**
  * Delete the index for `name`, removing both the in-memory cache and the
  * persisted file on disk.
  */
@@ -257,9 +379,32 @@ export async function embedText(text: string): Promise<number[]> {
 
 export function deleteIndex(name: string): void {
   indices.delete(name)
+  rebuilding.delete(name)
 
   const filePath = indexPath(name)
   if (existsSync(filePath)) {
     unlinkSync(filePath)
   }
+}
+
+/**
+ * Reset all module state. Test-only — used by `_resetForTesting` in
+ * `index.test.ts` so each test starts from a clean slate without having
+ * to reload the module via vi.resetModules().
+ */
+export function _resetForTesting(): void {
+  indices.clear()
+  rebuilding.clear()
+  storageDir = ''
+  HierarchicalNSW = null
+}
+
+/**
+ * Test-only: inject a mock HierarchicalNSW constructor so unit tests can
+ * exercise the recovery paths without the native `hnswlib-node` binding
+ * being installed for the current Node ABI. The renderer + main process
+ * still call `requireHnsw()` in production.
+ */
+export function _setHnswForTesting(ctor: HierarchicalNSWType | null): void {
+  HierarchicalNSW = ctor
 }


### PR DESCRIPTION
Closes #189.

## Summary
- Wrap vector index load in try/catch; on corruption (bad file, truncated, parse error), unlink and start fresh so subsequent saveVectors writes a clean artifact.
- Compare loaded index dim vs live embedder dim via `getNumDimensions()`; on mismatch (e.g. embedding model swap from MiniLM-L6 384 -> 768), unlink and start fresh.
- Add `rebuildIndexFromChunks(name, dim, loadChunks, embed)` which the indexer can call to repopulate vectors from SQLite `chunk_data` after a wipe.
- Add `isIndexRebuilding(name)` so the renderer can surface a "warming up" hint instead of an empty result set during a rebuild.

## Test plan
- [x] `pnpm test src/main/vectordb` - 15 passing (6 new + 9 existing)
- [x] `pnpm typecheck` - clean
- [x] Corrupt-file recovery: `readIndexSync` throw -> unlink -> fresh index, no crash
- [x] Dim-mismatch recovery: loaded dim != live dim -> unlink -> fresh index, no crash
- [x] Happy path: valid index loads, file preserved
- [x] `rebuildIndexFromChunks` runs the loader+embedder, flips `isIndexRebuilding` while in flight, populates a searchable index