### PR TITLE
chore(electron): auto-fix lint pass on main (#219 part 1/2)

### DIFF
--- a/apps/rishi-electron/e2e/navigation-history-epub.spec.ts
+++ b/apps/rishi-electron/e2e/navigation-history-epub.spec.ts
@@ -105,9 +105,9 @@ test.describe('Navigation history — EPUB', () => {
     const tocVisible = await tocPanel.isVisible({ timeout: 5000 }).catch(() => false)
     if (!tocVisible) {
       // Try the sheet-based ReaderTOC (used in EPUB via ReactReader).
-      await expect(
-        bookPage.locator('text=Table of Contents').first()
-      ).toBeVisible({ timeout: 5000 })
+      await expect(bookPage.locator('text=Table of Contents').first()).toBeVisible({
+        timeout: 5000
+      })
     }
 
     // Click the first TOC entry button.
@@ -197,46 +197,52 @@ test.describe('Navigation history — EPUB', () => {
 
     // Dispatch JUMP_REQUESTED as if an internal link was clicked: from the
     // current page back to the initial CFI.
-    await bookPage.evaluate((cfis) => {
-      // Import via the module's singleton. The actor is a module-level const
-      // so it is reachable at runtime via the store exposed on __rishi.
-      // We reach it by dynamically importing from the renderer's module graph.
-      // Simpler: dispatch through the window event that triggers the same path.
-      const w = window as unknown as {
-        __rishi?: {
-          epubStore: { getState: () => { currentEpubLocation: string } }
+    await bookPage.evaluate(
+      (cfis) => {
+        // Import via the module's singleton. The actor is a module-level const
+        // so it is reachable at runtime via the store exposed on __rishi.
+        // We reach it by dynamically importing from the renderer's module graph.
+        // Simpler: dispatch through the window event that triggers the same path.
+        const w = window as unknown as {
+          __rishi?: {
+            epubStore: { getState: () => { currentEpubLocation: string } }
+          }
         }
-      }
-      if (!w.__rishi) throw new Error('window.__rishi not exposed')
+        if (!w.__rishi) throw new Error('window.__rishi not exposed')
 
-      // The navigation history actor is a singleton imported by EpubView.
-      // We can't import ES modules at page.evaluate time, so we dispatch a
-      // synthetic CustomEvent that EpubView doesn't listen to. Instead, we
-      // reach the actor via a globally-accessible reference that EpubView
-      // attaches during its effect.
-      //
-      // Fallback: import the actor from the module bundle via window.__rishiNavActor
-      // if it was exposed. Since it isn't, we trigger the same DOM codepath by
-      // synthesising a click on an anchor inside the epub iframe.
-      //
-      // This evaluate just captures the CFIs we need; the actual dispatch
-      // happens in the next evaluate block.
-      return cfis
-    }, { from: fromCfi, to: initialCfi })
+        // The navigation history actor is a singleton imported by EpubView.
+        // We can't import ES modules at page.evaluate time, so we dispatch a
+        // synthetic CustomEvent that EpubView doesn't listen to. Instead, we
+        // reach the actor via a globally-accessible reference that EpubView
+        // attaches during its effect.
+        //
+        // Fallback: import the actor from the module bundle via window.__rishiNavActor
+        // if it was exposed. Since it isn't, we trigger the same DOM codepath by
+        // synthesising a click on an anchor inside the epub iframe.
+        //
+        // This evaluate just captures the CFIs we need; the actual dispatch
+        // happens in the next evaluate block.
+        return cfis
+      },
+      { from: fromCfi, to: initialCfi }
+    )
 
     // Dispatch JUMP_REQUESTED via the navigationHistoryActor singleton,
     // exposed on window.__rishi by testing/expose-stores.ts.
-    await bookPage.evaluate((cfis: { from: string; to: string }) => {
-      // @ts-expect-error — runtime-exposed via testing/expose-stores.ts
-      window.__rishi.navigationHistoryActor.send({
-        type: 'JUMP_REQUESTED',
-        from: { kind: 'epub', cfi: cfis.from },
-        fromTts: null,
-        to: { kind: 'epub', cfi: cfis.to },
-        source: 'link',
-        fromLabel: 'previous spot'
-      })
-    }, { from: fromCfi, to: initialCfi })
+    await bookPage.evaluate(
+      (cfis: { from: string; to: string }) => {
+        // @ts-expect-error — runtime-exposed via testing/expose-stores.ts
+        window.__rishi.navigationHistoryActor.send({
+          type: 'JUMP_REQUESTED',
+          from: { kind: 'epub', cfi: cfis.from },
+          fromTts: null,
+          to: { kind: 'epub', cfi: cfis.to },
+          source: 'link',
+          fromLabel: 'previous spot'
+        })
+      },
+      { from: fromCfi, to: initialCfi }
+    )
 
     // Pill should appear.
     await waitForPill(bookPage)
@@ -291,6 +297,9 @@ test.describe('Navigation history — EPUB', () => {
     await bookPage.waitForTimeout(500)
 
     // Assert the pill is NOT present — page-flips are not jumps.
-    await expect(bookPage.locator('[data-testid="nav-history-back-label"]'), 'pill must not appear on sequential page-flips').toHaveCount(0)
+    await expect(
+      bookPage.locator('[data-testid="nav-history-back-label"]'),
+      'pill must not appear on sequential page-flips'
+    ).toHaveCount(0)
   })
 })

--- a/apps/rishi-electron/e2e/navigation-history-pdf.spec.ts
+++ b/apps/rishi-electron/e2e/navigation-history-pdf.spec.ts
@@ -135,9 +135,9 @@ test.describe('Navigation history — PDF', () => {
     await bookPage.waitForTimeout(3000)
 
     // Confirm the reader mounted.
-    await expect(
-      bookPage.locator('[data-testid="pdf-scroll-container"]').first()
-    ).toBeVisible({ timeout: 15000 })
+    await expect(bookPage.locator('[data-testid="pdf-scroll-container"]').first()).toBeVisible({
+      timeout: 15000
+    })
 
     // Read total pages (from any rendered data-page-number attribute).
     const totalPages = await bookPage.evaluate(() => {
@@ -215,9 +215,9 @@ test.describe('Navigation history — PDF', () => {
     const bookPage = await openBook(app.page, book.id)
     await bookPage.waitForTimeout(3000)
 
-    await expect(
-      bookPage.locator('[data-testid="pdf-scroll-container"]').first()
-    ).toBeVisible({ timeout: 15000 })
+    await expect(bookPage.locator('[data-testid="pdf-scroll-container"]').first()).toBeVisible({
+      timeout: 15000
+    })
 
     const totalPages = await bookPage.evaluate(() => {
       const all = Array.from(document.querySelectorAll('[data-page-number]'))

--- a/apps/rishi-electron/e2e/pdf-footer-detection.spec.ts
+++ b/apps/rishi-electron/e2e/pdf-footer-detection.spec.ts
@@ -100,13 +100,10 @@ test('builds a non-empty FooterMask for a book with running footers', async () =
 // We need an item-position debug helper to assert positions live in the bottom
 // band; rather than expand `expose-stores.ts` from a test, fixme this case so
 // the architect/implementer can opt into it.
-test.fixme(
-  'masked items live in the bottom band',
-  async () => {
-    // TODO: extend `window.__rishi` with a `getPageItemPositions(bookId, page)`
-    // helper, then assert each masked item's transform[5] < 0.15 * page.view height.
-  }
-)
+test.fixme('masked items live in the bottom band', async () => {
+  // TODO: extend `window.__rishi` with a `getPageItemPositions(bookId, page)`
+  // helper, then assert each masked item's transform[5] < 0.15 * page.view height.
+})
 
 test('paragraph indices stay stable when the heuristic engages (gaps preserved)', async () => {
   const app: LaunchedApp = await launchApp()

--- a/apps/rishi-electron/e2e/pdf-next-paragraph-snap-back.spec.ts
+++ b/apps/rishi-electron/e2e/pdf-next-paragraph-snap-back.spec.ts
@@ -69,9 +69,9 @@ test('NEXT on last paragraph of page N lands on page N+1 and does not snap back 
 
     // Confirm the reader mounted and at least two pages of paragraphs are
     // available — the bug only manifests when crossing a page boundary.
-    await expect(
-      bookPage.locator('[data-testid="pdf-scroll-container"]').first()
-    ).toBeVisible({ timeout: 15000 })
+    await expect(bookPage.locator('[data-testid="pdf-scroll-container"]').first()).toBeVisible({
+      timeout: 15000
+    })
 
     // Wait until pdfStore has paragraphs for page 1 (the source page). Page 2's
     // text is rendered lazily by the virtualizer once we scroll there, so we
@@ -93,11 +93,7 @@ test('NEXT on last paragraph of page N lands on page N+1 and does not snap back 
         }
         const s = w.__rishi?.pdfStore.getState()
         if (!s) return false
-        return (
-          s.pageCount >= 2 &&
-          !!s.pageNumberToPageData[1] &&
-          s.currentViewParagraphs.length > 0
-        )
+        return s.pageCount >= 2 && !!s.pageNumberToPageData[1] && s.currentViewParagraphs.length > 0
       },
       undefined,
       { timeout: 30000 }
@@ -131,8 +127,7 @@ test('NEXT on last paragraph of page N lands on page N+1 and does not snap back 
       for (let i = 0; i < dataSize; i++) u8[44 + i] = 0x80
       const noop = (): void => {}
       w.__rishi.setTestTtsService({
-        requestAudio: async () =>
-          URL.createObjectURL(new Blob([u8], { type: 'audio/wav' })),
+        requestAudio: async () => URL.createObjectURL(new Blob([u8], { type: 'audio/wav' })),
         cancelRequest: () => true,
         cancelBookRequests: noop,
         clearBookCache: async () => {},
@@ -158,7 +153,8 @@ test('NEXT on last paragraph of page N lands on page N+1 and does not snap back 
       return {
         pageNumber: s.pageNumber,
         paragraphCount: s.currentViewParagraphs.length,
-        lastParagraphIndex: s.currentViewParagraphs[s.currentViewParagraphs.length - 1]?.index ?? null
+        lastParagraphIndex:
+          s.currentViewParagraphs[s.currentViewParagraphs.length - 1]?.index ?? null
       }
     })
     console.log('[diag] startState:', JSON.stringify(startState))
@@ -284,10 +280,9 @@ test('NEXT on last paragraph of page N lands on page N+1 and does not snap back 
     expect(before.viewIndexes, 'before-click: page-1 paragraph indexes').toContain(
       advanceResult.lastIndex
     )
-    expect(
-      before.activeIndex,
-      'before-click: active paragraph is last paragraph of page 1'
-    ).toBe(advanceResult.lastIndex)
+    expect(before.activeIndex, 'before-click: active paragraph is last paragraph of page 1').toBe(
+      advanceResult.lastIndex
+    )
 
     // ===== THE ACTION: NEXT on last paragraph of page 1 =====
     // This is exactly what the user does ("click next paragraph"). When the
@@ -369,12 +364,10 @@ test('NEXT on last paragraph of page N lands on page N+1 and does not snap back 
           }
         }
       }
-      const page2Paragraphs = w.__rishi.playerStore
-        .getState()
-        .currentParagraphs.filter((p) => {
-          const n = Number(p.index)
-          return Number.isFinite(n) && n >= 20000 && n < 30000
-        })
+      const page2Paragraphs = w.__rishi.playerStore.getState().currentParagraphs.filter((p) => {
+        const n = Number(p.index)
+        return Number.isFinite(n) && n >= 20000 && n < 30000
+      })
       const first = page2Paragraphs[0]
       if (!first) throw new Error('page-2 paragraphs not published to playerStore')
       // Simulate the playerMachine advancing to page 2's first paragraph.
@@ -424,9 +417,7 @@ test('NEXT on last paragraph of page N lands on page N+1 and does not snap back 
         playerState: string
         flag: boolean
       }> = []
-      const container = document.querySelector<HTMLElement>(
-        '[data-testid="pdf-scroll-container"]'
-      )
+      const container = document.querySelector<HTMLElement>('[data-testid="pdf-scroll-container"]')
       while (performance.now() - start < 3000) {
         const pdf = w.__rishi.pdfStore.getState()
         const player = w.__rishi.playerStore.getState()

--- a/apps/rishi-electron/e2e/pdf-scroll-position.spec.ts
+++ b/apps/rishi-electron/e2e/pdf-scroll-position.spec.ts
@@ -91,9 +91,7 @@ test('PDF sub-page scroll position persists across close + reopen', async () => 
       if (!scroller) return -1
       const scrollerTop = scroller.getBoundingClientRect().top
       const targetY = scrollerTop + 1
-      const nodes = Array.from(
-        document.querySelectorAll<HTMLElement>('[data-page-number]')
-      )
+      const nodes = Array.from(document.querySelectorAll<HTMLElement>('[data-page-number]'))
       let best: { num: number; dist: number } | null = null
       for (const node of nodes) {
         const rect = node.getBoundingClientRect()

--- a/apps/rishi-electron/e2e/resume-paragraph.spec.ts
+++ b/apps/rishi-electron/e2e/resume-paragraph.spec.ts
@@ -14,7 +14,9 @@ interface PlayerMachineSnapshot {
   resumeParagraphIndex: string | null
 }
 
-async function readMachineContext(page: import('@playwright/test').Page): Promise<PlayerMachineSnapshot> {
+async function readMachineContext(
+  page: import('@playwright/test').Page
+): Promise<PlayerMachineSnapshot> {
   // The renderer exposes the playerStore on window.__rishi but the xstate
   // actor's context isn't exposed directly. We assert on visible store fields
   // that mirror the machine context (paragraphIndex via activeParagraph's
@@ -88,9 +90,11 @@ test.describe('resume from last-played paragraph', () => {
     // 3. Persist that id via the real IPC + DB query path.
     await app.page.evaluate(
       async ({ bookId, lastParagraph }) => {
-        const e = (window as unknown as {
-          electron: { updateBookLastParagraph: (id: number, p: string | null) => Promise<void> }
-        }).electron
+        const e = (
+          window as unknown as {
+            electron: { updateBookLastParagraph: (id: number, p: string | null) => Promise<void> }
+          }
+        ).electron
         await e.updateBookLastParagraph(bookId, lastParagraph)
       },
       { bookId: book.id, lastParagraph: resumeId }

--- a/apps/rishi-electron/electron-builder.yml
+++ b/apps/rishi-electron/electron-builder.yml
@@ -35,7 +35,7 @@ asarUnpack:
 mac:
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
-    - NSMicrophoneUsageDescription: "Rishi needs microphone access for voice chat features."
+    - NSMicrophoneUsageDescription: 'Rishi needs microphone access for voice chat features.'
   notarize: true
   target:
     - target: dmg
@@ -57,7 +57,7 @@ win:
       arch:
         - x64
 nsis:
-  artifactName: "Rishi-${version}-setup.${ext}"
+  artifactName: 'Rishi-${version}-setup.${ext}'
 linux:
   target:
     - target: AppImage

--- a/apps/rishi-electron/src/main/database/queries.test.ts
+++ b/apps/rishi-electron/src/main/database/queries.test.ts
@@ -30,7 +30,7 @@ const SCHEMA = `
 function makeDb(): Database {
   const db = new BetterSqlite3(':memory:')
   // better-sqlite3 multi-statement DDL goes through Database#exec.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   ;(db as any).exec(SCHEMA)
   return db
 }

--- a/apps/rishi-electron/src/main/ipc/books.ts
+++ b/apps/rishi-electron/src/main/ipc/books.ts
@@ -77,9 +77,7 @@ export function registerBookHandlers(): void {
     try {
       return void updateBookLastParagraph(bookId, lastParagraph)
     } catch (error) {
-      throw new Error(
-        `Failed to update last paragraph for book ${bookId}: ${errorMessage(error)}`
-      )
+      throw new Error(`Failed to update last paragraph for book ${bookId}: ${errorMessage(error)}`)
     }
   })
 

--- a/apps/rishi-electron/src/renderer/src/components/BookDiscoveryModal.test.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/BookDiscoveryModal.test.tsx
@@ -16,8 +16,7 @@ function renderWithClient(ui: React.ReactElement) {
 const importBatch = vi.fn<(paths: string[]) => Promise<ImportResult[]>>()
 const startDiscovery = vi.fn()
 const cancelDiscovery = vi.fn<() => Promise<void>>()
-const onDiscoveryEvent =
-  vi.fn<(cb: (event: DiscoveryEvent) => void) => () => void>()
+const onDiscoveryEvent = vi.fn<(cb: (event: DiscoveryEvent) => void) => () => void>()
 const openBook = vi.fn<(id: number) => Promise<void>>()
 
 let discoveryListener: ((event: DiscoveryEvent) => void) | null = null
@@ -34,9 +33,8 @@ vi.mock('@/services', async () => {
 })
 
 vi.mock('@tanstack/react-query', async () => {
-  const actual = await vi.importActual<typeof import('@tanstack/react-query')>(
-    '@tanstack/react-query'
-  )
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
   return {
     ...actual,
     useQueryClient: () => ({ invalidateQueries: vi.fn().mockResolvedValue(undefined) })
@@ -87,9 +85,7 @@ beforeEach(() => {
   })
   openBook.mockReset().mockResolvedValue(undefined)
   ;(window.electron as unknown as { openBook: typeof openBook }).openBook = openBook
-  ;(window.electron.getBookFilepaths as ReturnType<typeof vi.fn>) = vi
-    .fn()
-    .mockResolvedValue([])
+  ;(window.electron.getBookFilepaths as ReturnType<typeof vi.fn>) = vi.fn().mockResolvedValue([])
 })
 
 describe('BookDiscoveryModal selection behavior', () => {
@@ -235,9 +231,7 @@ describe('BookDiscoveryModal selection behavior', () => {
 describe('BookDiscoveryModal post-import behavior', () => {
   it('closes the wizard after the import resolves (regardless of success)', async () => {
     const onClose = vi.fn()
-    importBatch.mockResolvedValue([
-      { ok: true, bookId: 1, filePath: '/docs/a.pdf', format: 'pdf' }
-    ])
+    importBatch.mockResolvedValue([{ ok: true, bookId: 1, filePath: '/docs/a.pdf', format: 'pdf' }])
     renderWithClient(<BookDiscoveryModal open={true} onClose={onClose} />)
     await waitFor(() => expect(window.electron.getBookFilepaths).toHaveBeenCalled())
     emitBooks([makeBook({ filepath: '/docs/a.pdf', folder: '/docs' })])
@@ -306,9 +300,7 @@ describe('BookDiscoveryModal post-import behavior', () => {
       { ok: false, filePath: '/docs/dupe.pdf', stage: 'duplicate', error: 'Already in library' }
     ])
     renderWithClient(<BookDiscoveryModal open={true} onClose={onClose} />)
-    await waitFor(() =>
-      expect(window.electron.getBookFilepaths).toHaveBeenCalled()
-    )
+    await waitFor(() => expect(window.electron.getBookFilepaths).toHaveBeenCalled())
     emitBooks([makeBook({ filepath: '/docs/dupe.pdf', folder: '/docs' })])
 
     fireEvent.click(screen.getByRole('checkbox', { name: /select dupe\.pdf/i }))
@@ -341,9 +333,7 @@ describe('BookDiscoveryModal post-import behavior', () => {
 
 describe('BookDiscoveryModal discovery filter', () => {
   beforeEach(() => {
-    ;(window.electron.getBookFilepaths as ReturnType<typeof vi.fn>) = vi
-      .fn()
-      .mockResolvedValue([])
+    ;(window.electron.getBookFilepaths as ReturnType<typeof vi.fn>) = vi.fn().mockResolvedValue([])
   })
 
   it('hides discovered books whose filepath is already in the library', async () => {
@@ -355,9 +345,7 @@ describe('BookDiscoveryModal discovery filter', () => {
 
     // Wait for the filepath query to resolve before emitting books — the
     // wizard buffers book-found events until the existing-paths query is ready.
-    await waitFor(() =>
-      expect(window.electron.getBookFilepaths).toHaveBeenCalled()
-    )
+    await waitFor(() => expect(window.electron.getBookFilepaths).toHaveBeenCalled())
 
     emitBooks([
       makeBook({ filepath: '/docs/already.pdf', folder: '/docs' }),
@@ -375,9 +363,7 @@ describe('BookDiscoveryModal discovery filter', () => {
 
     renderWithClient(<BookDiscoveryModal open={true} onClose={vi.fn()} />)
 
-    await waitFor(() =>
-      expect(window.electron.getBookFilepaths).toHaveBeenCalled()
-    )
+    await waitFor(() => expect(window.electron.getBookFilepaths).toHaveBeenCalled())
 
     emitBooks([
       makeBook({ filepath: '/docs/a.pdf', folder: '/docs' }),

--- a/apps/rishi-electron/src/renderer/src/components/BookDiscoveryModal.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/BookDiscoveryModal.tsx
@@ -456,9 +456,7 @@ export function BookDiscoveryModal({ open, onClose }: BookDiscoveryModalProps) {
                                   {book.author}
                                 </span>
                               ) : null}
-                              <span className="text-xs text-gray-400 uppercase">
-                                {book.format}
-                              </span>
+                              <span className="text-xs text-gray-400 uppercase">{book.format}</span>
                               <span className="text-xs text-gray-400">
                                 {formatFileSize(book.fileSize)}
                               </span>
@@ -502,7 +500,7 @@ export function BookDiscoveryModal({ open, onClose }: BookDiscoveryModalProps) {
         </div>
 
         {/* Bulk-import confirmation */}
-        {confirmOpen && (
+        {confirmOpen ? (
           <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/40">
             <div
               role="dialog"
@@ -539,7 +537,7 @@ export function BookDiscoveryModal({ open, onClose }: BookDiscoveryModalProps) {
               </div>
             </div>
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/apps/rishi-electron/src/renderer/src/components/auth/__tests__/PremiumFeatureDialog.test.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/auth/__tests__/PremiumFeatureDialog.test.tsx
@@ -33,9 +33,7 @@ describe('PremiumFeatureDialog (consumes shared FEATURE_COPY)', () => {
   })
 
   it("renders the shared FEATURE_COPY body as the dialog description for 'ai-chat'", () => {
-    render(
-      <PremiumFeatureDialog open={true} onOpenChange={() => {}} feature="ai-chat" />,
-    )
+    render(<PremiumFeatureDialog open={true} onOpenChange={() => {}} feature="ai-chat" />)
     expect(screen.getByText(FEATURE_COPY['ai-chat'].body)).toBeInTheDocument()
   })
 
@@ -52,9 +50,7 @@ describe('PremiumFeatureDialog (consumes shared FEATURE_COPY)', () => {
 
   it("calls onOpenChange(false) when 'Maybe later' is clicked", () => {
     const onOpenChange = vi.fn()
-    render(
-      <PremiumFeatureDialog open={true} onOpenChange={onOpenChange} feature="tts" />,
-    )
+    render(<PremiumFeatureDialog open={true} onOpenChange={onOpenChange} feature="tts" />)
     fireEvent.click(screen.getByText('Maybe later'))
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })

--- a/apps/rishi-electron/src/renderer/src/components/azw3/Azw3View.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/azw3/Azw3View.tsx
@@ -526,13 +526,9 @@ export default function Azw3View({ book }: { book: Book }): React.JSX.Element {
   // event wiring.
   const reconcileTts = useCallback(
     (desired: string | null) => {
-      reconcileAzw3TtsHighlight(
-        iframeRef.current?.contentDocument ?? null,
-        chapterIndex,
-        desired,
-      )
+      reconcileAzw3TtsHighlight(iframeRef.current?.contentDocument ?? null, chapterIndex, desired)
     },
-    [chapterIndex],
+    [chapterIndex]
   )
   useTtsHighlightReconciler(reconcileTts, iframeEl)
 
@@ -564,11 +560,11 @@ export default function Azw3View({ book }: { book: Book }): React.JSX.Element {
         const totalPages = pagesInCurrentChapterRef.current
         const targetPage = Math.max(
           0,
-          Math.min(totalPages - 1, Math.floor(elementLeftFromBodyStart / pageStep)),
+          Math.min(totalPages - 1, Math.floor(elementLeftFromBodyStart / pageStep))
         )
         const applied = applyScrollToPage(doc, win, targetPage, totalPages, pageStep)
         setPageWithinChapter((prev) => (prev === applied ? prev : applied))
-      },
+      }
     )
     return unsub
   }, [applyScrollToPage, chapterIndex])
@@ -717,48 +713,51 @@ export default function Azw3View({ book }: { book: Book }): React.JSX.Element {
 
   return (
     <div ref={readerRootRef} className="relative h-full">
-    <div className="relative h-screen flex flex-col" style={{ background: themeStyle.background }}>
-      <div className="flex-1 overflow-hidden">
-        {loading ? (
-          <div className="flex items-center justify-center h-full">
-            <div
-              className="animate-spin rounded-full h-8 w-8 border-2 border-current border-t-transparent"
-              style={{ color: themeStyle.color }}
+      <div
+        className="relative h-screen flex flex-col"
+        style={{ background: themeStyle.background }}
+      >
+        <div className="flex-1 overflow-hidden">
+          {loading ? (
+            <div className="flex items-center justify-center h-full">
+              <div
+                className="animate-spin rounded-full h-8 w-8 border-2 border-current border-t-transparent"
+                style={{ color: themeStyle.color }}
+              />
+            </div>
+          ) : chapterUrl ? (
+            <iframe
+              // Force a fresh DOM node per chapter so React tears down and
+              // recreates the iframe — guarantees a clean onLoad fires and
+              // prevents stale `contentDocument` reads between src change and
+              // load completion.
+              key={chapterIndex}
+              ref={handleIframeRef}
+              src={chapterUrl}
+              onLoad={handleIframeLoad}
+              className="w-full h-full border-none"
+              title={book.title}
+              // `allow-scripts` is required so that KF8 books containing inline
+              // scripts or `<iframe srcdoc=...>` subframes can finish laying
+              // out — without it, real publisher AZW3s render blank ("Blocked
+              // script execution in 'about:srcdoc'"). Matches what foliate-js's
+              // own paginator uses on its iframes (see paginator.js).
+              sandbox="allow-same-origin allow-scripts"
+              style={{ background: themeStyle.background }}
             />
-          </div>
-        ) : chapterUrl ? (
-          <iframe
-            // Force a fresh DOM node per chapter so React tears down and
-            // recreates the iframe — guarantees a clean onLoad fires and
-            // prevents stale `contentDocument` reads between src change and
-            // load completion.
-            key={chapterIndex}
-            ref={handleIframeRef}
-            src={chapterUrl}
-            onLoad={handleIframeLoad}
-            className="w-full h-full border-none"
-            title={book.title}
-            // `allow-scripts` is required so that KF8 books containing inline
-            // scripts or `<iframe srcdoc=...>` subframes can finish laying
-            // out — without it, real publisher AZW3s render blank ("Blocked
-            // script execution in 'about:srcdoc'"). Matches what foliate-js's
-            // own paginator uses on its iframes (see paginator.js).
-            sandbox="allow-same-origin allow-scripts"
-            style={{ background: themeStyle.background }}
-          />
-        ) : null}
-      </div>
+          ) : null}
+        </div>
 
-      {/* Side-edge navigation arrows — same component the EPUB reader uses
+        {/* Side-edge navigation arrows — same component the EPUB reader uses
           so the two readers share the same UX. */}
-      <NavigationArrows
-        onPrev={goPrevPage}
-        onNext={goNextPage}
-        hidePrev={atFirstPage}
-        hideNext={atLastPage}
-      />
+        <NavigationArrows
+          onPrev={goPrevPage}
+          onNext={goNextPage}
+          hidePrev={atFirstPage}
+          hideNext={atLastPage}
+        />
 
-      {/* Subtle bottom page counter — "X" by default, "X of Y" on hover.
+        {/* Subtle bottom page counter — "X" by default, "X of Y" on hover.
           Values are global page numbers (summed across all measured
           chapters) so the counter advances monotonically across chapter
           boundaries instead of resetting to 1. Until a chapter is
@@ -766,94 +765,94 @@ export default function Azw3View({ book }: { book: Book }): React.JSX.Element {
           the visible "of N" falls back to '?' before any chapters are
           measured. Tests rely on data-current / data-total so they don't
           depend on hover-state text. */}
-      {chapterCount > 0 && (
-        <div
-          data-testid="azw3-page-counter"
-          data-current={globalCurrent}
-          data-total={globalTotal || globalCurrent}
-          className="group/page"
-          style={{
-            position: 'fixed',
-            bottom: 0,
-            left: 0,
-            right: 0,
-            textAlign: 'center',
-            zIndex: 5,
-            padding: '8px 0',
-            pointerEvents: 'none'
-          }}
-        >
-          <span
+        {chapterCount > 0 && (
+          <div
+            data-testid="azw3-page-counter"
+            data-current={globalCurrent}
+            data-total={globalTotal || globalCurrent}
+            className="group/page"
             style={{
-              fontSize: 12,
-              color: themeStyle.color,
-              opacity: 0.4
+              position: 'fixed',
+              bottom: 0,
+              left: 0,
+              right: 0,
+              textAlign: 'center',
+              zIndex: 5,
+              padding: '8px 0',
+              pointerEvents: 'none'
             }}
           >
-            <span>{globalCurrent}</span>
-            <span className="hidden group-hover/page:inline"> of {globalTotal || '?'}</span>
-          </span>
-        </div>
-      )}
-
-      {/* AI chat orb, voice chat launcher, and TTS controls */}
-      <ReaderOverlayControls
-        bookId={book.id.toString()}
-        chatPanelOpen={chatPanelOpen}
-        onChatOrbClick={() => setChatPanelOpen((prev) => !prev)}
-      />
-
-      <ReaderTOC
-        open={tocOpen}
-        onOpenChange={setTocOpen}
-        title="Navigation"
-        bookSyncId={bookSyncId}
-        onBookmarkNavigate={(location) => {
-          const parsed = parseLocation(location)
-          if (parsed.chapter >= 0) {
-            // Dispatch a JUMP_REQUESTED before navigating so the history
-            // machine records the "from" anchor and can offer resume later.
-            const currentPos = formatLocation(chapterIndex, pageWithinChapter)
-            const activeParagraph = usePlayerStore.getState().activeParagraph
-            const indexStr = activeParagraph?.index
-            const paragraphIndex = indexStr != null ? Number(indexStr) : null
-            const fromTts =
-              paragraphIndex != null && Number.isFinite(paragraphIndex)
-                ? { paragraphIndex }
-                : null
-            navigationHistoryActor.send({
-              type: 'JUMP_REQUESTED',
-              from: { kind: formatKind, cfi: currentPos },
-              fromTts,
-              to: { kind: formatKind, cfi: location },
-              source: 'bookmark',
-              fromLabel: 'previous spot'
-            })
-            // Land on the persisted page within the chapter.
-            pendingPageAfterLoadRef.current = parsed.page
-            setChapterIndex(parsed.chapter)
-            setTocOpen(false)
-          }
-        }}
-        tocContent={
-          <div className="p-4 text-gray-400 text-sm text-center">
-            Chapter {chapterIndex + 1} of {chapterCount}
+            <span
+              style={{
+                fontSize: 12,
+                color: themeStyle.color,
+                opacity: 0.4
+              }}
+            >
+              <span>{globalCurrent}</span>
+              <span className="hidden group-hover/page:inline"> of {globalTotal || '?'}</span>
+            </span>
           </div>
-        }
-      />
+        )}
 
-      {AuthDialog}
+        {/* AI chat orb, voice chat launcher, and TTS controls */}
+        <ReaderOverlayControls
+          bookId={book.id.toString()}
+          chatPanelOpen={chatPanelOpen}
+          onChatOrbClick={() => setChatPanelOpen((prev) => !prev)}
+        />
 
-      <ChatPanel
-        bookId={book.id}
-        bookSyncId={bookSyncId}
-        bookTitle={book.title}
-        rendition={null}
-        open={chatPanelOpen}
-        onOpenChange={setChatPanelOpen}
-      />
-    </div>
-    <NavigationHistoryFooter />
+        <ReaderTOC
+          open={tocOpen}
+          onOpenChange={setTocOpen}
+          title="Navigation"
+          bookSyncId={bookSyncId}
+          onBookmarkNavigate={(location) => {
+            const parsed = parseLocation(location)
+            if (parsed.chapter >= 0) {
+              // Dispatch a JUMP_REQUESTED before navigating so the history
+              // machine records the "from" anchor and can offer resume later.
+              const currentPos = formatLocation(chapterIndex, pageWithinChapter)
+              const activeParagraph = usePlayerStore.getState().activeParagraph
+              const indexStr = activeParagraph?.index
+              const paragraphIndex = indexStr != null ? Number(indexStr) : null
+              const fromTts =
+                paragraphIndex != null && Number.isFinite(paragraphIndex)
+                  ? { paragraphIndex }
+                  : null
+              navigationHistoryActor.send({
+                type: 'JUMP_REQUESTED',
+                from: { kind: formatKind, cfi: currentPos },
+                fromTts,
+                to: { kind: formatKind, cfi: location },
+                source: 'bookmark',
+                fromLabel: 'previous spot'
+              })
+              // Land on the persisted page within the chapter.
+              pendingPageAfterLoadRef.current = parsed.page
+              setChapterIndex(parsed.chapter)
+              setTocOpen(false)
+            }
+          }}
+          tocContent={
+            <div className="p-4 text-gray-400 text-sm text-center">
+              Chapter {chapterIndex + 1} of {chapterCount}
+            </div>
+          }
+        />
+
+        {AuthDialog}
+
+        <ChatPanel
+          bookId={book.id}
+          bookSyncId={bookSyncId}
+          bookTitle={book.title}
+          rendition={null}
+          open={chatPanelOpen}
+          onOpenChange={setChatPanelOpen}
+        />
+      </div>
+      <NavigationHistoryFooter />
     </div>
   )
 }

--- a/apps/rishi-electron/src/renderer/src/components/azw3/reconcileTtsHighlight.ts
+++ b/apps/rishi-electron/src/renderer/src/components/azw3/reconcileTtsHighlight.ts
@@ -14,14 +14,14 @@ import { findParagraphElement, parseParagraphIndex, TTS_ACTIVE_CLASS } from './h
 export function reconcileAzw3TtsHighlight(
   iframeDoc: Document | null,
   currentChapterIndex: number,
-  desiredIndex: string | null,
+  desiredIndex: string | null
 ): void {
   if (!iframeDoc) return
 
   let desiredEl: Element | null = null
   if (desiredIndex) {
     const parsed = parseParagraphIndex(desiredIndex)
-    if (parsed && parsed.chapter === currentChapterIndex) {
+    if (parsed?.chapter === currentChapterIndex) {
       desiredEl = findParagraphElement(iframeDoc, parsed.paragraph)
     }
   }

--- a/apps/rishi-electron/src/renderer/src/components/epub/EpubView.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/epub/EpubView.tsx
@@ -91,9 +91,7 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
   // a stale id from a different format would otherwise be handed to epubjs,
   // which silently ignores it and opens at the start of the book.
   const resumeCfi = book.lastParagraph?.startsWith('epubcfi(') ? book.lastParagraph : null
-  const [currentLocation, setCurrentLocation] = useState<string>(
-    resumeCfi || book.location || '0'
-  )
+  const [currentLocation, setCurrentLocation] = useState<string>(resumeCfi || book.location || '0')
   // Sync with book.location when it changes from a refetch (e.g., returning from library).
   // Only sync before the rendition has settled to avoid overriding user navigation.
   const bookLocationRef = useRef(book.location)
@@ -382,7 +380,7 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
     if (!iframeDoc) return
     // Re-create the overlay if the iframe doc changed (page reflow can
     // swap iframes). Cheap to construct; no state inside.
-    if (!noteIconOverlayRef.current || noteIconOverlayRef.current.iframeDoc !== iframeDoc) {
+    if (noteIconOverlayRef.current?.iframeDoc !== iframeDoc) {
       noteIconOverlayRef.current?.destroy()
       noteIconOverlayRef.current = new NoteIconOverlay({
         iframeDoc,
@@ -419,18 +417,11 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
         highlightsByRangeRef.current.set(cfi, hl)
         // Note-only rows have no SVG mark — skip the highlightRange call.
         if (isNoteOnly(hl)) continue
-        void highlightRange(
-          rendition,
-          cfi,
-          {},
-          makeAnnotationClickCb(cfi),
-          'epubjs-hl',
-          {
-            fill: getHighlightHex(hl.color as HighlightColor),
-            'fill-opacity': '0.3',
-            'mix-blend-mode': 'multiply'
-          }
-        )
+        void highlightRange(rendition, cfi, {}, makeAnnotationClickCb(cfi), 'epubjs-hl', {
+          fill: getHighlightHex(hl.color as HighlightColor),
+          'fill-opacity': '0.3',
+          'mix-blend-mode': 'multiply'
+        })
       }
       refreshNoteIcons()
     })
@@ -979,7 +970,6 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
       position: { kind: 'epub', cfi: currentLocation },
       ttsContext
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentLocation])
 
   // Navigation history: RESUME_REQUESTED → display the stored CFI
@@ -1315,7 +1305,7 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
           // row and saved.
           const row = editingNoteRow
           setEditingNoteRow(null)
-          if (!row || !row.cfiRange) return
+          if (!row?.cfiRange) return
           const cfi = row.cfiRange
           const live = highlightsByRangeRef.current.get(cfi) ?? row
           if (isNoteOnly(live) && live.note.trim().length === 0 && live.cfiRange) {
@@ -1326,9 +1316,7 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
                 getSyncService().triggerWrite()
                 refreshNoteIcons()
               })
-              .catch((err: unknown) =>
-                console.warn('[note] orphan cleanup failed:', err)
-              )
+              .catch((err: unknown) => console.warn('[note] orphan cleanup failed:', err))
           }
         }}
         onSaved={async () => {
@@ -1349,9 +1337,9 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
           const fresh = highlightsByRangeRef.current.get(editedCfi)
           if (!fresh) return
           const hasNote = fresh.note.trim().length > 0
-          setInlinePopover((prev) => (prev && prev.cfiRange === editedCfi ? { ...prev, hasNote } : prev))
+          setInlinePopover((prev) => (prev?.cfiRange === editedCfi ? { ...prev, hasNote } : prev))
           setSelectionTargetHighlight((prev) =>
-            prev && prev.cfiRange === editedCfi ? { ...prev, hasNote } : prev
+            prev?.cfiRange === editedCfi ? { ...prev, hasNote } : prev
           )
           // Re-paint the in-iframe icons so a freshly-added note surfaces
           // its marker immediately, and one that was cleared disappears.

--- a/apps/rishi-electron/src/renderer/src/components/epub/EpubView.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/epub/EpubView.tsx
@@ -91,7 +91,7 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
   // a stale id from a different format would otherwise be handed to epubjs,
   // which silently ignores it and opens at the start of the book.
   const resumeCfi = book.lastParagraph?.startsWith('epubcfi(') ? book.lastParagraph : null
-  const [currentLocation, setCurrentLocation] = useState<string>(resumeCfi || book.location || '0')
+  const [currentLocation, setCurrentLocation] = useState<string>(resumeCfi ?? book.location ?? '0')
   // Sync with book.location when it changes from a refetch (e.g., returning from library).
   // Only sync before the rendition has settled to avoid overriding user navigation.
   const bookLocationRef = useRef(book.location)
@@ -976,7 +976,7 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
   useEffect(() => {
     return onResumeRequested((anchor) => {
       if (anchor.position.kind !== 'epub') return
-      renditionRef.current?.display(anchor.position.cfi)
+      void renditionRef.current?.display(anchor.position.cfi)
     })
   }, [])
 

--- a/apps/rishi-electron/src/renderer/src/components/epub/reconcileTtsHighlight.test.ts
+++ b/apps/rishi-electron/src/renderer/src/components/epub/reconcileTtsHighlight.test.ts
@@ -5,7 +5,7 @@ const removeHighlightMock = vi.fn().mockResolvedValue(true)
 
 vi.mock('@/modules/epubwrapper', () => ({
   highlightRange: (...args: unknown[]) => highlightRangeMock(...args),
-  removeHighlight: (...args: unknown[]) => removeHighlightMock(...args),
+  removeHighlight: (...args: unknown[]) => removeHighlightMock(...args)
 }))
 
 import { createEpubTtsReconciler } from './reconcileTtsHighlight'

--- a/apps/rishi-electron/src/renderer/src/components/highlights/HighlightActionPopover.test.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/highlights/HighlightActionPopover.test.tsx
@@ -18,8 +18,9 @@ describe('HighlightActionPopover', () => {
   it('renders a swatch per HIGHLIGHT_COLORS entry, plus a note button and Delete button', () => {
     render(<HighlightActionPopover {...baseProps()} />)
     for (const c of HIGHLIGHT_COLORS) {
-      expect(screen.getByRole('button', { name: new RegExp(`change.*${c.name}`, 'i') }))
-        .toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: new RegExp(`change.*${c.name}`, 'i') })
+      ).toBeInTheDocument()
     }
     expect(screen.getByRole('button', { name: /add note/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /delete highlight/i })).toBeInTheDocument()
@@ -88,8 +89,9 @@ describe('HighlightActionPopover', () => {
     it("does not render color swatches when currentColor is 'none'", () => {
       render(<HighlightActionPopover {...baseProps()} currentColor={'none' as never} />)
       for (const c of HIGHLIGHT_COLORS) {
-        expect(screen.queryByRole('button', { name: new RegExp(`change.*${c.name}`, 'i') }))
-          .toBeNull()
+        expect(
+          screen.queryByRole('button', { name: new RegExp(`change.*${c.name}`, 'i') })
+        ).toBeNull()
       }
     })
 
@@ -99,7 +101,7 @@ describe('HighlightActionPopover', () => {
       expect(screen.getByRole('button', { name: /delete highlight/i })).toBeInTheDocument()
     })
 
-    it("fires onEditNote when the note button is clicked on a note-only popover", () => {
+    it('fires onEditNote when the note button is clicked on a note-only popover', () => {
       const props = baseProps()
       render(<HighlightActionPopover {...props} currentColor={'none' as never} />)
       fireEvent.click(screen.getByRole('button', { name: /add note/i }))

--- a/apps/rishi-electron/src/renderer/src/components/highlights/HighlightActionPopover.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/highlights/HighlightActionPopover.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { MessageSquarePlus, MessageSquareText, Trash2 } from 'lucide-react'
-import {
-  HIGHLIGHT_COLORS,
-  NOTE_COLOR_NONE,
-  type HighlightColor
-} from '@/types/highlight'
+import { HIGHLIGHT_COLORS, NOTE_COLOR_NONE, type HighlightColor } from '@/types/highlight'
 
 export interface HighlightActionPopoverProps {
   position: { x: number; y: number }
@@ -62,31 +58,32 @@ export function HighlightActionPopover({
       style={{ left: position.x, top: position.y }}
     >
       <div className="flex items-center gap-2">
-        {currentColor !== NOTE_COLOR_NONE && HIGHLIGHT_COLORS.map((c) => {
-          const isCurrent = c.name === currentColor
-          return (
-            <button
-              key={c.name}
-              type="button"
-              aria-pressed={isCurrent}
-              aria-label={`Change to ${c.name}`}
-              title={`Change to ${c.name}`}
-              className={
-                'rounded-full border border-gray-300/50 transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-blue-500 ' +
-                (isCurrent ? 'ring-2 ring-inset ring-blue-500' : '')
-              }
-              style={{
-                width: 28,
-                height: 28,
-                backgroundColor: c.hex
-              }}
-              onClick={() => {
-                onSelectColor(c.name)
-                onClose()
-              }}
-            />
-          )
-        })}
+        {currentColor !== NOTE_COLOR_NONE &&
+          HIGHLIGHT_COLORS.map((c) => {
+            const isCurrent = c.name === currentColor
+            return (
+              <button
+                key={c.name}
+                type="button"
+                aria-pressed={isCurrent}
+                aria-label={`Change to ${c.name}`}
+                title={`Change to ${c.name}`}
+                className={
+                  'rounded-full border border-gray-300/50 transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-blue-500 ' +
+                  (isCurrent ? 'ring-2 ring-inset ring-blue-500' : '')
+                }
+                style={{
+                  width: 28,
+                  height: 28,
+                  backgroundColor: c.hex
+                }}
+                onClick={() => {
+                  onSelectColor(c.name)
+                  onClose()
+                }}
+              />
+            )
+          })}
 
         <button
           type="button"
@@ -103,7 +100,11 @@ export function HighlightActionPopover({
             onClose()
           }}
         >
-          {hasNote ? <MessageSquareText size={16} /> : <MessageSquarePlus size={16} className="text-gray-700 dark:text-gray-200" />}
+          {hasNote ? (
+            <MessageSquareText size={16} />
+          ) : (
+            <MessageSquarePlus size={16} className="text-gray-700 dark:text-gray-200" />
+          )}
         </button>
 
         <button

--- a/apps/rishi-electron/src/renderer/src/components/highlights/HighlightsPanel.test.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/highlights/HighlightsPanel.test.tsx
@@ -55,7 +55,7 @@ beforeEach(() => {
 })
 
 describe('HighlightsPanel — note-only support', () => {
-  it("renders a distinct (non-transparent, non-highlight-color) border strip for a note-only row so users can tell them apart from colored highlights", async () => {
+  it('renders a distinct (non-transparent, non-highlight-color) border strip for a note-only row so users can tell them apart from colored highlights', async () => {
     ;(getHighlightsForBook as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
       row({ id: 'note-only', color: NOTE_COLOR_NONE, note: 'a thought' })
     ])
@@ -122,7 +122,11 @@ describe('HighlightsPanel — note-only support', () => {
     fireEvent.click(screen.getByRole('button', { name: /delete highlight/i }))
 
     await waitFor(() => expect(deleteHighlightWithUndoMock).toHaveBeenCalledTimes(1))
-    const args = (deleteHighlightWithUndoMock as unknown as { lastArgs: { target: { applyVisual: () => Promise<void> } } }).lastArgs
+    const args = (
+      deleteHighlightWithUndoMock as unknown as {
+        lastArgs: { target: { applyVisual: () => Promise<void> } }
+      }
+    ).lastArgs
     await args.target.applyVisual()
     // The note-only row has no SVG mark to restore — applyVisual must be a
     // pure no-op that never calls into epubjs.
@@ -150,7 +154,11 @@ describe('HighlightsPanel — note-only support', () => {
     fireEvent.click(screen.getByRole('button', { name: /delete highlight/i }))
 
     await waitFor(() => expect(deleteHighlightWithUndoMock).toHaveBeenCalledTimes(1))
-    const args = (deleteHighlightWithUndoMock as unknown as { lastArgs: { target: { applyVisual: () => Promise<void> } } }).lastArgs
+    const args = (
+      deleteHighlightWithUndoMock as unknown as {
+        lastArgs: { target: { applyVisual: () => Promise<void> } }
+      }
+    ).lastArgs
     await args.target.applyVisual()
     expect(highlightRangeMock).toHaveBeenCalledTimes(1)
   })

--- a/apps/rishi-electron/src/renderer/src/components/highlights/SelectionPopover.test.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/highlights/SelectionPopover.test.tsx
@@ -49,8 +49,9 @@ describe('SelectionPopover', () => {
     it('color swatches remain visible in fresh-selection mode alongside the Add note button', () => {
       render(<SelectionPopover {...baseProps} onAddNote={vi.fn()} />)
       for (const c of HIGHLIGHT_COLORS) {
-        expect(screen.getByRole('button', { name: new RegExp(`highlight.*${c.name}`, 'i') }))
-          .toBeInTheDocument()
+        expect(
+          screen.getByRole('button', { name: new RegExp(`highlight.*${c.name}`, 'i') })
+        ).toBeInTheDocument()
       }
     })
 
@@ -88,9 +89,7 @@ describe('SelectionPopover', () => {
     })
 
     it('renders note and Delete buttons when handlers are provided', () => {
-      render(
-        <SelectionPopover {...baseProps} onEditNote={vi.fn()} onDelete={vi.fn()} />
-      )
+      render(<SelectionPopover {...baseProps} onEditNote={vi.fn()} onDelete={vi.fn()} />)
       expect(screen.getByRole('button', { name: /add note/i })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /delete highlight/i })).toBeInTheDocument()
     })
@@ -127,7 +126,7 @@ describe('SelectionPopover', () => {
       expect(onClose).toHaveBeenCalledTimes(1)
     })
 
-    it('onDelete must work even when the caller-supplied handler captures its target via closure (regression: parent inlinePopover state may be cleared by a sibling popover\'s outside-click race before the click fires)', () => {
+    it("onDelete must work even when the caller-supplied handler captures its target via closure (regression: parent inlinePopover state may be cleared by a sibling popover's outside-click race before the click fires)", () => {
       // Simulate: parent renders SelectionPopover with onDelete that
       // captures a cfiRange in a closure (not derived from live state).
       // After render, the parent's state is wiped — yet the captured
@@ -135,9 +134,7 @@ describe('SelectionPopover', () => {
       const deletedCfis: string[] = []
       const capturedCfi = 'cfi:captured'
       const onDelete = () => deletedCfis.push(capturedCfi)
-      render(
-        <SelectionPopover {...baseProps} onEditNote={vi.fn()} onDelete={onDelete} />
-      )
+      render(<SelectionPopover {...baseProps} onEditNote={vi.fn()} onDelete={onDelete} />)
       fireEvent.click(screen.getByRole('button', { name: /delete highlight/i }))
       expect(deletedCfis).toEqual([capturedCfi])
     })
@@ -149,9 +146,7 @@ describe('SelectionPopover', () => {
     })
 
     it('note button is labelled "View note" when hasNote is true (visual indicator that a note exists)', () => {
-      render(
-        <SelectionPopover {...baseProps} onEditNote={vi.fn()} onDelete={vi.fn()} hasNote />
-      )
+      render(<SelectionPopover {...baseProps} onEditNote={vi.fn()} onDelete={vi.fn()} hasNote />)
       expect(screen.getByRole('button', { name: /view note/i })).toBeInTheDocument()
       expect(screen.queryByRole('button', { name: /^add note/i })).toBeNull()
     })

--- a/apps/rishi-electron/src/renderer/src/components/highlights/SelectionPopover.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/highlights/SelectionPopover.tsx
@@ -130,7 +130,11 @@ export function SelectionPopover({
               onClose()
             }}
           >
-            {hasNote ? <MessageSquareText size={16} /> : <MessageSquarePlus size={16} className="text-gray-700 dark:text-gray-200" />}
+            {hasNote ? (
+              <MessageSquareText size={16} />
+            ) : (
+              <MessageSquarePlus size={16} className="text-gray-700 dark:text-gray-200" />
+            )}
           </button>
         ) : null}
         {onDelete ? (

--- a/apps/rishi-electron/src/renderer/src/components/highlights/createHighlightClickHandler.test.ts
+++ b/apps/rishi-electron/src/renderer/src/components/highlights/createHighlightClickHandler.test.ts
@@ -32,9 +32,7 @@ function makeIframe(rect: Partial<DOMRect>): HTMLElement {
 
 function makeView(iframe: HTMLElement | null) {
   return {
-    element: iframe
-      ? ({ querySelector: () => iframe } as unknown as HTMLDivElement)
-      : undefined
+    element: iframe ? ({ querySelector: () => iframe } as unknown as HTMLDivElement) : undefined
   }
 }
 

--- a/apps/rishi-electron/src/renderer/src/components/highlights/highlightClickPosition.test.ts
+++ b/apps/rishi-electron/src/renderer/src/components/highlights/highlightClickPosition.test.ts
@@ -47,7 +47,9 @@ describe('computeHighlightClickPosition', () => {
 
   it('returns mid-viewport when clientX/Y are not numeric', () => {
     const iframe = makeIframe({ left: 50, top: 30 })
-    const target = { ownerDocument: { defaultView: { frameElement: iframe } } } as unknown as Element
+    const target = {
+      ownerDocument: { defaultView: { frameElement: iframe } }
+    } as unknown as Element
     const e = { target } as unknown as MouseEvent
     expect(computeHighlightClickPosition(e, null, viewport)).toEqual({ x: 500, y: 400 })
   })

--- a/apps/rishi-electron/src/renderer/src/components/mobi/MobiView.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/mobi/MobiView.tsx
@@ -113,7 +113,6 @@ export default function MobiView({ book }: { book: Book }): React.JSX.Element {
       position: { kind: 'mobi', cfi: String(chapterIndex) },
       ttsContext
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chapterIndex])
 
   // Navigation history: RESUME_REQUESTED → navigate to the stored chapter
@@ -286,112 +285,112 @@ export default function MobiView({ book }: { book: Book }): React.JSX.Element {
 
   return (
     <div ref={readerRootRef} className="relative h-full">
-    <div
-      className="relative h-screen flex flex-col"
-      style={{ background: themes[theme].background }}
-    >
-      {/* Main content area */}
-      <div className="flex-1 overflow-hidden">
-        {loading ? (
-          <div className="flex items-center justify-center h-full">
-            <div
-              className="animate-spin rounded-full h-8 w-8 border-2 border-current border-t-transparent"
-              style={{ color: themes[theme].color }}
+      <div
+        className="relative h-screen flex flex-col"
+        style={{ background: themes[theme].background }}
+      >
+        {/* Main content area */}
+        <div className="flex-1 overflow-hidden">
+          {loading ? (
+            <div className="flex items-center justify-center h-full">
+              <div
+                className="animate-spin rounded-full h-8 w-8 border-2 border-current border-t-transparent"
+                style={{ color: themes[theme].color }}
+              />
+            </div>
+          ) : (
+            <iframe
+              ref={iframeRef}
+              srcDoc={srcdoc}
+              className="w-full h-full border-none"
+              title={book.title}
+              sandbox="allow-same-origin"
             />
-          </div>
-        ) : (
-          <iframe
-            ref={iframeRef}
-            srcDoc={srcdoc}
-            className="w-full h-full border-none"
-            title={book.title}
-            sandbox="allow-same-origin"
-          />
-        )}
-      </div>
-
-      {/* Chapter navigation bar */}
-      <div className="fixed bottom-20 left-1/2 -translate-x-1/2 z-10">
-        <div className="flex items-center gap-3 px-4 py-2 bg-black/60 rounded-2xl backdrop-blur-lg">
-          <button
-            onClick={goPrev}
-            disabled={chapterIndex <= 0}
-            className="p-1 text-white disabled:opacity-30 hover:opacity-80 transition-opacity"
-            aria-label="Previous chapter"
-          >
-            <ChevronLeft size={20} />
-          </button>
-          <span className="text-white text-sm font-medium min-w-[4rem] text-center">
-            {chapterCount > 0 ? `${chapterIndex + 1} / ${chapterCount}` : '...'}
-          </span>
-          <button
-            onClick={goNext}
-            disabled={chapterIndex >= chapterCount - 1}
-            className="p-1 text-white disabled:opacity-30 hover:opacity-80 transition-opacity"
-            aria-label="Next chapter"
-          >
-            <ChevronRight size={20} />
-          </button>
+          )}
         </div>
-      </div>
 
-      {/* AI chat orb, voice chat launcher, and TTS controls */}
-      <ReaderOverlayControls
-        bookId={book.id.toString()}
-        chatPanelOpen={chatPanelOpen}
-        onChatOrbClick={() => setChatPanelOpen((prev) => !prev)}
-      />
-
-      {/* TOC / Bookmarks Sidebar */}
-      <ReaderTOC
-        open={tocOpen}
-        onOpenChange={setTocOpen}
-        title="Navigation"
-        bookSyncId={bookSyncId}
-        onBookmarkNavigate={(location) => {
-          const idx = parseInt(location, 10)
-          if (Number.isFinite(idx) && idx >= 0) {
-            // Dispatch a JUMP_REQUESTED before navigating so the history
-            // machine records the "from" anchor and can offer resume later.
-            const activeParagraph = usePlayerStore.getState().activeParagraph
-            const indexStr = activeParagraph?.index
-            const paragraphIndex = indexStr != null ? Number(indexStr) : null
-            const fromTts =
-              paragraphIndex != null && Number.isFinite(paragraphIndex)
-                ? { paragraphIndex }
-                : null
-            navigationHistoryActor.send({
-              type: 'JUMP_REQUESTED',
-              from: { kind: 'mobi', cfi: String(chapterIndex) },
-              fromTts,
-              to: { kind: 'mobi', cfi: location },
-              source: 'bookmark',
-              fromLabel: 'previous spot'
-            })
-            setChapterIndex(idx)
-            setTocOpen(false)
-          }
-        }}
-        tocContent={
-          <div className="p-4 text-gray-400 text-sm text-center">
-            Chapter {chapterIndex + 1} of {chapterCount}
+        {/* Chapter navigation bar */}
+        <div className="fixed bottom-20 left-1/2 -translate-x-1/2 z-10">
+          <div className="flex items-center gap-3 px-4 py-2 bg-black/60 rounded-2xl backdrop-blur-lg">
+            <button
+              onClick={goPrev}
+              disabled={chapterIndex <= 0}
+              className="p-1 text-white disabled:opacity-30 hover:opacity-80 transition-opacity"
+              aria-label="Previous chapter"
+            >
+              <ChevronLeft size={20} />
+            </button>
+            <span className="text-white text-sm font-medium min-w-[4rem] text-center">
+              {chapterCount > 0 ? `${chapterIndex + 1} / ${chapterCount}` : '...'}
+            </span>
+            <button
+              onClick={goNext}
+              disabled={chapterIndex >= chapterCount - 1}
+              className="p-1 text-white disabled:opacity-30 hover:opacity-80 transition-opacity"
+              aria-label="Next chapter"
+            >
+              <ChevronRight size={20} />
+            </button>
           </div>
-        }
-      />
+        </div>
 
-      {AuthDialog}
+        {/* AI chat orb, voice chat launcher, and TTS controls */}
+        <ReaderOverlayControls
+          bookId={book.id.toString()}
+          chatPanelOpen={chatPanelOpen}
+          onChatOrbClick={() => setChatPanelOpen((prev) => !prev)}
+        />
 
-      {/* Chat Panel */}
-      <ChatPanel
-        bookId={book.id}
-        bookSyncId={bookSyncId}
-        bookTitle={book.title}
-        rendition={null}
-        open={chatPanelOpen}
-        onOpenChange={setChatPanelOpen}
-      />
-    </div>
-    <NavigationHistoryFooter />
+        {/* TOC / Bookmarks Sidebar */}
+        <ReaderTOC
+          open={tocOpen}
+          onOpenChange={setTocOpen}
+          title="Navigation"
+          bookSyncId={bookSyncId}
+          onBookmarkNavigate={(location) => {
+            const idx = parseInt(location, 10)
+            if (Number.isFinite(idx) && idx >= 0) {
+              // Dispatch a JUMP_REQUESTED before navigating so the history
+              // machine records the "from" anchor and can offer resume later.
+              const activeParagraph = usePlayerStore.getState().activeParagraph
+              const indexStr = activeParagraph?.index
+              const paragraphIndex = indexStr != null ? Number(indexStr) : null
+              const fromTts =
+                paragraphIndex != null && Number.isFinite(paragraphIndex)
+                  ? { paragraphIndex }
+                  : null
+              navigationHistoryActor.send({
+                type: 'JUMP_REQUESTED',
+                from: { kind: 'mobi', cfi: String(chapterIndex) },
+                fromTts,
+                to: { kind: 'mobi', cfi: location },
+                source: 'bookmark',
+                fromLabel: 'previous spot'
+              })
+              setChapterIndex(idx)
+              setTocOpen(false)
+            }
+          }}
+          tocContent={
+            <div className="p-4 text-gray-400 text-sm text-center">
+              Chapter {chapterIndex + 1} of {chapterCount}
+            </div>
+          }
+        />
+
+        {AuthDialog}
+
+        {/* Chat Panel */}
+        <ChatPanel
+          bookId={book.id}
+          bookSyncId={bookSyncId}
+          bookTitle={book.title}
+          rendition={null}
+          open={chatPanelOpen}
+          onOpenChange={setChatPanelOpen}
+        />
+      </div>
+      <NavigationHistoryFooter />
     </div>
   )
 }

--- a/apps/rishi-electron/src/renderer/src/components/navigation-history/NavigationHistoryFooter.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/navigation-history/NavigationHistoryFooter.tsx
@@ -1,4 +1,4 @@
-import { type JSX } from 'react'
+import type { JSX } from 'react'
 import { usePillVisible, useTopAnchor, useStackDepth } from '@/hooks/useNavigationHistory'
 import { navigationHistoryActor } from '@/machines/navigationHistory/navigationHistoryActor'
 

--- a/apps/rishi-electron/src/renderer/src/components/pdf/HighlightLayer.test.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/pdf/HighlightLayer.test.tsx
@@ -6,18 +6,35 @@ import type { ViewportLike } from '@/modules/pdf-locator'
 
 function makeViewport(scale = 1): ViewportLike {
   return {
-    width: 400 * scale, height: 600 * scale, scale,
-    convertToViewportPoint(x, y) { return [x * scale, (600 - y) * scale] },
-    convertToPdfPoint(x, y) { return [x / scale, 600 - y / scale] }
+    width: 400 * scale,
+    height: 600 * scale,
+    scale,
+    convertToViewportPoint(x, y) {
+      return [x * scale, (600 - y) * scale]
+    },
+    convertToPdfPoint(x, y) {
+      return [x / scale, 600 - y / scale]
+    }
   }
 }
 
 function makeRow(overrides: Partial<HighlightRow> = {}): HighlightRow {
   return {
-    id: 'r1', bookId: 'b1', format: 'pdf', cfiRange: null,
+    id: 'r1',
+    bookId: 'b1',
+    format: 'pdf',
+    cfiRange: null,
     locator: JSON.stringify({ page: 1, rects: [{ x: 10, y: 580, w: 100, h: 15 }] }),
-    text: 'hi', color: 'yellow', note: '', chapter: null,
-    createdAt: 'now', updatedAt: null, syncId: null, syncVersion: 0, isDirty: 0, isDeleted: 0,
+    text: 'hi',
+    color: 'yellow',
+    note: '',
+    chapter: null,
+    createdAt: 'now',
+    updatedAt: null,
+    syncId: null,
+    syncVersion: 0,
+    isDirty: 0,
+    isDeleted: 0,
     ...overrides
   }
 }
@@ -27,10 +44,13 @@ describe('HighlightLayer', () => {
     const rows = [
       makeRow({
         id: 'a',
-        locator: JSON.stringify({ page: 1, rects: [
-          { x: 0, y: 580, w: 50, h: 15 },
-          { x: 0, y: 560, w: 80, h: 15 }
-        ]})
+        locator: JSON.stringify({
+          page: 1,
+          rects: [
+            { x: 0, y: 580, w: 50, h: 15 },
+            { x: 0, y: 560, w: 80, h: 15 }
+          ]
+        })
       }),
       makeRow({ id: 'b' })
     ]
@@ -50,7 +70,10 @@ describe('HighlightLayer', () => {
     const rows = [
       makeRow({ id: 'null-loc', locator: null }),
       makeRow({ id: 'bad-json', locator: '{not json' }),
-      makeRow({ id: 'other-page', locator: JSON.stringify({ page: 99, rects: [{ x: 0, y: 0, w: 10, h: 10 }] }) }),
+      makeRow({
+        id: 'other-page',
+        locator: JSON.stringify({ page: 99, rects: [{ x: 0, y: 0, w: 10, h: 10 }] })
+      }),
       makeRow({ id: 'ok' })
     ]
     render(

--- a/apps/rishi-electron/src/renderer/src/components/pdf/HighlightLayer.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/pdf/HighlightLayer.tsx
@@ -32,7 +32,11 @@ function hexWithAlpha(hex: string, alpha: number): string {
 }
 
 export function HighlightLayer({
-  pageNumber, pageEl, viewport, highlights, onHighlightClick
+  pageNumber,
+  pageEl,
+  viewport,
+  highlights,
+  onHighlightClick
 }: HighlightLayerProps): JSX.Element {
   const rendered = useMemo(() => {
     const items: Array<{
@@ -42,7 +46,7 @@ export function HighlightLayer({
     }> = []
     for (const row of highlights) {
       const loc = parseLocator(row.locator)
-      if (!loc || loc.page !== pageNumber) continue
+      if (loc?.page !== pageNumber) continue
       const screenRects = pdfLocatorToScreenRects(loc, pageEl, viewport)
       screenRects.forEach((rect, idx) => {
         items.push({ key: `${row.id}:${idx}`, row, rect })
@@ -64,7 +68,10 @@ export function HighlightLayer({
           onClick={(e) => onHighlightClick(row, e)}
           style={{
             position: 'absolute',
-            left: rect.left, top: rect.top, width: rect.width, height: rect.height,
+            left: rect.left,
+            top: rect.top,
+            width: rect.width,
+            height: rect.height,
             backgroundColor: hexWithAlpha(getHighlightHex(row.color as HighlightColor), 0.35),
             pointerEvents: 'auto',
             cursor: 'pointer'

--- a/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf-page.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf-page.tsx
@@ -142,8 +142,7 @@ function PageComponentInner({
   const handleLoadSuccess = useCallback(
     (page: PDFPageProxy) => {
       setPdfPage(page)
-      const pageEl =
-        wrapperRef.current?.querySelector<HTMLElement>('.react-pdf__Page') ?? null
+      const pageEl = wrapperRef.current?.querySelector<HTMLElement>('.react-pdf__Page') ?? null
       if (pageEl && onPageReady) onPageReady(pageNumber, { pageEl, page })
     },
     [pageNumber, onPageReady]
@@ -157,13 +156,11 @@ function PageComponentInner({
   const handleAnnotationClick = useCallback(
     (e: ReactMouseEvent<HTMLDivElement>): void => {
       if (!seekTo) return
-      const link = (e.target as HTMLElement).closest('a') as HTMLAnchorElement | null
+      const link = (e.target as HTMLElement).closest('a')
       if (!link) return
       const href = link.getAttribute('href')
       const targetPageStr =
-        link.getAttribute('data-page-number') ??
-        href?.match(/page=(\d+)/)?.[1] ??
-        null
+        link.getAttribute('data-page-number') ?? href?.match(/page=(\d+)/)?.[1] ?? null
       if (!targetPageStr) return
       const targetPage = Number(targetPageStr)
       if (!Number.isFinite(targetPage) || targetPage <= 0) return
@@ -186,31 +183,31 @@ function PageComponentInner({
     <div ref={wrapperRef} style={{ position: 'relative' }}>
       {/* onClickCapture intercepts annotation-layer link clicks before react-pdf's handler */}
       <div onClickCapture={handleAnnotationClick}>
-      <Page
-        pdf={pdf}
-        pageNumber={pageNumber}
-        key={pageNumber.toString()}
-        customTextRenderer={customTextRenderer}
-        height={isDualPage ? pdfHeight : undefined}
-        width={isDualPage ? undefined : pdfWidth}
-        className="rounded shadow-lg"
-        renderTextLayer={true}
-        renderAnnotationLayer={true}
-        canvasBackground="white"
-        onGetTextSuccess={handleGetTextSuccess}
-        loading={
-          <div
-            className="bg-white grid place-items-center"
-            style={{ width: pdfWidth, aspectRatio: '8.5 / 11' }}
-          >
-            <Loader />
-          </div>
-        }
-        onRenderSuccess={handleRenderSuccess}
-        onLoadSuccess={handleLoadSuccess}
-      />
+        <Page
+          pdf={pdf}
+          pageNumber={pageNumber}
+          key={pageNumber.toString()}
+          customTextRenderer={customTextRenderer}
+          height={isDualPage ? pdfHeight : undefined}
+          width={isDualPage ? undefined : pdfWidth}
+          className="rounded shadow-lg"
+          renderTextLayer={true}
+          renderAnnotationLayer={true}
+          canvasBackground="white"
+          onGetTextSuccess={handleGetTextSuccess}
+          loading={
+            <div
+              className="bg-white grid place-items-center"
+              style={{ width: pdfWidth, aspectRatio: '8.5 / 11' }}
+            >
+              <Loader />
+            </div>
+          }
+          onRenderSuccess={handleRenderSuccess}
+          onLoadSuccess={handleLoadSuccess}
+        />
       </div>
-      {pdfPage && wrapperRef.current && highlights && onHighlightClick && (
+      {pdfPage && wrapperRef.current && highlights && onHighlightClick ? (
         <HighlightLayer
           pageNumber={pageNumber}
           pageEl={
@@ -231,7 +228,7 @@ function PageComponentInner({
           highlights={highlights}
           onHighlightClick={onHighlightClick}
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf.tsx
@@ -72,7 +72,11 @@ import { usePdfHighlights } from '@/hooks/usePdfHighlights'
 import { usePdfReadAloudFromSelection } from '@/hooks/usePdfReadAloudFromSelection'
 import { useUndoableHighlightShortcut } from '@/hooks/useUndoableHighlightShortcut'
 import { applyHighlightWithUndoPdf, deleteHighlightByIdWithUndo } from '@/modules/highlight-actions'
-import { updateHighlightColor, type HighlightRow, type PdfLocator } from '@/modules/highlight-storage'
+import {
+  updateHighlightColor,
+  type HighlightRow,
+  type PdfLocator
+} from '@/modules/highlight-storage'
 import type { PDFPageProxy } from 'pdfjs-dist'
 import type { HighlightColor } from '@/types/highlight'
 import type { MouseEvent as ReactMouseEvent } from 'react'
@@ -137,7 +141,9 @@ export function PdfView({
       const scale = info.pageEl.getBoundingClientRect().width / info.page.view[2]
       // pdfjs-dist types return `any[]` from convertToViewportPoint; cast via
       // unknown to the structural ViewportLike which expects [number, number].
-      return info.page.getViewport({ scale }) as unknown as import('@/modules/pdf-locator').ViewportLike
+      return info.page.getViewport({
+        scale
+      }) as unknown as import('@/modules/pdf-locator').ViewportLike
     },
     onSelect: (sel) =>
       setSelectionPopover({ locator: sel.locator, text: sel.text, anchorPos: sel.anchorPos }),
@@ -365,7 +371,8 @@ export function PdfView({
 
   // Helper: build a TtsContext from the current activeParagraph.
   // ParagraphWithIndex.index is a string; TtsContext.paragraphIndex is a number.
-  const ttsContext = activeParagraph != null ? { paragraphIndex: Number(activeParagraph.index) } : null
+  const ttsContext =
+    activeParagraph != null ? { paragraphIndex: Number(activeParagraph.index) } : null
 
   // Navigation history: lifecycle events (BOOK_OPENED / BOOK_CLOSED)
   useEffect(() => {
@@ -381,7 +388,6 @@ export function PdfView({
     return () => navigationHistoryActor.send({ type: 'BOOK_CLOSED' })
     // Re-fire if book.id changes (component is mounted with key={book.id} so this
     // normally only fires once per mount, but kept explicit for correctness).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [book.id])
 
   // Navigation history: PAGE_VISITED on every page change
@@ -455,9 +461,10 @@ export function PdfView({
     ({ pageNumber: itemPageNumber }: { pageNumber: number }) => {
       const fromPage = usePdfStore.getState().pageNumber
       const fromPosition: PositionDescriptor = { kind: 'pdf', page: fromPage, offset: 0 }
-      const fromTts = usePlayerStore.getState().activeParagraph != null
-        ? { paragraphIndex: Number(usePlayerStore.getState().activeParagraph!.index) }
-        : null
+      const fromTts =
+        usePlayerStore.getState().activeParagraph != null
+          ? { paragraphIndex: Number(usePlayerStore.getState().activeParagraph!.index) }
+          : null
       navigationHistoryActor.send({
         type: 'JUMP_REQUESTED',
         from: fromPosition,
@@ -804,9 +811,7 @@ export function PdfView({
   const handleInlineColorChange = async (color: HighlightColor): Promise<void> => {
     if (!inlinePopover) return
     await updateHighlightColor(inlinePopover.rowId, color)
-    setHighlights((prev) =>
-      prev.map((r) => (r.id === inlinePopover.rowId ? { ...r, color } : r))
-    )
+    setHighlights((prev) => prev.map((r) => (r.id === inlinePopover.rowId ? { ...r, color } : r)))
     setInlinePopover(null)
   }
 
@@ -1050,7 +1055,7 @@ export function PdfView({
           </div>
         </SheetContent>
       </Sheet>
-      {selectionPopover && (
+      {selectionPopover ? (
         <SelectionPopover
           cfiRange={''}
           selectedText={selectionPopover.text}
@@ -1058,8 +1063,8 @@ export function PdfView({
           onHighlight={(color) => void handleCreatePdfHighlight(color)}
           onClose={() => setSelectionPopover(null)}
         />
-      )}
-      {inlinePopover && (
+      ) : null}
+      {inlinePopover ? (
         <HighlightActionPopover
           position={inlinePopover.position}
           currentColor={inlinePopover.currentColor}
@@ -1072,7 +1077,7 @@ export function PdfView({
           onDelete={() => void handleInlineDelete()}
           onClose={() => setInlinePopover(null)}
         />
-      )}
+      ) : null}
       <NoteEditor
         highlight={editingNoteRow}
         open={editingNoteRow !== null}

--- a/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf.tsx
@@ -43,6 +43,7 @@ import type { PDFDocumentProxy } from 'pdfjs-dist'
 import { useVirualization } from '../hooks/useVirualization'
 import { PAGE_GAP } from '../utils/constants'
 import { parsePdfLocation } from '@/lib/pdfLocation'
+import type { ViewportLike } from '@/modules/pdf-locator'
 import { pdfParagraphToPageNumber } from '@/components/pdf/utils/pdfParagraphToPageNumber'
 import { Effect, Fiber } from 'effect'
 import { indexBookProgram } from '@/services/indexing/index-program'
@@ -143,7 +144,7 @@ export function PdfView({
       // unknown to the structural ViewportLike which expects [number, number].
       return info.page.getViewport({
         scale
-      }) as unknown as import('@/modules/pdf-locator').ViewportLike
+      }) as unknown as ViewportLike
     },
     onSelect: (sel) =>
       setSelectionPopover({ locator: sel.locator, text: sel.text, anchorPos: sel.anchorPos }),

--- a/apps/rishi-electron/src/renderer/src/components/pdf/hooks/useScrolling.test.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/pdf/hooks/useScrolling.test.tsx
@@ -59,14 +59,34 @@ function setupContainerWithMark(): {
     configurable: true
   })
   container.getBoundingClientRect = (): DOMRect =>
-    ({ top: 0, left: 0, right: 0, bottom: 800, width: 0, height: 800, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect
+    ({
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 800,
+      width: 0,
+      height: 800,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    }) as DOMRect
 
   const mark = document.createElement('mark')
   mark.textContent = 'first paragraph of newly-landed page N+1'
   // Mark is at viewport top — same geometry as just after
   // `virtualizer.scrollToIndex(N, { align: 'start' })`.
   mark.getBoundingClientRect = (): DOMRect =>
-    ({ top: 0, left: 0, right: 0, bottom: 24, width: 0, height: 24, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect
+    ({
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 24,
+      width: 0,
+      height: 24,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    }) as DOMRect
   // happy-dom's `innerText` falls back to `textContent`, which is what
   // useScrolling's `.find((m) => m.innerText)` actually reads.
   container.appendChild(mark)
@@ -163,7 +183,10 @@ describe('useScrolling — page-advance snap-back race (issue #30 refined sympto
     // no longer clears it). With the original buggy code the flag is
     // already `false` at this point.
     const publishedParagraphs = usePdfStore.getState().currentViewParagraphs
-    expect(publishedParagraphs.length, 'publishParagraphsForPage produced at least one paragraph').toBeGreaterThan(0)
+    expect(
+      publishedParagraphs.length,
+      'publishParagraphsForPage produced at least one paragraph'
+    ).toBeGreaterThan(0)
 
     renderUseScrolling(container)
 

--- a/apps/rishi-electron/src/renderer/src/components/pdf/utils/findRepeatingPageSuffix.test.ts
+++ b/apps/rishi-electron/src/renderer/src/components/pdf/utils/findRepeatingPageSuffix.test.ts
@@ -156,8 +156,7 @@ describe('findRepeatingPageSuffix', () => {
       // Other pages use the random alphabetic suffix to ensure normalization
       // doesn't collapse them onto each other (digit-replace would).
       const uniqueSuffix = `closing remark ${String.fromCharCode(64 + p)}${String.fromCharCode(96 + p)} subject`
-      const bottomText =
-        p <= 2 ? 'Shared closing remark only on two pages' : uniqueSuffix
+      const bottomText = p <= 2 ? 'Shared closing remark only on two pages' : uniqueSuffix
       pages.push(
         makePage(p, [
           { str: `Distinct body topic ${String.fromCharCode(64 + p)} for page ${p}`, y: 700 },

--- a/apps/rishi-electron/src/renderer/src/components/react-reader/index.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/react-reader/index.tsx
@@ -122,9 +122,7 @@ export class ReactReader extends PureComponent<IReactReaderProps, IReactReaderSt
       const indexStr = activeParagraph?.index
       const paragraphIndex = indexStr != null ? Number(indexStr) : null
       const fromTts =
-        paragraphIndex != null && Number.isFinite(paragraphIndex)
-          ? { paragraphIndex }
-          : null
+        paragraphIndex != null && Number.isFinite(paragraphIndex) ? { paragraphIndex } : null
       navigationHistoryActor.send({
         type: 'JUMP_REQUESTED',
         from: { kind: 'epub', cfi: currentCfi },

--- a/apps/rishi-electron/src/renderer/src/config/worker-url.ts
+++ b/apps/rishi-electron/src/renderer/src/config/worker-url.ts
@@ -23,7 +23,7 @@
  */
 export const WORKER_URL: string =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- import.meta.env shape is augmented in vite-env.d.ts; cast keeps this file framework-agnostic for vitest.
-  ((import.meta as any)?.env?.VITE_WORKER_URL as string | undefined) || 'https://api.fidexa.org'
+  ((import.meta as any)?.env?.VITE_WORKER_URL as string | undefined) ?? 'https://api.fidexa.org'
 
 // Side-effect: expose to the window for E2E assertions. Guarded so this module
 // stays importable in node-side vitest contexts where `window` is undefined.

--- a/apps/rishi-electron/src/renderer/src/config/worker-url.ts
+++ b/apps/rishi-electron/src/renderer/src/config/worker-url.ts
@@ -23,8 +23,7 @@
  */
 export const WORKER_URL: string =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- import.meta.env shape is augmented in vite-env.d.ts; cast keeps this file framework-agnostic for vitest.
-  ((import.meta as any)?.env?.VITE_WORKER_URL as string | undefined) ||
-  'https://api.fidexa.org'
+  ((import.meta as any)?.env?.VITE_WORKER_URL as string | undefined) || 'https://api.fidexa.org'
 
 // Side-effect: expose to the window for E2E assertions. Guarded so this module
 // stays importable in node-side vitest contexts where `window` is undefined.

--- a/apps/rishi-electron/src/renderer/src/hooks/reader/useCommonMenuHandlers.ts
+++ b/apps/rishi-electron/src/renderer/src/hooks/reader/useCommonMenuHandlers.ts
@@ -59,7 +59,8 @@ export function useCommonMenuHandlers({
         else if (state.startsWith('paused')) send({ type: 'RESUME' })
         else requireAuthRef.current('tts', () => send({ type: 'PLAY' }))
       },
-      openChat: () => requireAuthRef.current('ai-chat', () => setChatPanelOpenRef.current((v) => !v)),
+      openChat: () =>
+        requireAuthRef.current('ai-chat', () => setChatPanelOpenRef.current((v) => !v)),
       voiceChat: () => {
         const { isChatting: chatting, setIsChatting } = useChatStore.getState()
         if (chatting) setIsChatting(false)

--- a/apps/rishi-electron/src/renderer/src/hooks/useMenuCommands.test.ts
+++ b/apps/rishi-electron/src/renderer/src/hooks/useMenuCommands.test.ts
@@ -8,8 +8,7 @@ let listener: Listener | null = null
 // Restore window.electron to whatever test-setup.ts installed at file load so
 // per-test stubs in this file cannot leak into other tests in the same file
 // (or, if Vitest isolation is ever disabled, into other files).
-const originalElectron = (globalThis as unknown as { window: { electron: object } }).window
-  .electron
+const originalElectron = (globalThis as unknown as { window: { electron: object } }).window.electron
 
 beforeEach(() => {
   listener = null

--- a/apps/rishi-electron/src/renderer/src/hooks/usePdfReadAloudFromSelection.test.tsx
+++ b/apps/rishi-electron/src/renderer/src/hooks/usePdfReadAloudFromSelection.test.tsx
@@ -49,7 +49,9 @@ describe('usePdfReadAloudFromSelection', () => {
   }
 
   it('registers the IPC listener on mount and unsubscribes on unmount', () => {
-    const { unmount } = renderHook(() => usePdfReadAloudFromSelection({ requireAuth: (_f, run) => run() }))
+    const { unmount } = renderHook(() =>
+      usePdfReadAloudFromSelection({ requireAuth: (_f, run) => run() })
+    )
     expect(onSpy).toHaveBeenCalledWith('reader:readAloudFromSelection', expect.any(Function))
     unmount()
     expect(unsubscribeSpy).toHaveBeenCalledTimes(1)

--- a/apps/rishi-electron/src/renderer/src/hooks/usePdfReader.ts
+++ b/apps/rishi-electron/src/renderer/src/hooks/usePdfReader.ts
@@ -324,7 +324,10 @@ export function usePdfReader(
 // Exported for the issue-#30 snap-back test (useScrolling.test.tsx) so the
 // flag-lifecycle contract can be exercised end-to-end at the unit-test
 // level. Production consumers stay inside usePdfReader's effect.
-export function publishParagraphsForPage(page: number, pageDataMap: Record<number, TextContent>): void {
+export function publishParagraphsForPage(
+  page: number,
+  pageDataMap: Record<number, TextContent>
+): void {
   const data = pageDataMap[page] as TextContent | undefined
   if (!data) return
   const bookId = usePdfStore.getState().book?.id

--- a/apps/rishi-electron/src/renderer/src/hooks/usePdfTextSelection.test.tsx
+++ b/apps/rishi-electron/src/renderer/src/hooks/usePdfTextSelection.test.tsx
@@ -3,16 +3,26 @@ import { renderHook, act } from '@testing-library/react'
 import { usePdfTextSelection, type PdfSelectionEvent } from './usePdfTextSelection'
 import type { ViewportLike } from '@/modules/pdf-locator'
 
-function setupPage(opts: { pageNumber: number; rect: { left: number; top: number; width: number; height: number } }) {
+function setupPage(opts: {
+  pageNumber: number
+  rect: { left: number; top: number; width: number; height: number }
+}) {
   const page = document.createElement('div')
   page.className = 'react-pdf__Page'
   page.setAttribute('data-page-number', String(opts.pageNumber))
   Object.defineProperty(page, 'getBoundingClientRect', {
     value: () => ({
-      left: opts.rect.left, top: opts.rect.top,
-      right: opts.rect.left + opts.rect.width, bottom: opts.rect.top + opts.rect.height,
-      width: opts.rect.width, height: opts.rect.height, x: opts.rect.left, y: opts.rect.top,
-      toJSON() { return this }
+      left: opts.rect.left,
+      top: opts.rect.top,
+      right: opts.rect.left + opts.rect.width,
+      bottom: opts.rect.top + opts.rect.height,
+      width: opts.rect.width,
+      height: opts.rect.height,
+      x: opts.rect.left,
+      y: opts.rect.top,
+      toJSON() {
+        return this
+      }
     })
   })
   const text = document.createTextNode('hello world')
@@ -22,9 +32,15 @@ function setupPage(opts: { pageNumber: number; rect: { left: number; top: number
 
 function makeViewport(scale = 1): ViewportLike {
   return {
-    width: 400 * scale, height: 600 * scale, scale,
-    convertToViewportPoint(x, y) { return [x * scale, (600 - y) * scale] },
-    convertToPdfPoint(x, y) { return [x / scale, 600 - y / scale] }
+    width: 400 * scale,
+    height: 600 * scale,
+    scale,
+    convertToViewportPoint(x, y) {
+      return [x * scale, (600 - y) * scale]
+    },
+    convertToPdfPoint(x, y) {
+      return [x / scale, 600 - y / scale]
+    }
   }
 }
 
@@ -32,9 +48,9 @@ describe('usePdfTextSelection', () => {
   let container: HTMLDivElement
   let containerRef: { current: HTMLDivElement | null }
   // Typed as the actual callback shapes so TypeScript is satisfied at call sites.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   let onSelect: ((sel: PdfSelectionEvent) => void) & { mock: any }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   let onClear: (() => void) & { mock: any }
 
   beforeEach(() => {
@@ -51,7 +67,10 @@ describe('usePdfTextSelection', () => {
   })
 
   it('fires onSelect with locator and anchorPos when mouseup completes a non-collapsed selection on a single page', () => {
-    const { page, text } = setupPage({ pageNumber: 4, rect: { left: 0, top: 0, width: 400, height: 600 } })
+    const { page, text } = setupPage({
+      pageNumber: 4,
+      rect: { left: 0, top: 0, width: 400, height: 600 }
+    })
     container.appendChild(page)
 
     renderHook(() =>
@@ -59,7 +78,8 @@ describe('usePdfTextSelection', () => {
         containerRef,
         getPageElement: (n) => (n === 4 ? page : null),
         getViewport: () => makeViewport(1),
-        onSelect, onClear
+        onSelect,
+        onClear
       })
     )
 
@@ -74,7 +94,9 @@ describe('usePdfTextSelection', () => {
     sel.addRange(range)
 
     act(() => {
-      container.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, clientX: 30, clientY: 20 }))
+      container.dispatchEvent(
+        new MouseEvent('mouseup', { bubbles: true, clientX: 30, clientY: 20 })
+      )
     })
 
     expect(onSelect).toHaveBeenCalledTimes(1)
@@ -87,19 +109,23 @@ describe('usePdfTextSelection', () => {
   it('ignores cross-page selections', () => {
     const a = setupPage({ pageNumber: 1, rect: { left: 0, top: 0, width: 400, height: 600 } })
     const b = setupPage({ pageNumber: 2, rect: { left: 0, top: 700, width: 400, height: 600 } })
-    container.appendChild(a.page); container.appendChild(b.page)
-    renderHook(() => usePdfTextSelection({
-      containerRef,
-      getPageElement: (n) => (n === 1 ? a.page : b.page),
-      getViewport: () => makeViewport(1),
-      onSelect, onClear
-    }))
+    container.appendChild(a.page)
+    container.appendChild(b.page)
+    renderHook(() =>
+      usePdfTextSelection({
+        containerRef,
+        getPageElement: (n) => (n === 1 ? a.page : b.page),
+        getViewport: () => makeViewport(1),
+        onSelect,
+        onClear
+      })
+    )
     const range = document.createRange()
     range.setStart(a.text, 0)
     range.setEnd(b.text, 5)
-    Object.defineProperty(range, 'getClientRects', { value: () => [
-      { left: 0, top: 0, width: 50, height: 14, right: 50, bottom: 14 }
-    ]})
+    Object.defineProperty(range, 'getClientRects', {
+      value: () => [{ left: 0, top: 0, width: 50, height: 14, right: 50, bottom: 14 }]
+    })
     window.getSelection()!.removeAllRanges()
     window.getSelection()!.addRange(range)
     act(() => container.dispatchEvent(new MouseEvent('mouseup', { bubbles: true })))
@@ -113,9 +139,9 @@ describe('usePdfTextSelection', () => {
     const singlePageRange = document.createRange()
     singlePageRange.setStart(a.text, 0)
     singlePageRange.setEnd(a.text, 5)
-    Object.defineProperty(singlePageRange, 'getClientRects', { value: () => [
-      { left: 0, top: 0, width: 50, height: 14, right: 50, bottom: 14 }
-    ]})
+    Object.defineProperty(singlePageRange, 'getClientRects', {
+      value: () => [{ left: 0, top: 0, width: 50, height: 14, right: 50, bottom: 14 }]
+    })
     window.getSelection()!.removeAllRanges()
     window.getSelection()!.addRange(singlePageRange)
     act(() => container.dispatchEvent(new MouseEvent('mouseup', { bubbles: true })))
@@ -124,11 +150,15 @@ describe('usePdfTextSelection', () => {
   })
 
   it('fires onClear when selection becomes collapsed', () => {
-    renderHook(() => usePdfTextSelection({
-      containerRef,
-      getPageElement: () => null, getViewport: () => null,
-      onSelect, onClear
-    }))
+    renderHook(() =>
+      usePdfTextSelection({
+        containerRef,
+        getPageElement: () => null,
+        getViewport: () => null,
+        onSelect,
+        onClear
+      })
+    )
     act(() => {
       window.getSelection()!.removeAllRanges()
       document.dispatchEvent(new Event('selectionchange'))

--- a/apps/rishi-electron/src/renderer/src/hooks/usePdfTextSelection.ts
+++ b/apps/rishi-electron/src/renderer/src/hooks/usePdfTextSelection.ts
@@ -43,7 +43,7 @@ export function usePdfTextSelection(params: UsePdfTextSelectionParams): void {
       const range = sel.getRangeAt(0)
       const startInfo = findPageInfo(range.startContainer)
       const endInfo = findPageInfo(range.endContainer)
-      if (!startInfo || !endInfo || startInfo.el !== endInfo.el) return
+      if (!startInfo || startInfo.el !== endInfo?.el) return
       const expectedEl = getPageElement(startInfo.pageNumber)
       if (expectedEl !== startInfo.el) return
       const viewport = getViewport(startInfo.pageNumber)

--- a/apps/rishi-electron/src/renderer/src/hooks/usePlayerMachine.ts
+++ b/apps/rishi-electron/src/renderer/src/hooks/usePlayerMachine.ts
@@ -115,7 +115,7 @@ export function usePlayerMachine(bookId: string) {
 
       if (nextActive) {
         const currentParagraphs = usePlayerStore.getState().currentParagraphs
-        const idx = currentParagraphs.findIndex((p) => p.index === nextActive!.index)
+        const idx = currentParagraphs.findIndex((p) => p.index === nextActive.index)
         if (idx >= 0) {
           const element = resolveParagraphElement(idx)
           if (element) {

--- a/apps/rishi-electron/src/renderer/src/hooks/useTtsHighlightReconciler.test.ts
+++ b/apps/rishi-electron/src/renderer/src/hooks/useTtsHighlightReconciler.test.ts
@@ -5,7 +5,7 @@ import { useTtsHighlightReconciler } from './useTtsHighlightReconciler'
 
 function setActive(index: string | null): void {
   usePlayerStore.setState({
-    activeParagraph: index ? ({ index, key: index, text: '' } as never) : null,
+    activeParagraph: index ? ({ index, key: index, text: '' } as never) : null
   })
 }
 
@@ -97,7 +97,9 @@ describe('useTtsHighlightReconciler — integration (the bug class)', () => {
   it('sweeps stale state on focus return even when activeParagraph did not change', () => {
     setActive('p5')
     let lastSeen: string | null | undefined
-    const reconcile = vi.fn((d: string | null) => { lastSeen = d })
+    const reconcile = vi.fn((d: string | null) => {
+      lastSeen = d
+    })
     renderHook(() => useTtsHighlightReconciler(reconcile, null))
     window.dispatchEvent(new Event('blur'))
     reconcile.mockClear()
@@ -108,7 +110,9 @@ describe('useTtsHighlightReconciler — integration (the bug class)', () => {
 
   it('full cycle: activeParagraph p5 → blur → focus → advance to p7', () => {
     const calls: Array<string | null> = []
-    const reconcile = vi.fn((d: string | null) => { calls.push(d) })
+    const reconcile = vi.fn((d: string | null) => {
+      calls.push(d)
+    })
     renderHook(() => useTtsHighlightReconciler(reconcile, null))
     act(() => setActive('p5'))
     window.dispatchEvent(new Event('focus'))

--- a/apps/rishi-electron/src/renderer/src/hooks/useTtsHighlightReconciler.ts
+++ b/apps/rishi-electron/src/renderer/src/hooks/useTtsHighlightReconciler.ts
@@ -28,7 +28,7 @@ export type ReconcileTtsHighlight = (desiredIndex: string | null) => void
  */
 export function useTtsHighlightReconciler(
   reconcile: ReconcileTtsHighlight,
-  iframe: HTMLIFrameElement | null,
+  iframe: HTMLIFrameElement | null
 ): void {
   useEffect(() => {
     const run = (): void => {
@@ -42,7 +42,7 @@ export function useTtsHighlightReconciler(
     const unsubStore = usePlayerStore.subscribe(
       (s) => ({ active: s.activeParagraph, resume: s.lastPlayedParagraphIndex }),
       () => run(),
-      { equalityFn: (a, b) => a.active === b.active && a.resume === b.resume },
+      { equalityFn: (a, b) => a.active === b.active && a.resume === b.resume }
     )
 
     const onVisibility = (): void => {

--- a/apps/rishi-electron/src/renderer/src/lib/visualHeuristic.ts
+++ b/apps/rishi-electron/src/renderer/src/lib/visualHeuristic.ts
@@ -110,7 +110,7 @@ function scanElement(el: Element, hits: VisualHit[]): void {
   // double-counting: a katex/math child's text is already included in the
   // parent's textContent, so if a child owns the equation we don't also
   // attribute it to the parent.
-  if ((direct === null || direct.kind !== 'equation') && !childHasEquation) {
+  if (direct?.kind !== 'equation' && !childHasEquation) {
     if (hasLatexEquation(el.textContent ?? '')) {
       hits.push({ kind: 'equation', element: el, label: 'equation' })
     }
@@ -160,7 +160,7 @@ export function summarizeVisuals(root: Element): VisualSummary {
   let figures = 0
   let images = 0
 
-  const walker = root.ownerDocument!.createTreeWalker(root, NodeFilter.SHOW_ELEMENT)
+  const walker = root.ownerDocument.createTreeWalker(root, NodeFilter.SHOW_ELEMENT)
   let node = walker.currentNode as Element | null
   while (node) {
     const tag = node.tagName.toLowerCase()

--- a/apps/rishi-electron/src/renderer/src/machines/navigationHistory/navigationHistoryMachine.test.ts
+++ b/apps/rishi-electron/src/renderer/src/machines/navigationHistory/navigationHistoryMachine.test.ts
@@ -72,7 +72,11 @@ describe('navigationHistoryMachine — stack', () => {
     actor.send({ type: 'BOOK_OPENED', bookId: 'b', initialPosition: pos(10) })
     actor.send({
       type: 'JUMP_REQUESTED',
-      from: pos(10), fromTts: null, to: pos(50), source: 'link', fromLabel: 'p. 10'
+      from: pos(10),
+      fromTts: null,
+      to: pos(50),
+      source: 'link',
+      fromLabel: 'p. 10'
     })
     actor.send({ type: 'PAGE_VISITED', position: pos(50), ttsContext: null })
     expect((actor.getSnapshot().value as { active: { stack: string } }).active.stack).toBe('idle')
@@ -83,7 +87,11 @@ describe('navigationHistoryMachine — stack', () => {
     actor.send({ type: 'BOOK_OPENED', bookId: 'b', initialPosition: pos(10) })
     actor.send({
       type: 'JUMP_REQUESTED',
-      from: pos(10), fromTts: null, to: pos(50), source: 'link', fromLabel: 'p. 10'
+      from: pos(10),
+      fromTts: null,
+      to: pos(50),
+      source: 'link',
+      fromLabel: 'p. 10'
     })
     actor.send({ type: 'PAGE_VISITED', position: pos(50), ttsContext: null })
     actor.send({ type: 'POP_BACK' })
@@ -217,7 +225,11 @@ describe('navigationHistoryMachine — resume map + pill', () => {
     expect(actor.getSnapshot().context.pillVisible).toBe(false)
     actor.send({
       type: 'JUMP_REQUESTED',
-      from: pos(1), fromTts: null, to: pos(5), source: 'link', fromLabel: 'p. 1'
+      from: pos(1),
+      fromTts: null,
+      to: pos(5),
+      source: 'link',
+      fromLabel: 'p. 1'
     })
     expect(actor.getSnapshot().context.pillVisible).toBe(true)
     actor.send({ type: 'PAGE_VISITED', position: pos(5), ttsContext: null })
@@ -232,7 +244,11 @@ describe('navigationHistoryMachine — resume map + pill', () => {
     actor.send({ type: 'BOOK_OPENED', bookId: 'b', initialPosition: pos(1) })
     actor.send({
       type: 'JUMP_REQUESTED',
-      from: pos(1), fromTts: null, to: pos(5), source: 'link', fromLabel: 'p. 1'
+      from: pos(1),
+      fromTts: null,
+      to: pos(5),
+      source: 'link',
+      fromLabel: 'p. 1'
     })
     actor.send({ type: 'DISMISS_PILL' })
     expect(actor.getSnapshot().context.pillVisible).toBe(false)
@@ -244,7 +260,11 @@ describe('navigationHistoryMachine — resume map + pill', () => {
     actor.send({ type: 'BOOK_OPENED', bookId: 'b', initialPosition: pos(1) })
     actor.send({
       type: 'JUMP_REQUESTED',
-      from: pos(1), fromTts: null, to: pos(5), source: 'link', fromLabel: 'p. 1'
+      from: pos(1),
+      fromTts: null,
+      to: pos(5),
+      source: 'link',
+      fromLabel: 'p. 1'
     })
     actor.send({ type: 'PAGE_VISITED', position: pos(5), ttsContext: null })
     expect(actor.getSnapshot().context.pillVisible).toBe(true)
@@ -295,7 +315,11 @@ describe('navigationHistoryMachine — smart resume emission', () => {
     // deliberate jump back to page 7
     actor.send({
       type: 'JUMP_REQUESTED',
-      from: pos(9), fromTts: null, to: pos(7, 100), source: 'link', fromLabel: 'p. 9'
+      from: pos(9),
+      fromTts: null,
+      to: pos(7, 100),
+      source: 'link',
+      fromLabel: 'p. 9'
     })
     actor.send({ type: 'PAGE_VISITED', position: pos(7, 100), ttsContext: null })
     expect(emitted.length).toBe(beforeJump) // no new emission — deliberate wins

--- a/apps/rishi-electron/src/renderer/src/machines/navigationHistory/navigationHistoryMachine.ts
+++ b/apps/rishi-electron/src/renderer/src/machines/navigationHistory/navigationHistoryMachine.ts
@@ -1,5 +1,10 @@
 import { setup, assign, emit } from 'xstate'
-import type { AnchorPoint, NavigationHistoryContext, NavigationHistoryEvent, NavigationHistoryEmitted } from './types'
+import type {
+  AnchorPoint,
+  NavigationHistoryContext,
+  NavigationHistoryEvent,
+  NavigationHistoryEmitted
+} from './types'
 import { STACK_MAX_DEPTH, DWELL_MS } from './types'
 import { pageKey } from './pageKey'
 
@@ -118,7 +123,11 @@ export const navigationHistoryMachine = setup({
             idle: {
               on: {
                 JUMP_REQUESTED: { target: 'navigating', actions: 'pushAnchor' },
-                POP_BACK: { target: 'navigating', guard: 'hasStackEntries', actions: ['popAnchor', 'hidePillIfStackEmpty'] },
+                POP_BACK: {
+                  target: 'navigating',
+                  guard: 'hasStackEntries',
+                  actions: ['popAnchor', 'hidePillIfStackEmpty']
+                },
                 PAGE_VISITED: [
                   {
                     guard: 'hasResumeAnchor',

--- a/apps/rishi-electron/src/renderer/src/machines/navigationHistory/pageKey.test.ts
+++ b/apps/rishi-electron/src/renderer/src/machines/navigationHistory/pageKey.test.ts
@@ -9,14 +9,14 @@ describe('pageKey', () => {
 
   it('EPUB key reflects spine index only', () => {
     // CFI format: epubcfi(/6/<spinePos*2+2>!/...)
-    const cfiA = 'epubcfi(/6/14!/4/2/2,/1:0,/1:100)'  // spinePos 6
-    const cfiB = 'epubcfi(/6/14!/4/4/2,/1:0,/1:100)'  // same spinePos 6, different intra-spine
+    const cfiA = 'epubcfi(/6/14!/4/2/2,/1:0,/1:100)' // spinePos 6
+    const cfiB = 'epubcfi(/6/14!/4/4/2,/1:0,/1:100)' // same spinePos 6, different intra-spine
     expect(pageKey({ kind: 'epub', cfi: cfiA })).toBe(pageKey({ kind: 'epub', cfi: cfiB }))
   })
 
   it('different spine indices yield different keys', () => {
-    const cfi1 = 'epubcfi(/6/4!/4/2/2,/1:0,/1:100)'   // spinePos 1
-    const cfi2 = 'epubcfi(/6/14!/4/2/2,/1:0,/1:100)'  // spinePos 6
+    const cfi1 = 'epubcfi(/6/4!/4/2/2,/1:0,/1:100)' // spinePos 1
+    const cfi2 = 'epubcfi(/6/14!/4/2/2,/1:0,/1:100)' // spinePos 6
     expect(pageKey({ kind: 'epub', cfi: cfi1 })).not.toBe(pageKey({ kind: 'epub', cfi: cfi2 }))
   })
 

--- a/apps/rishi-electron/src/renderer/src/modules/buildRealtimeAgent.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/buildRealtimeAgent.ts
@@ -296,7 +296,13 @@ export function buildRealtimeAgent({
   return new RealtimeAgent({
     name: 'Assistant',
     voice: 'alloy',
-    instructions: INSTRUCTIONS_TEMPLATE(pageText, language, outline, activeParagraphText, visualSummary),
+    instructions: INSTRUCTIONS_TEMPLATE(
+      pageText,
+      language,
+      outline,
+      activeParagraphText,
+      visualSummary
+    ),
     tools: tools as never
   })
 }

--- a/apps/rishi-electron/src/renderer/src/modules/file-sync.test.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/file-sync.test.ts
@@ -38,9 +38,7 @@ describe('uploadBookFile — request body', () => {
     const fetchSpy = vi
       .fn()
       // First call: /upload-url -> dedup hit so we never touch the PUT URL
-      .mockResolvedValueOnce(
-        uploadUrlResponse({ r2Key: 'r2/abc', exists: true })
-      )
+      .mockResolvedValueOnce(uploadUrlResponse({ r2Key: 'r2/abc', exists: true }))
     global.fetch = fetchSpy as unknown as typeof fetch
 
     await uploadBookFile('/tmp/book.epub', 'hash-abc', 'epub', 12345)
@@ -193,7 +191,9 @@ describe('uploadBookFile — size-limit error responses', () => {
   it('still throws a generic Error when the response is not a size-limit shape', async () => {
     global.fetch = vi
       .fn()
-      .mockResolvedValueOnce(new Response('', { status: 500, statusText: 'boom' })) as unknown as typeof fetch
+      .mockResolvedValueOnce(
+        new Response('', { status: 500, statusText: 'boom' })
+      ) as unknown as typeof fetch
 
     let caught: unknown
     try {

--- a/apps/rishi-electron/src/renderer/src/modules/highlight-actions.test.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/highlight-actions.test.ts
@@ -1,30 +1,46 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('@/modules/highlight-storage', () => ({
-  saveHighlight: vi.fn(async (params: { bookSyncId: string; cfiRange: string; text: string; color?: string; note?: string; chapter?: string }) =>
-    window.electron.highlightsSave({
-      format: 'epub',
-      bookSyncId: params.bookSyncId,
-      cfiRange: params.cfiRange,
-      locator: null,
-      text: params.text,
-      color: params.color ?? 'yellow',
-      note: params.note ?? '',
-      chapter: params.chapter ?? null
-    })
+  saveHighlight: vi.fn(
+    async (params: {
+      bookSyncId: string
+      cfiRange: string
+      text: string
+      color?: string
+      note?: string
+      chapter?: string
+    }) =>
+      window.electron.highlightsSave({
+        format: 'epub',
+        bookSyncId: params.bookSyncId,
+        cfiRange: params.cfiRange,
+        locator: null,
+        text: params.text,
+        color: params.color ?? 'yellow',
+        note: params.note ?? '',
+        chapter: params.chapter ?? null
+      })
   ),
   deleteHighlight: vi.fn().mockResolvedValue(undefined),
-  saveHighlightPdf: vi.fn(async (params: { bookSyncId: string; locator: unknown; text: string; color?: string; note?: string; chapter?: string | null }) =>
-    window.electron.highlightsSave({
-      format: 'pdf',
-      bookSyncId: params.bookSyncId,
-      cfiRange: null,
-      locator: JSON.stringify(params.locator),
-      text: params.text,
-      color: params.color ?? 'yellow',
-      note: params.note ?? '',
-      chapter: params.chapter ?? null
-    })
+  saveHighlightPdf: vi.fn(
+    async (params: {
+      bookSyncId: string
+      locator: unknown
+      text: string
+      color?: string
+      note?: string
+      chapter?: string | null
+    }) =>
+      window.electron.highlightsSave({
+        format: 'pdf',
+        bookSyncId: params.bookSyncId,
+        cfiRange: null,
+        locator: JSON.stringify(params.locator),
+        text: params.text,
+        color: params.color ?? 'yellow',
+        note: params.note ?? '',
+        chapter: params.chapter ?? null
+      })
   ),
   deleteHighlightById: vi.fn(async (id: string) => window.electron.highlightsDeleteById(id)),
   getHighlightsForBook: vi.fn().mockResolvedValue([])
@@ -364,9 +380,14 @@ describe('deleteHighlightByIdWithUndo', () => {
       target: { applyVisual: vi.fn(), removeVisual: vi.fn() },
       rowId: 'r1',
       snapshot: {
-        bookId: 'b1', format: 'pdf', cfiRange: null,
+        bookId: 'b1',
+        format: 'pdf',
+        cfiRange: null,
         locator: JSON.stringify({ page: 1, rects: [{ x: 0, y: 0, w: 10, h: 10 }] }),
-        text: 'hi', color: 'yellow', note: '', chapter: null
+        text: 'hi',
+        color: 'yellow',
+        note: '',
+        chapter: null
       }
     })
     expect(deleteMock).toHaveBeenCalledWith('r1')
@@ -386,8 +407,14 @@ describe('deleteHighlightByIdWithUndo', () => {
       target: { applyVisual: vi.fn(), removeVisual: vi.fn() },
       rowId: 'r2',
       snapshot: {
-        bookId: 'b1', format: 'epub', cfiRange: 'epubcfi(/6/4!/4/2)', locator: null,
-        text: 't', color: 'yellow', note: '', chapter: null
+        bookId: 'b1',
+        format: 'epub',
+        cfiRange: 'epubcfi(/6/4!/4/2)',
+        locator: null,
+        text: 't',
+        color: 'yellow',
+        note: '',
+        chapter: null
       }
     })
     await handle.undo()

--- a/apps/rishi-electron/src/renderer/src/modules/highlight-actions.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/highlight-actions.ts
@@ -140,7 +140,10 @@ export interface DeleteHighlightArgs {
 export interface DeleteHighlightByIdWithUndoArgs {
   target: HighlightTarget
   rowId: string
-  snapshot: Pick<HighlightRow, 'bookId' | 'format' | 'cfiRange' | 'locator' | 'text' | 'color' | 'note' | 'chapter'>
+  snapshot: Pick<
+    HighlightRow,
+    'bookId' | 'format' | 'cfiRange' | 'locator' | 'text' | 'color' | 'note' | 'chapter'
+  >
 }
 
 export async function deleteHighlightByIdWithUndo(

--- a/apps/rishi-electron/src/renderer/src/modules/highlight-storage.test.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/highlight-storage.test.ts
@@ -113,18 +113,38 @@ describe('highlight-storage — PDF support', () => {
     const listMock = window.electron.highlightsList as unknown as ReturnType<typeof vi.fn>
     listMock.mockResolvedValueOnce([
       {
-        id: 'r1', bookId: 'b1',
-        format: 'epub', cfiRange: 'epubcfi(/6/4!/4/2)', locator: null,
-        text: 't', color: 'yellow', note: '', chapter: null,
-        createdAt: '2026-05-17T00:00:00.000Z', updatedAt: null,
-        syncId: null, syncVersion: 0, isDirty: 0, isDeleted: 0
+        id: 'r1',
+        bookId: 'b1',
+        format: 'epub',
+        cfiRange: 'epubcfi(/6/4!/4/2)',
+        locator: null,
+        text: 't',
+        color: 'yellow',
+        note: '',
+        chapter: null,
+        createdAt: '2026-05-17T00:00:00.000Z',
+        updatedAt: null,
+        syncId: null,
+        syncVersion: 0,
+        isDirty: 0,
+        isDeleted: 0
       },
       {
-        id: 'r2', bookId: 'b1',
-        format: 'pdf', cfiRange: null, locator: JSON.stringify({ page: 1, rects: [] }),
-        text: 't2', color: 'green', note: '', chapter: null,
-        createdAt: '2026-05-17T00:00:00.000Z', updatedAt: null,
-        syncId: null, syncVersion: 0, isDirty: 0, isDeleted: 0
+        id: 'r2',
+        bookId: 'b1',
+        format: 'pdf',
+        cfiRange: null,
+        locator: JSON.stringify({ page: 1, rects: [] }),
+        text: 't2',
+        color: 'green',
+        note: '',
+        chapter: null,
+        createdAt: '2026-05-17T00:00:00.000Z',
+        updatedAt: null,
+        syncId: null,
+        syncVersion: 0,
+        isDirty: 0,
+        isDeleted: 0
       }
     ])
 
@@ -141,11 +161,21 @@ describe('highlight-storage — PDF support', () => {
     const listMock = window.electron.highlightsList as unknown as ReturnType<typeof vi.fn>
     listMock.mockResolvedValueOnce([
       {
-        id: 'pdf-1', bookId: 'b1',
-        format: 'pdf', cfiRange: null, locator: JSON.stringify({ page: 2, rects: [{ x: 0, y: 0, w: 50, h: 10 }] }),
-        text: 'pdf text', color: 'blue', note: '', chapter: null,
-        createdAt: '2026-05-17T00:00:00.000Z', updatedAt: null,
-        syncId: null, syncVersion: 0, isDirty: 0, isDeleted: 0
+        id: 'pdf-1',
+        bookId: 'b1',
+        format: 'pdf',
+        cfiRange: null,
+        locator: JSON.stringify({ page: 2, rects: [{ x: 0, y: 0, w: 50, h: 10 }] }),
+        text: 'pdf text',
+        color: 'blue',
+        note: '',
+        chapter: null,
+        createdAt: '2026-05-17T00:00:00.000Z',
+        updatedAt: null,
+        syncId: null,
+        syncVersion: 0,
+        isDirty: 0,
+        isDeleted: 0
       }
     ])
 

--- a/apps/rishi-electron/src/renderer/src/modules/note-icon-overlay.test.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/note-icon-overlay.test.ts
@@ -55,7 +55,7 @@ describe('NoteIconOverlay', () => {
     expect(iframeDoc.querySelectorAll(`[${NOTE_ICON_ATTR}]`)).toHaveLength(0)
   })
 
-  it('positions each icon at the top-right of the range\'s LAST bounding rect (multi-line ranges anchor to the last line)', () => {
+  it("positions each icon at the top-right of the range's LAST bounding rect (multi-line ranges anchor to the last line)", () => {
     const overlay = new NoteIconOverlay({
       iframeDoc,
       resolveRange: () =>
@@ -80,9 +80,7 @@ describe('NoteIconOverlay', () => {
     const overlay = new NoteIconOverlay({
       iframeDoc,
       resolveRange: (cfi) =>
-        cfi === 'cfi:present'
-          ? fakeRange([{ top: 0, left: 0, right: 100, bottom: 20 }])
-          : null,
+        cfi === 'cfi:present' ? fakeRange([{ top: 0, left: 0, right: 100, bottom: 20 }]) : null,
       onIconClick: vi.fn()
     })
 

--- a/apps/rishi-electron/src/renderer/src/modules/pageCapture/encode.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/pageCapture/encode.ts
@@ -51,8 +51,16 @@ export async function encodeCanvasToWebp(
 
   const dataUrl = await new Promise<string>((resolve, reject) => {
     const reader = new FileReader()
-    reader.onerror = () => reject(reader.error)
-    reader.onload = () => resolve(String(reader.result))
+    reader.onerror = () =>
+      reject(reader.error instanceof Error ? reader.error : new Error('FileReader: unknown error'))
+    reader.onload = () => {
+      const result = reader.result
+      if (typeof result === 'string') {
+        resolve(result)
+      } else {
+        reject(new Error('FileReader: expected string data URL, got non-string result'))
+      }
+    }
     reader.readAsDataURL(blob)
   })
 

--- a/apps/rishi-electron/src/renderer/src/modules/pageCapture/index.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/pageCapture/index.ts
@@ -11,7 +11,10 @@ export const CaptureError = {
 export type CaptureErrorCode = (typeof CaptureError)[keyof typeof CaptureError]
 
 export class PageCaptureError extends Error {
-  constructor(public code: CaptureErrorCode, message: string) {
+  constructor(
+    public code: CaptureErrorCode,
+    message: string
+  ) {
     super(message)
     this.name = 'PageCaptureError'
   }

--- a/apps/rishi-electron/src/renderer/src/modules/pdf-locator.test.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/pdf-locator.test.ts
@@ -19,14 +19,26 @@ function makeViewport(opts: { width: number; height: number; scale: number }) {
   } as const
 }
 
-function makePageEl(rect: { left: number; top: number; width: number; height: number }): HTMLElement {
+function makePageEl(rect: {
+  left: number
+  top: number
+  width: number
+  height: number
+}): HTMLElement {
   const div = document.createElement('div')
   Object.defineProperty(div, 'getBoundingClientRect', {
     value: () => ({
-      left: rect.left, top: rect.top,
-      right: rect.left + rect.width, bottom: rect.top + rect.height,
-      width: rect.width, height: rect.height, x: rect.left, y: rect.top,
-      toJSON() { return this }
+      left: rect.left,
+      top: rect.top,
+      right: rect.left + rect.width,
+      bottom: rect.top + rect.height,
+      width: rect.width,
+      height: rect.height,
+      x: rect.left,
+      y: rect.top,
+      toJSON() {
+        return this
+      }
     })
   })
   return div
@@ -48,9 +60,11 @@ describe('pdf-locator', () => {
       pageB.className = 'react-pdf__Page'
       const t1 = document.createTextNode('hello')
       const t2 = document.createTextNode('world')
-      pageA.appendChild(t1); pageB.appendChild(t2)
+      pageA.appendChild(t1)
+      pageB.appendChild(t2)
       const range = document.createRange()
-      range.setStart(t1, 0); range.setEnd(t2, 5)
+      range.setStart(t1, 0)
+      range.setEnd(t2, 5)
       const viewport = makeViewport({ width: 400, height: 600, scale: 1 })
       expect(selectionToPdfLocator(range, pageA, viewport as never, 1)).toBeNull()
     })
@@ -62,7 +76,8 @@ describe('pdf-locator', () => {
       const range = document.createRange()
       const text = document.createTextNode('xyz')
       pageEl.appendChild(text)
-      range.setStart(text, 0); range.setEnd(text, 3)
+      range.setStart(text, 0)
+      range.setEnd(text, 3)
       Object.defineProperty(range, 'getClientRects', {
         value: () => [{ left: 60, top: 120, width: 100, height: 15, right: 160, bottom: 135 }]
       })
@@ -85,7 +100,8 @@ describe('pdf-locator', () => {
       const range = document.createRange()
       const t = document.createTextNode('abcdef')
       pageEl1.appendChild(t)
-      range.setStart(t, 0); range.setEnd(t, 3)
+      range.setStart(t, 0)
+      range.setEnd(t, 3)
       Object.defineProperty(range, 'getClientRects', {
         value: () => [{ left: 0, top: 0, width: 50, height: 12, right: 50, bottom: 12 }]
       })
@@ -104,12 +120,13 @@ describe('pdf-locator', () => {
       const text = document.createTextNode('xyz')
       pageEl.appendChild(text)
       const range = document.createRange()
-      range.setStart(text, 0); range.setEnd(text, 3)
+      range.setStart(text, 0)
+      range.setEnd(text, 3)
       Object.defineProperty(range, 'getClientRects', {
         value: () => [
-          { left: 0, top: 0, width: 0, height: 10, right: 0, bottom: 10 },     // zero width
-          { left: 0, top: 0, width: 10, height: 0, right: 10, bottom: 0 },     // zero height
-          { left: 0, top: 0, width: 10, height: 10, right: 10, bottom: 10 }    // valid
+          { left: 0, top: 0, width: 0, height: 10, right: 0, bottom: 10 }, // zero width
+          { left: 0, top: 0, width: 10, height: 0, right: 10, bottom: 0 }, // zero height
+          { left: 0, top: 0, width: 10, height: 10, right: 10, bottom: 10 } // valid
         ]
       })
       const result = selectionToPdfLocator(range, pageEl, viewport as never, 1)
@@ -123,7 +140,8 @@ describe('pdf-locator', () => {
       const vp = makeViewport({ width: 400, height: 600, scale: 1 })
       const screen = pdfLocatorToScreenRects(
         { page: 1, rects: [{ x: 10, y: 565, w: 100, h: 15 }] },
-        pageEl, vp as never
+        pageEl,
+        vp as never
       )
       expect(screen).toEqual([{ left: 10, top: 20, width: 100, height: 15 }])
     })

--- a/apps/rishi-electron/src/renderer/src/routeTree.gen.ts
+++ b/apps/rishi-electron/src/renderer/src/routeTree.gen.ts
@@ -19,17 +19,17 @@ const BooksIdLazyRouteImport = createFileRoute('/books/$id')()
 const IndexLazyRoute = IndexLazyRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRouteImport
 } as any).lazy(() => import('./routes/index.lazy').then((d) => d.Route))
 const BooksIdLazyRoute = BooksIdLazyRouteImport.update({
   id: '/books/$id',
   path: '/books/$id',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRouteImport
 } as any).lazy(() => import('./routes/books.$id.lazy').then((d) => d.Route))
 const SettingsAccountRoute = SettingsAccountRouteImport.update({
   id: '/settings/account',
   path: '/settings/account',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRouteImport
 } as any)
 
 export interface FileRoutesByFullPath {
@@ -91,7 +91,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexLazyRoute: IndexLazyRoute,
   SettingsAccountRoute: SettingsAccountRoute,
-  BooksIdLazyRoute: BooksIdLazyRoute,
+  BooksIdLazyRoute: BooksIdLazyRoute
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/rishi-electron/src/renderer/src/routes/__root.tsx
+++ b/apps/rishi-electron/src/renderer/src/routes/__root.tsx
@@ -57,8 +57,7 @@ function RootComponent(): JSX.Element {
     const id = e.windowIdentity
 
     const enforce = (): void => {
-      const path =
-        window.location.hash.replace(/^#/, '').replace(/^\/+/, '/') || location.pathname
+      const path = window.location.hash.replace(/^#/, '').replace(/^\/+/, '/') || location.pathname
 
       if (id?.kind === 'library') {
         const m = path.match(/^\/books\/(\d+)/)

--- a/apps/rishi-electron/src/renderer/src/services/book-import/importer.test.ts
+++ b/apps/rishi-electron/src/renderer/src/services/book-import/importer.test.ts
@@ -213,13 +213,7 @@ describe('runImport — save failure does NOT roll back copy', () => {
     expect(result.ok).toBe(false)
     if (!result.ok) expect(result.stage).toBe('save')
     expect(removeCalls).toEqual([])
-    expect(events.map((e) => e.kind)).toEqual([
-      'copying',
-      'hashing',
-      'parsing',
-      'saving',
-      'failed'
-    ])
+    expect(events.map((e) => e.kind)).toEqual(['copying', 'hashing', 'parsing', 'saving', 'failed'])
   })
 })
 
@@ -273,13 +267,7 @@ describe('runImport — happy path EPUB', () => {
     expect(copyCalls).toEqual(['/Downloads/sample.epub'])
     expect(savedBooks).toHaveLength(1)
     expect(savedBooks[0].filepath).toBe('/userData/sample.epub')
-    expect(events.map((e) => e.kind)).toEqual([
-      'copying',
-      'hashing',
-      'parsing',
-      'saving',
-      'done'
-    ])
+    expect(events.map((e) => e.kind)).toEqual(['copying', 'hashing', 'parsing', 'saving', 'done'])
   })
 })
 

--- a/apps/rishi-electron/src/renderer/src/services/book-import/service.test.ts
+++ b/apps/rishi-electron/src/renderer/src/services/book-import/service.test.ts
@@ -162,8 +162,7 @@ describe('BookImportService.importBatch', () => {
     // detected as a duplicate within the same importBatch call — proving the
     // dedup adapter sees writes made earlier in the batch.
     const { db, savedBooks } = makeDbForImport({
-      findBookByHashImpl: async (hash) =>
-        savedBooks.find((b) => b.fileHash === hash) ?? null
+      findBookByHashImpl: async (hash) => savedBooks.find((b) => b.fileHash === hash) ?? null
     })
     const fileSync = makeFileSync({ hashImpl: async () => 'same-hash' })
     const service = createBookImportService(makeDeps({ db, fileSync }))

--- a/apps/rishi-electron/src/renderer/src/services/index.ts
+++ b/apps/rishi-electron/src/renderer/src/services/index.ts
@@ -18,7 +18,13 @@ import {
   type VoiceChatService
 } from './voice-chat'
 
-export type { DiscoveredBook, ImportResult, ImportSuccess, PageDataInsertable, ScanProgress } from './book-import'
+export type {
+  DiscoveredBook,
+  ImportResult,
+  ImportSuccess,
+  PageDataInsertable,
+  ScanProgress
+} from './book-import'
 import { createSyncEngine } from '@rishi/shared/sync-engine'
 import { embedSingleText, embedWithFallback } from '@/modules/embed-fallback'
 import { hashBookFile, uploadBookFile, getFileSize } from '@/modules/file-sync'
@@ -298,7 +304,7 @@ export function getVoiceChatService(): VoiceChatService {
               }
             }
           }
-        } as never) as never,
+        }) as never,
       media: {
         getUserMedia: (constraints) => navigator.mediaDevices.getUserMedia(constraints),
         createAudioElement: () => {
@@ -311,8 +317,9 @@ export function getVoiceChatService(): VoiceChatService {
           // Prefer Opus-in-WebM (Deepgram accepts it directly); fall back to
           // the platform default if the codec isn't supported.
           const preferred = 'audio/webm;codecs=opus'
-          const options =
-            MediaRecorder.isTypeSupported(preferred) ? { mimeType: preferred } : undefined
+          const options = MediaRecorder.isTypeSupported(preferred)
+            ? { mimeType: preferred }
+            : undefined
           try {
             return new MediaRecorder(
               stream as unknown as MediaStream,

--- a/apps/rishi-electron/src/renderer/src/services/index.ts
+++ b/apps/rishi-electron/src/renderer/src/services/index.ts
@@ -398,7 +398,7 @@ export function getVoiceChatService(): VoiceChatService {
     void usePrefsStore
       .getState()
       .hydrate()
-      .catch((err) => {
+      .catch((err: unknown) => {
         console.warn('[prefs] hydrate failed', err)
       })
   }

--- a/apps/rishi-electron/src/renderer/src/services/tts/index.ts
+++ b/apps/rishi-electron/src/renderer/src/services/tts/index.ts
@@ -16,7 +16,7 @@ import { createVisualCueEmitter, type VisualCueEmitter } from './visual-cue-emit
 let _visualCueEmitter: VisualCueEmitter | null = null
 
 export function getVisualCueEmitter(): VisualCueEmitter {
-  if (!_visualCueEmitter) _visualCueEmitter = createVisualCueEmitter()
+  _visualCueEmitter ??= createVisualCueEmitter()
   return _visualCueEmitter
 }
 

--- a/apps/rishi-electron/src/renderer/src/services/voice-chat/activation-program.ts
+++ b/apps/rishi-electron/src/renderer/src/services/voice-chat/activation-program.ts
@@ -396,7 +396,7 @@ export function makeActivationProgram(a: ActivationDeps): ActivationProgram {
               // On activation failure: stop the recorder so its hooks detach
               // and the buffer is dropped. On success: replayBufferedSpeech
               // owns the stop.
-              if (!success && b && b.recorder.state === 'recording') {
+              if (!success && b?.recorder.state === 'recording') {
                 try {
                   b.recorder.stop()
                 } catch (err) {

--- a/apps/rishi-electron/src/renderer/src/services/voice-chat/local-vad.test.ts
+++ b/apps/rishi-electron/src/renderer/src/services/voice-chat/local-vad.test.ts
@@ -220,9 +220,10 @@ describe('createLocalVad — waitForSpeechEnd', () => {
     await advance(baseConfig.pollIntervalMs)
 
     const settled = vi.fn()
-    const waitPromise = vad
-      .waitForSpeechEnd(300)
-      .then(() => settled('ok'), (e: unknown) => settled(e))
+    const waitPromise = vad.waitForSpeechEnd(300).then(
+      () => settled('ok'),
+      (e: unknown) => settled(e)
+    )
 
     await advance(400)
     await waitPromise
@@ -240,9 +241,10 @@ describe('createLocalVad — waitForSpeechEnd', () => {
     await advance(baseConfig.pollIntervalMs)
 
     const settled = vi.fn()
-    const waitPromise = vad
-      .waitForSpeechEnd(10_000)
-      .then(() => settled('ok'), (e: unknown) => settled(e))
+    const waitPromise = vad.waitForSpeechEnd(10_000).then(
+      () => settled('ok'),
+      (e: unknown) => settled(e)
+    )
 
     vad.dispose()
     await advance(0)

--- a/apps/rishi-electron/src/renderer/src/services/voice-chat/local-vad.ts
+++ b/apps/rishi-electron/src/renderer/src/services/voice-chat/local-vad.ts
@@ -18,7 +18,10 @@ interface AudioCtxLike {
   state: 'suspended' | 'running' | 'closed'
   resume(): Promise<void>
   close(): Promise<void>
-  createMediaStreamSource(stream: MediaStreamLike): { connect(dest: unknown): void; disconnect(): void }
+  createMediaStreamSource(stream: MediaStreamLike): {
+    connect(dest: unknown): void
+    disconnect(): void
+  }
   createAnalyser(): AnalyserLike
 }
 
@@ -39,7 +42,7 @@ function readGlobalAudioContext(): (new () => AudioCtxLike) | null {
 function computeRms(samples: Float32Array): number {
   let sumSq = 0
   for (let i = 0; i < samples.length; i++) {
-    const s = samples[i]!
+    const s = samples[i]
     sumSq += s * s
   }
   return Math.sqrt(sumSq / samples.length)

--- a/apps/rishi-electron/src/renderer/src/services/voice-chat/service.test.ts
+++ b/apps/rishi-electron/src/renderer/src/services/voice-chat/service.test.ts
@@ -100,11 +100,18 @@ export function makeAgent(): {
   factory: (args: AgentFactoryArgs) => RealtimeAgentLike
   lastArgs: () => AgentFactoryArgs | null
   triggerEnd: (reason: string) => void
-  triggerInspectImage: (image: { dataUrl: string; width: number; height: number; bytes: number }) => void
+  triggerInspectImage: (image: {
+    dataUrl: string
+    width: number
+    height: number
+    bytes: number
+  }) => void
 } {
   let lastArgs: AgentFactoryArgs | null = null
   let lastOnEnd: ((reason: string) => void) | null = null
-  let lastOnInspect: ((image: { dataUrl: string; width: number; height: number; bytes: number }) => void) | null = null
+  let lastOnInspect:
+    | ((image: { dataUrl: string; width: number; height: number; bytes: number }) => void)
+    | null = null
   return {
     factory: (args) => {
       lastArgs = args
@@ -1169,9 +1176,7 @@ describe('createVoiceChatService — buffered speech replay', () => {
   it('starts a MediaRecorder during connect when MediaPort supports it', async () => {
     const media = makeMedia({ withRecorder: true })
     const session = makeSession()
-    const svc = createVoiceChatService(
-      makeDeps({ media, sessionFactory: session.factory })
-    )
+    const svc = createVoiceChatService(makeDeps({ media, sessionFactory: session.factory }))
     await svc.activate(1, { pageText: 'p' })
 
     const rec = media.lastRecorder()
@@ -1186,9 +1191,7 @@ describe('createVoiceChatService — buffered speech replay', () => {
     // connect window — otherwise the mock's connect resolves synchronously
     // and the recorder is stopped before any audio can land in the buffer.
     const session = makeSession({ connectDelayMs: 20 })
-    const svc = createVoiceChatService(
-      makeDeps({ media, ipc, sessionFactory: session.factory })
-    )
+    const svc = createVoiceChatService(makeDeps({ media, ipc, sessionFactory: session.factory }))
 
     const activation = svc.activate(1, { pageText: 'p' })
     // Give the Effect fiber time to acquire mic + create recorder before we
@@ -1207,9 +1210,7 @@ describe('createVoiceChatService — buffered speech replay', () => {
     const media = makeMedia({ withRecorder: true })
     const ipc = makeIpc({ key: 'k', transcript: 'nope' })
     const session = makeSession()
-    const svc = createVoiceChatService(
-      makeDeps({ media, ipc, sessionFactory: session.factory })
-    )
+    const svc = createVoiceChatService(makeDeps({ media, ipc, sessionFactory: session.factory }))
     await svc.activate(1, { pageText: 'p' })
     await new Promise((r) => setTimeout(r, 0))
 
@@ -1221,9 +1222,7 @@ describe('createVoiceChatService — buffered speech replay', () => {
     const media = makeMedia({ withRecorder: true })
     const ipc = makeIpc({ key: 'k', transcript: '   ' })
     const session = makeSession({ connectDelayMs: 20 })
-    const svc = createVoiceChatService(
-      makeDeps({ media, ipc, sessionFactory: session.factory })
-    )
+    const svc = createVoiceChatService(makeDeps({ media, ipc, sessionFactory: session.factory }))
 
     const activation = svc.activate(1, { pageText: 'p' })
     await new Promise((r) => setTimeout(r, 0))
@@ -1242,9 +1241,7 @@ describe('createVoiceChatService — buffered speech replay', () => {
       transcribeFailWith: new Error('deepgram exploded')
     })
     const session = makeSession({ connectDelayMs: 20 })
-    const svc = createVoiceChatService(
-      makeDeps({ media, ipc, sessionFactory: session.factory })
-    )
+    const svc = createVoiceChatService(makeDeps({ media, ipc, sessionFactory: session.factory }))
 
     const activation = svc.activate(1, { pageText: 'p' })
     await new Promise((r) => setTimeout(r, 0))
@@ -1261,9 +1258,7 @@ describe('createVoiceChatService — buffered speech replay', () => {
     const media = makeMedia() // no withRecorder
     const ipc = makeIpc({ key: 'k', transcript: 'unreachable' })
     const session = makeSession()
-    const svc = createVoiceChatService(
-      makeDeps({ media, ipc, sessionFactory: session.factory })
-    )
+    const svc = createVoiceChatService(makeDeps({ media, ipc, sessionFactory: session.factory }))
     await svc.activate(1, { pageText: 'p' })
     await new Promise((r) => setTimeout(r, 0))
 
@@ -1275,9 +1270,7 @@ describe('createVoiceChatService — buffered speech replay', () => {
   it('stops the recorder if activation fails before connect completes', async () => {
     const media = makeMedia({ withRecorder: true })
     const session = makeSession({ connectFailWith: new Error('boom') })
-    const svc = createVoiceChatService(
-      makeDeps({ media, sessionFactory: session.factory })
-    )
+    const svc = createVoiceChatService(makeDeps({ media, sessionFactory: session.factory }))
 
     await expect(svc.activate(1, { pageText: 'p' })).rejects.toThrow('boom')
 
@@ -1311,9 +1304,7 @@ describe('createVoiceChatService — buffered speech replay', () => {
   it('activation succeeds when createMediaRecorder throws on construction', async () => {
     const media = makeMedia({ withRecorder: true, recorderConstructThrows: true })
     const session = makeSession()
-    const svc = createVoiceChatService(
-      makeDeps({ media, sessionFactory: session.factory })
-    )
+    const svc = createVoiceChatService(makeDeps({ media, sessionFactory: session.factory }))
 
     await svc.activate(1, { pageText: 'p' })
 
@@ -1326,9 +1317,7 @@ describe('createVoiceChatService — buffered speech replay', () => {
     const media = makeMedia({ withRecorder: true, recorderStopThrows: true })
     const ipc = makeIpc({ key: 'k', transcript: 'should not be called' })
     const session = makeSession({ connectDelayMs: 20 })
-    const svc = createVoiceChatService(
-      makeDeps({ media, ipc, sessionFactory: session.factory })
-    )
+    const svc = createVoiceChatService(makeDeps({ media, ipc, sessionFactory: session.factory }))
 
     const activation = svc.activate(1, { pageText: 'p' })
     await new Promise((r) => setTimeout(r, 0))
@@ -1349,9 +1338,7 @@ describe('createVoiceChatService — buffered speech replay', () => {
     const media = makeMedia({ withRecorder: true, deferOnstop: true })
     const ipc = makeIpc({ key: 'k', transcript: 'late audio captured' })
     const session = makeSession({ connectDelayMs: 20 })
-    const svc = createVoiceChatService(
-      makeDeps({ media, ipc, sessionFactory: session.factory })
-    )
+    const svc = createVoiceChatService(makeDeps({ media, ipc, sessionFactory: session.factory }))
 
     const activation = svc.activate(1, { pageText: 'p' })
     await new Promise((r) => setTimeout(r, 0))
@@ -1377,9 +1364,7 @@ describe('createVoiceChatService — buffered speech replay', () => {
     const media = makeMedia({ withRecorder: true })
     const ipc = makeIpc({ key: 'k', transcript: 'capped' })
     const session = makeSession({ connectDelayMs: 30 })
-    const svc = createVoiceChatService(
-      makeDeps({ media, ipc, sessionFactory: session.factory })
-    )
+    const svc = createVoiceChatService(makeDeps({ media, ipc, sessionFactory: session.factory }))
 
     const activation = svc.activate(1, { pageText: 'p' })
     await new Promise((r) => setTimeout(r, 0))
@@ -1402,9 +1387,7 @@ describe('createVoiceChatService — buffered speech replay', () => {
     const media = makeMedia({ withRecorder: true })
     const ipc = makeIpc({ key: 'k', transcript: 'fresh-text' })
     const session = makeSession({ connectDelayMs: 15 })
-    const svc = createVoiceChatService(
-      makeDeps({ media, ipc, sessionFactory: session.factory })
-    )
+    const svc = createVoiceChatService(makeDeps({ media, ipc, sessionFactory: session.factory }))
 
     // First activation with a chunk.
     const first = svc.activate(1, { pageText: 'p1' })
@@ -1431,9 +1414,7 @@ describe('createVoiceChatService — buffered speech replay', () => {
   it('deactivate during in-flight cold path stops the recorder via finalizer', async () => {
     const media = makeMedia({ withRecorder: true })
     const session = makeSession({ connectDelayMs: 100 })
-    const svc = createVoiceChatService(
-      makeDeps({ media, sessionFactory: session.factory })
-    )
+    const svc = createVoiceChatService(makeDeps({ media, sessionFactory: session.factory }))
 
     const activatePromise = svc.activate(1, { pageText: 'p' })
     // Wait for the fiber to walk through mic + session build + recorder start.
@@ -1506,7 +1487,8 @@ describe('createVoiceChatService — VAD gating', () => {
     // doesn't create a duplicate turn.
     const sendOrder = session.sendMessage.mock.invocationCallOrder[0]!
     const muteOrder = session.mute.mock.invocationCallOrder.find(
-      (n) => session.mute.mock.calls[session.mute.mock.invocationCallOrder.indexOf(n)]?.[0] === false
+      (n) =>
+        session.mute.mock.calls[session.mute.mock.invocationCallOrder.indexOf(n)]?.[0] === false
     )
     expect(sendOrder).toBeLessThan(muteOrder!)
   })
@@ -1627,9 +1609,7 @@ describe('createVoiceChatService — VAD gating', () => {
   it('VAD is disposed alongside the session', async () => {
     const { port: vadPort, vad } = makeVad({ initialEverSpoke: true })
     const session = makeSession()
-    const svc = createVoiceChatService(
-      makeDeps({ sessionFactory: session.factory, vad: vadPort })
-    )
+    const svc = createVoiceChatService(makeDeps({ sessionFactory: session.factory, vad: vadPort }))
 
     await svc.activate(1, { pageText: 'p' })
     expect(vad!.disposeCalls()).toBe(0)

--- a/apps/rishi-electron/src/renderer/src/services/voice-chat/service.ts
+++ b/apps/rishi-electron/src/renderer/src/services/voice-chat/service.ts
@@ -187,7 +187,8 @@ export function createVoiceChatService(deps: VoiceChatServiceDeps): VoiceChatSer
             activeParagraphText: ctx.activeParagraphText,
             visualSummary: ctx.visualSummary,
             onEndConversation: (reason) => endedByAgentEmitter.emit(reason),
-            onInspectImage: (image) => liveSession.addImage(image.dataUrl, { triggerResponse: false }),
+            onInspectImage: (image) =>
+              liveSession.addImage(image.dataUrl, { triggerResponse: false }),
             rag,
             language: getLanguage()
           })

--- a/apps/rishi-electron/src/renderer/src/stores/pdfStore.test.ts
+++ b/apps/rishi-electron/src/renderer/src/stores/pdfStore.test.ts
@@ -131,15 +131,15 @@ describe('pdfStore', () => {
     const mask = new Map<number, Set<number>>([[5, new Set([2, 3])]])
     usePdfStore.getState().addBook(1)
     usePdfStore.getState().setFooterMask(1, mask)
-    expect(
-      Object.prototype.hasOwnProperty.call(usePdfStore.getState().footerMaskByBookId, 1)
-    ).toBe(true)
+    expect(Object.prototype.hasOwnProperty.call(usePdfStore.getState().footerMaskByBookId, 1)).toBe(
+      true
+    )
 
     usePdfStore.getState().removeBook(1)
 
-    expect(
-      Object.prototype.hasOwnProperty.call(usePdfStore.getState().footerMaskByBookId, 1)
-    ).toBe(false)
+    expect(Object.prototype.hasOwnProperty.call(usePdfStore.getState().footerMaskByBookId, 1)).toBe(
+      false
+    )
     expect(usePdfStore.getState().footerMaskByBookId[1]).toBeUndefined()
   })
 })

--- a/apps/rishi-electron/src/renderer/src/styles/globals.css
+++ b/apps/rishi-electron/src/renderer/src/styles/globals.css
@@ -1,5 +1,5 @@
-@import "tailwindcss";
-@import "tw-animate-css";
+@import 'tailwindcss';
+@import 'tw-animate-css';
 
 *[data-electron-drag-region] {
   -webkit-app-region: drag;


### PR DESCRIPTION
## What

Mechanical auto-fix pass against #219 — \`pnpm exec eslint . --fix\` followed by \`pnpm exec prettier --write .\`, no hand edits.

## Numbers

| Stage | Problems | Errors | Warnings |
|---|---|---|---|
| \`main\` HEAD (74284feb) | 675 | **65** | 610 |
| This PR | 82 | **45** | 37 |
| **Cleared** | **593** | **20** | **573** |

Typecheck (\`pnpm typecheck\` = both tsc projects) passes clean. No semantic regressions from the auto-fix.

## ⚠️ This PR does NOT green CI on its own

45 lint errors remain (rule breakdown in the commit message). Lint will still exit 1. The remaining errors are real per-site fixes:

| Rule | Count | Nature |
|---|---|---|
| \`@typescript-eslint/no-unnecessary-condition\` | 22 | TS-control-flow says condition is always truthy/falsy. Each site is either a real dead branch or a stale type narrowing. |
| \`react-hooks/refs\` (\"Cannot access refs during render\") | 8 | New rule; flags \`ref.current\` reads during render. Real refactor — move into \`useEffect\` or event handlers. |
| \`@typescript-eslint/no-empty-function\` | 4 | Empty \`connect\`/\`disconnect\` methods, likely mock/stub classes. Probably just need an \`// eslint-disable-next-line\` with rationale. |
| \`@typescript-eslint/prefer-nullish-coalescing\` | 3 | Mechanical \`||\` → \`??\` on nullable types. |
| \`react-hooks/set-state-in-effect\` | 2 | New rule; real refactor — derive state during render instead of in effect. |
| 6 singletons | 6 | \`consistent-type-imports\`, \`require-await\`, \`prefer-promise-reject-errors\`, \`no-base-to-string\`, \`use-unknown-in-catch-callback-variable\`, \`no-floating-promises\`, \`react-refresh/only-export-components\` |

Follow-up issue tracks the manual cleanup.

## Why split

- **Mechanical pass is low-risk and high-volume.** Reviewing 66 files of \`eslint --fix\` + \`prettier --write\` changes is much easier when the diff is pure mechanical (no semantic intent to vet).
- **Manual fixes are high-risk and low-volume.** Each remaining error needs a per-site judgement call (is the dead branch real intent? does the ref access need to move into an effect or into a handler?). Reviewing them benefits from a small focused diff.
- **Rebaseable inheritance.** The 10 open electron PRs (#29, #210–#218) can rebase on this branch / on main once merged. Cuts down the per-PR churn from prettier (570 warnings).

## Scope of this PR

- Only \`.ts\`/\`.tsx\`/\`.css\` source files modified. 12 markdown plan docs in \`apps/rishi-electron/docs/superpowers/\` were touched by prettier — reverted because they're irrelevant to CI lint and would add noise.

## What's NOT in this PR

- The remaining 45 manual errors (tracked in the follow-up issue).
- The Mobile lint failure (#220).
- The Worker setup-bun failure (#221).
- Any changes to the lint config or rule severity — the rules are configured \`error\` intentionally as footgun-catchers.

Closes part 1 of #219.