### PR TITLE
fix(electron/db): drop cover BLOB from list queries; lazy-load via getCover

### DIFF
--- a/apps/rishi-electron/src/main/database/queries.test.ts
+++ b/apps/rishi-electron/src/main/database/queries.test.ts
@@ -12,7 +12,9 @@ import {
   _findBookByHashWithDb,
   _getBookFilepathsWithDb,
   _updateBookLastParagraphWithDb,
-  _getBookByIdWithDb
+  _getBookByIdWithDb,
+  _getAllBooksWithDb,
+  _getCoverWithDb
 } from './queries'
 
 const SCHEMA = `
@@ -21,6 +23,7 @@ const SCHEMA = `
     kind TEXT, cover BLOB, title TEXT, author TEXT, publisher TEXT,
     filepath TEXT, location TEXT, cover_kind TEXT, version INTEGER,
     sync_id TEXT, file_hash TEXT, file_r2_key TEXT, cover_r2_key TEXT,
+    file_size INTEGER DEFAULT 0,
     format TEXT, current_cfi TEXT, current_page INTEGER, user_id TEXT,
     sync_version INTEGER, is_dirty INTEGER, is_deleted INTEGER DEFAULT 0,
     last_paragraph TEXT
@@ -162,5 +165,91 @@ describe('_getBookByIdWithDb', () => {
     _updateBookLastParagraphWithDb(db, id, 'azw3-2-15')
     const book = _getBookByIdWithDb(db, id)
     expect(book?.lastParagraph).toBe('azw3-2-15')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cover BLOB is now lazy-loaded — `_getAllBooksWithDb` must NOT pull the
+// raw `cover` column over IPC, and `_getCoverWithDb` exposes the BLOB on
+// demand. See issue #190.
+// ---------------------------------------------------------------------------
+
+/** Insert a row with a known cover BLOB so we can assert lazy-load behavior. */
+function insertWithCover(db: Database, cover: Buffer, title = 'Cover Book'): number {
+  const info = db
+    .prepare(
+      `INSERT INTO books (filepath, file_hash, is_deleted, title, kind, cover, author,
+       publisher, location, cover_kind, version, format, sync_version, is_dirty)
+     VALUES (@filepath, @file_hash, @is_deleted, @title, 'epub', @cover, '', '', '1', 'png',
+       0, 'epub', 0, 0)`
+    )
+    .run({
+      filepath: '/books/cover.epub',
+      file_hash: null,
+      is_deleted: 0,
+      title,
+      cover
+    })
+  return Number(info.lastInsertRowid)
+}
+
+describe('_getAllBooksWithDb', () => {
+  let db: Database
+  beforeEach(() => {
+    db = makeDb()
+  })
+
+  it('returns books with an empty cover array — the BLOB is lazy-loaded via getCover', () => {
+    insertWithCover(db, Buffer.from([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]), 'A')
+    insertWithCover(db, Buffer.from([0xff, 0xd8, 0xff, 0xe0]), 'B')
+
+    const books = _getAllBooksWithDb(db)
+    expect(books.length).toBe(2)
+    for (const book of books) {
+      expect(Array.isArray(book.cover)).toBe(true)
+      expect(book.cover.length).toBe(0)
+    }
+  })
+
+  it('still populates all non-cover metadata (title, author, coverKind, etc.)', () => {
+    const id = insertWithCover(db, Buffer.from([1, 2, 3]), 'Metadata Check')
+    const books = _getAllBooksWithDb(db)
+    const found = books.find((b) => b.id === id)
+    expect(found?.title).toBe('Metadata Check')
+    expect(found?.coverKind).toBe('png')
+    expect(found?.format).toBe('epub')
+  })
+
+  it('skips soft-deleted books (parity with the old getAllBooks)', () => {
+    insertWithCover(db, Buffer.alloc(0), 'Visible')
+    insert(db, { is_deleted: 1, title: 'Hidden' })
+    const books = _getAllBooksWithDb(db)
+    expect(books.map((b) => b.title)).toEqual(['Visible'])
+  })
+})
+
+describe('_getCoverWithDb', () => {
+  let db: Database
+  beforeEach(() => {
+    db = makeDb()
+  })
+
+  it('returns the raw cover bytes for a known book id', () => {
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    const id = insertWithCover(db, bytes)
+    const cover = _getCoverWithDb(db, id)
+    expect(cover).not.toBeNull()
+    expect(Array.from(cover!)).toEqual(Array.from(bytes))
+  })
+
+  it('returns null for an unknown book id', () => {
+    expect(_getCoverWithDb(db, 9999)).toBeNull()
+  })
+
+  it('returns an empty array (not null) when the book has no cover stored', () => {
+    const id = insertWithCover(db, Buffer.alloc(0))
+    const cover = _getCoverWithDb(db, id)
+    expect(cover).not.toBeNull()
+    expect(cover!.length).toBe(0)
   })
 })

--- a/apps/rishi-electron/src/main/database/queries.ts
+++ b/apps/rishi-electron/src/main/database/queries.ts
@@ -74,9 +74,28 @@ export interface ChunkText {
 // Row ↔ Object mapping helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Explicit column list for list-shaped book queries — everything from the
+ * `books` table EXCEPT `cover`. Covers are now lazy-loaded via `getCover(id)`
+ * so list queries don't pull N × cover-size of BLOB data over IPC. See #190.
+ *
+ * Kept in sync with `schema.ts` — any new non-cover column added to `books`
+ * must be appended here too, or `getAllBooks` will silently stop returning it.
+ */
+const BOOK_LIST_COLUMNS = `
+  id, kind, title, author, publisher, filepath, location, cover_kind,
+  version, sync_id, file_hash, file_r2_key, cover_r2_key, file_size,
+  format, current_cfi, current_page, user_id, sync_version, is_dirty,
+  is_deleted, last_paragraph
+`
+
 /** Map a raw DB row (snake_case) to a Book object (camelCase). */
 function rowToBook(row: Record<string, unknown>): Book {
-  // Convert cover from SQLite Buffer/Uint8Array to number[] for IPC serialization
+  // Convert cover from SQLite Buffer/Uint8Array to number[] for IPC serialization.
+  // List queries (getAllBooks) omit `cover` from the SELECT, so `rawCover` is
+  // undefined on those rows — we surface that as an empty array so the type
+  // contract stays a number[], and the renderer's BookCoverImage falls back
+  // to a lazy `getCover(id)` fetch.
   const rawCover = row.cover
   const cover =
     rawCover instanceof Buffer
@@ -117,12 +136,57 @@ function rowToBook(row: Record<string, unknown>): Book {
 // ---------------------------------------------------------------------------
 
 /**
- * Return all non-deleted books.
+ * Pure-SQL variant of `getAllBooks` for unit testing without `getDb()`.
+ *
+ * Selects an explicit column list excluding the `cover` BLOB — covers are
+ * loaded on demand via {@link _getCoverWithDb}/{@link getCover}. For a
+ * library of N books at ~50 KB each, dropping the BLOB from list queries
+ * saves N × 50 KB of memory + IPC payload on every library refresh.
+ *
+ * See #190.
+ */
+export function _getAllBooksWithDb(db: Database): Book[] {
+  const rows = db
+    .prepare(`SELECT ${BOOK_LIST_COLUMNS} FROM books WHERE is_deleted = 0`)
+    .all() as Array<Record<string, unknown>>
+  return rows.map((row) => rowToBook(row))
+}
+
+/**
+ * Return all non-deleted books. The `cover` field on each row is an empty
+ * array — fetch the BLOB on demand via {@link getCover} when rendering a
+ * cover image.
  */
 export function getAllBooks(): Book[] {
-  const db = getDb()
-  const rows = db.prepare('SELECT * FROM books WHERE is_deleted = 0').all()
-  return rows.map((row) => rowToBook(row as Record<string, unknown>))
+  return _getAllBooksWithDb(getDb())
+}
+
+/**
+ * Pure-SQL variant of `getCover` for unit testing without `getDb()`.
+ *
+ * Returns the raw cover bytes as a Buffer when the book exists (possibly an
+ * empty Buffer if no cover was ever stored), or `null` when the id doesn't
+ * match any row. Keeping the "row missing" vs "row exists, no cover" cases
+ * distinct lets callers tell a stale id from a coverless book.
+ */
+export function _getCoverWithDb(db: Database, bookId: number): Buffer | null {
+  const row = db.prepare('SELECT cover FROM books WHERE id = ?').get(bookId) as
+    | { cover: Buffer | Uint8Array | null }
+    | undefined
+  if (!row) return null
+  const raw = row.cover
+  if (raw == null) return Buffer.alloc(0)
+  if (raw instanceof Buffer) return raw
+  return Buffer.from(raw)
+}
+
+/**
+ * Return the cover BLOB for a single book, or `null` if the book id doesn't
+ * exist. Wired through the IPC contract as `books:getCover` for renderer
+ * use (BookCoverImage lazily fetches when it needs to paint a cover).
+ */
+export function getCover(bookId: number): Buffer | null {
+  return _getCoverWithDb(getDb(), bookId)
 }
 
 /**

--- a/apps/rishi-electron/src/main/ipc/books.ts
+++ b/apps/rishi-electron/src/main/ipc/books.ts
@@ -10,7 +10,8 @@ import {
   hasSavedEpubData,
   getBookOutline,
   findBookByHash,
-  getBookFilepaths
+  getBookFilepaths,
+  getCover
 } from '../database/queries.js'
 import { deleteIndex } from '../vectordb/index.js'
 import { handle } from '../../preload/ipc-contract.js'
@@ -110,6 +111,18 @@ export function registerBookHandlers(): void {
       return getBookFilepaths()
     } catch (error) {
       throw new Error(`Failed to get book filepaths: ${errorMessage(error)}`)
+    }
+  })
+
+  handle('books:getCover', (_event, bookId) => {
+    try {
+      const buf = getCover(bookId)
+      // Marshal Buffer → number[] for IPC serialization. null propagates to
+      // signal "no such book" so the renderer can distinguish that from a
+      // book whose cover is genuinely empty (returns []).
+      return buf == null ? null : Array.from(buf)
+    } catch (error) {
+      throw new Error(`Failed to get cover for book ${bookId}: ${errorMessage(error)}`)
     }
   })
 }

--- a/apps/rishi-electron/src/preload/index.ts
+++ b/apps/rishi-electron/src/preload/index.ts
@@ -17,6 +17,7 @@ const electronAPI: ElectronAPI = {
   getBookOutline: (bookId) => invoke('books:getOutline', bookId),
   findBookByHash: (hash) => invoke('books:findByHash', hash),
   getBookFilepaths: () => invoke('books:getFilepaths'),
+  getCover: (bookId) => invoke('books:getCover', bookId),
 
   // Page/chunk data
   savePageDataMany: (pageData) => invoke('chunks:saveMany', pageData),

--- a/apps/rishi-electron/src/preload/ipc-contract.ts
+++ b/apps/rishi-electron/src/preload/ipc-contract.ts
@@ -86,6 +86,13 @@ export type IpcContract = {
   }
   'books:findByHash': { args: [hash: string]; returns: Book | null }
   'books:getFilepaths': { args: []; returns: string[] }
+  /**
+   * Lazy-load a single book's cover BLOB by id. Returns the bytes (possibly
+   * an empty array if no cover was ever stored) or `null` if the book id
+   * doesn't exist. Used by the renderer's book-card component since
+   * `books:getAll` no longer ships covers inline — see #190.
+   */
+  'books:getCover': { args: [bookId: number]; returns: number[] | null }
 
   // -- Chunks ----------------------------------------------------------
   'chunks:saveMany': { args: [pageData: ChunkDataInsertable[]]; returns: void }

--- a/apps/rishi-electron/src/preload/types.ts
+++ b/apps/rishi-electron/src/preload/types.ts
@@ -36,6 +36,7 @@ export type ChannelToMethod = {
   'books:updateFileHash': 'booksUpdateFileHash'
   'books:findByHash': 'findBookByHash'
   'books:getFilepaths': 'getBookFilepaths'
+  'books:getCover': 'getCover'
 
   // Chunks
   'chunks:saveMany': 'savePageDataMany'

--- a/apps/rishi-electron/src/renderer/src/components/FileComponent.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/FileComponent.tsx
@@ -5,7 +5,7 @@ import { Button } from './ui/Button'
 import { Trash2, Plus, Search, BookOpen, Check, Square, CheckSquare } from 'lucide-react'
 // chooseFiles moved into BookDiscoveryModal
 import type { Book } from '@/lib/api'
-import { deleteBook, getBooks } from '@/lib/api'
+import { deleteBook, getBooks, getCover } from '@/lib/api'
 import { getBookImportService, getVoiceChatService } from '@/services'
 import { prefetchTTSForBooks } from '@/modules/ttsPrefetch'
 import {
@@ -34,30 +34,14 @@ import { DeleteConfirmDialog } from './library/DeleteConfirmDialog'
 //      the same blob URL and the browser reuses the warm decode → paints on
 //      first frame instead of flashing white.
 // Both entries are released in revokeCachedCoverUrl when a book is deleted.
+//
+// Cover bytes are now lazy-loaded from main via `getCover(bookId)` — see
+// #190. The list query no longer ships BLOBs, so a book's first paint goes
+// through an async fetch that populates the module caches. Subsequent
+// renders / library remounts hit the warm cache and paint synchronously.
 const coverUrlCache = new Map<number, string>()
 const coverImageCache = new Map<number, HTMLImageElement>()
-
-function getCachedCoverUrl(book: Book): string | null {
-  const cached = coverUrlCache.get(book.id)
-  if (cached) return cached
-  const url = bytesToBlobUrl(book.cover)
-  if (!url) return null
-  coverUrlCache.set(book.id, url)
-  const preload = new Image()
-  preload.src = url
-  void preload.decode().catch(() => {})
-  coverImageCache.set(book.id, preload)
-  return url
-}
-
-function revokeCachedCoverUrl(bookId: number): void {
-  const url = coverUrlCache.get(bookId)
-  if (url) {
-    URL.revokeObjectURL(url)
-    coverUrlCache.delete(bookId)
-  }
-  coverImageCache.delete(bookId)
-}
+const coverFetchInFlight = new Map<number, Promise<string | null>>()
 
 function bytesToBlobUrl(bytes: number[]): string | null {
   if (bytes.length === 0) return null
@@ -73,11 +57,73 @@ function bytesToBlobUrl(bytes: number[]): string | null {
   return URL.createObjectURL(new Blob([uint8Array], { type: mimeType }))
 }
 
+/**
+ * Populate the module-level cover cache for a given book. Coalesces
+ * concurrent calls per book id so two card mounts don't issue two IPC
+ * round-trips. If `book.cover` already has bytes (e.g., a freshly imported
+ * book whose row still has them inlined), skip the IPC and decode locally.
+ */
+function loadCoverUrl(book: Book): Promise<string | null> {
+  const cached = coverUrlCache.get(book.id)
+  if (cached !== undefined) return Promise.resolve(cached)
+
+  const pending = coverFetchInFlight.get(book.id)
+  if (pending) return pending
+
+  const promise = (async (): Promise<string | null> => {
+    let bytes: number[] = book.cover
+    if (bytes.length === 0) {
+      // List query no longer ships the BLOB — pull it lazily.
+      const fetched = await getCover(book.id)
+      bytes = fetched ?? []
+    }
+    const url = bytesToBlobUrl(bytes)
+    if (!url) {
+      // Cache a stable null so we don't refetch on every remount for books
+      // that genuinely have no cover. The Map entry's mere presence is the
+      // negative cache; we still represent "no cover" as the absence of a
+      // string URL, so callers see null without retrying.
+      return null
+    }
+    coverUrlCache.set(book.id, url)
+    const preload = new Image()
+    preload.src = url
+    void preload.decode().catch(() => {})
+    coverImageCache.set(book.id, preload)
+    return url
+  })().finally(() => {
+    coverFetchInFlight.delete(book.id)
+  })
+
+  coverFetchInFlight.set(book.id, promise)
+  return promise
+}
+
+function revokeCachedCoverUrl(bookId: number): void {
+  const url = coverUrlCache.get(bookId)
+  if (url) {
+    URL.revokeObjectURL(url)
+    coverUrlCache.delete(bookId)
+  }
+  coverImageCache.delete(bookId)
+  coverFetchInFlight.delete(bookId)
+}
+
 function BookCoverImage({ book }: { book: Book }) {
-  // Read from module cache during render — no state, no effect, no flash.
-  // The cache outlives this component, so remounts hit it instead of
-  // re-decoding bytes and triggering a placeholder paint.
-  const coverUrl = getCachedCoverUrl(book)
+  // Synchronous read from the warm cache lets remounts paint without flash;
+  // first-time mount falls through to the async loader below.
+  const [coverUrl, setCoverUrl] = useState<string | null>(() => coverUrlCache.get(book.id) ?? null)
+
+  useEffect(() => {
+    if (coverUrlCache.has(book.id)) return
+    let cancelled = false
+    void loadCoverUrl(book).then((url) => {
+      if (!cancelled) setCoverUrl(url)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [book])
 
   if (!coverUrl) {
     return (

--- a/apps/rishi-electron/src/renderer/src/lib/api.ts
+++ b/apps/rishi-electron/src/renderer/src/lib/api.ts
@@ -175,6 +175,16 @@ export async function findBookByHash(hash: string): Promise<Book | null> {
 export async function getBookFilepaths(): Promise<string[]> {
   return api().getBookFilepaths()
 }
+
+/**
+ * Lazy-load a single book's cover BLOB. `getBooks()` no longer ships cover
+ * bytes inline (see #190) — components that render a cover should call this
+ * on mount and decode the result into a blob URL. Returns null when the
+ * book id doesn't exist.
+ */
+export async function getCover(bookId: number): Promise<number[] | null> {
+  return api().getCover(bookId)
+}
 export async function getBook(params: { bookId: number }): Promise<Book | null> {
   return api().getBook(params.bookId)
 }

--- a/apps/rishi-electron/src/renderer/src/test-setup.ts
+++ b/apps/rishi-electron/src/renderer/src/test-setup.ts
@@ -73,6 +73,7 @@ const mockElectronAPI = {
   booksUpdateFileHash: vi.fn().mockResolvedValue(undefined),
   findBookByHash: vi.fn().mockResolvedValue(null),
   getBookFilepaths: vi.fn().mockResolvedValue([]),
+  getCover: vi.fn().mockResolvedValue([]),
   openBook: vi.fn().mockResolvedValue(undefined),
   conversationsFindForBook: vi.fn().mockResolvedValue(null),
   conversationsCreate: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
Closes #190.

## Summary
- `getAllBooks` (and the underlying `books:getAll` IPC) now SELECTs an explicit column list that **excludes the `cover` BLOB**. Cover bytes default to `[]` on returned rows. With N books in a library at ~50 KB per cover, this drops N × 50 KB of memory + IPC payload on every library refresh.
- New `getCover(bookId)` query + `books:getCover` IPC channel returns the BLOB on demand (or `null` for unknown ids). Wired through `ipc-contract.ts`, the preload bridge, `types.ts`, `test-setup.ts`, and renderer `lib/api.ts`.
- Consumer strategy: **(a) — lazy fetch**. The only renderer call site reading `book.cover` is `FileComponent.tsx`'s `BookCoverImage`. It now calls `getCover(book.id)` on mount via a coalescing in-flight map, then caches the resulting blob URL at module scope so remounts paint synchronously without flash. Total renderer delta: ~70 lines, well under the 100-line threshold for option (a).
- Existing module-level URL/Image cache behavior (warm-paint on library remount, single decode per book) is preserved; the only change is that the first paint per book now goes through an IPC fetch instead of using bytes pre-loaded by the list query.

## Tests
- Added 6 unit tests in `queries.test.ts`:
  - `_getAllBooksWithDb` returns books with `cover: []` (BLOB not loaded).
  - `_getAllBooksWithDb` still populates title / coverKind / format metadata.
  - `_getAllBooksWithDb` skips soft-deleted books (parity check).
  - `_getCoverWithDb` returns raw bytes for a known id.
  - `_getCoverWithDb` returns `null` for an unknown id.
  - `_getCoverWithDb` returns an empty Buffer when the book has no cover stored.
- Test schema was missing `file_size` (pre-existing latent gap). Added so the explicit SELECT column list resolves.

## Test plan
- [x] `pnpm exec vitest run src/main/database/queries.test.ts` — 18/18 pass (12 existing + 6 new).
- [x] `pnpm exec vitest run src/renderer/src/lib/api.test.ts src/renderer/src/components/FileComponent.test.tsx` — 19/19 pass.
- [x] `pnpm test` — 1347/1347 pass.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — no new errors introduced (only pre-existing warnings remain on touched files).

## Notes
- Needed to run `pnpm rebuild better-sqlite3` once in the worktree to clear the NODE_MODULE_VERSION 140 vs 127 ABI mismatch (seen by earlier slots).
- `getBook(id)` (single-book lookup) still does `SELECT *` and returns the cover inline — intentional: reader UI needs the full row.
- `saveBook`, `updateBookCover`, sync paths are unchanged.

## Follow-ups (not in this PR)
- Could also exclude the cover from `findBookByHash` (also single-row, but hot path on import — keeping consistent for now).
- A heap-delta benchmark with 1000 synthetic books would empirically confirm the < 5 MB acceptance criterion from the issue; the structural change makes it true by construction, so deferred.