### PR TITLE
fix(mobile/reader): hoist useCallback above early-returns (#220)

### DIFF
--- a/apps/mobile/app/reader/djvu/[id].tsx
+++ b/apps/mobile/app/reader/djvu/[id].tsx
@@ -489,6 +489,25 @@ export default function DjvuReaderScreen() {
     }))
   }, [pageCount])
 
+  // CHT-002 — voice-chat activation context. DJVU is canvas-only (no text
+  // layer that survives the WebView round-trip), so the best we can do is
+  // pass a "Page N of M" page-text proxy plus the synthesised per-page
+  // outline. When TTS is active, forward the active paragraph too — the
+  // shared extractor can light this up if the DJVU has an OCR layer.
+  // Declared above the loading/error early-returns so the hook order stays
+  // stable across renders (react-hooks/rules-of-hooks).
+  const getActivationContext = useCallback(() => {
+    const outline = tocItems.map((t) => ({ href: t.href, label: t.label }))
+    const pageText = pageCount > 0
+      ? `Page ${currentPage} of ${pageCount}`
+      : `Page ${currentPage}`
+    return {
+      pageText,
+      outline,
+      activeParagraphText: activeParagraph?.text ?? undefined,
+    }
+  }, [tocItems, currentPage, pageCount, activeParagraph])
+
   const currentTocHref = useMemo(
     () => `djvu-page:${currentPage}`,
     [currentPage],
@@ -582,23 +601,6 @@ export default function DjvuReaderScreen() {
     pageCount > 0
       ? { kind: 'page', current: currentPage, total: pageCount }
       : { kind: 'none' }
-
-  // CHT-002 — voice-chat activation context. DJVU is canvas-only (no text
-  // layer that survives the WebView round-trip), so the best we can do is
-  // pass a "Page N of M" page-text proxy plus the synthesised per-page
-  // outline. When TTS is active, forward the active paragraph too — the
-  // shared extractor can light this up if the DJVU has an OCR layer.
-  const getActivationContext = useCallback(() => {
-    const outline = tocItems.map((t) => ({ href: t.href, label: t.label }))
-    const pageText = pageCount > 0
-      ? `Page ${currentPage} of ${pageCount}`
-      : `Page ${currentPage}`
-    return {
-      pageText,
-      outline,
-      activeParagraphText: activeParagraph?.text ?? undefined,
-    }
-  }, [tocItems, currentPage, pageCount, activeParagraph])
 
   const djvuNavCluster = (
     <DjvuNavCluster

--- a/apps/mobile/app/reader/mobi/[id].tsx
+++ b/apps/mobile/app/reader/mobi/[id].tsx
@@ -474,6 +474,23 @@ export default function MobiReaderScreen() {
     }))
   }, [chapterCount])
 
+  // CHT-002 — voice-chat activation context. MOBI doesn't cheaply expose
+  // the rendered DOM text (the parser ships HTML into the WebView and
+  // doesn't pipe it back), so we use the synthesised chapter label as
+  // `pageText` and pass the active TTS paragraph when one is live. Outline
+  // = the per-chapter TocItem list so the agent can resolve "previous
+  // chapter" etc.
+  // Declared above the loading/error early-returns so the hook order stays
+  // stable across renders (react-hooks/rules-of-hooks).
+  const getActivationContext = useCallback(() => {
+    const outline = tocItems.map((t) => ({ href: t.href, label: t.label }))
+    return {
+      pageText: `Chapter ${currentChapter + 1}`,
+      outline,
+      activeParagraphText: activeParagraph?.text ?? undefined,
+    }
+  }, [tocItems, currentChapter, activeParagraph])
+
   const currentTocHref = useMemo(
     () => `mobi-chapter:${currentChapter}`,
     [currentChapter],
@@ -671,21 +688,6 @@ export default function MobiReaderScreen() {
     chapterCount > 0
       ? { kind: 'chapter', current: currentChapter + 1, total: chapterCount }
       : { kind: 'none' }
-
-  // CHT-002 — voice-chat activation context. MOBI doesn't cheaply expose
-  // the rendered DOM text (the parser ships HTML into the WebView and
-  // doesn't pipe it back), so we use the synthesised chapter label as
-  // `pageText` and pass the active TTS paragraph when one is live. Outline
-  // = the per-chapter TocItem list so the agent can resolve "previous
-  // chapter" etc.
-  const getActivationContext = useCallback(() => {
-    const outline = tocItems.map((t) => ({ href: t.href, label: t.label }))
-    return {
-      pageText: `Chapter ${currentChapter + 1}`,
-      outline,
-      activeParagraphText: activeParagraph?.text ?? undefined,
-    }
-  }, [tocItems, currentChapter, activeParagraph])
 
   const mobiNavCluster = (
     <MobiNavCluster


### PR DESCRIPTION
## Problem (#220)

\`Mobile (lint)\` was failing on main with 2 \`react-hooks/rules-of-hooks\` errors:

- \`apps/mobile/app/reader/djvu/[id].tsx:591:32\` — \`useCallback\` after the loading + error early-returns
- \`apps/mobile/app/reader/mobi/[id].tsx:681:32\` — same pattern

Rules-of-hooks violations are real bugs: when the early-return fires, the hook isn't called, but on a re-render where the conditions don't fire, the hook IS called — so React's hook-order invariant breaks, which in production can cause state to cross between hook slots.

## Fix

Hoisted both \`getActivationContext\` \`useCallback\` blocks (including their docblocks) to immediately after the \`tocItems\` \`useMemo\` — the deepest dependency. All other deps (\`pageCount\`, \`currentPage\`, \`activeParagraph\` on djvu; \`chapterCount\`, \`currentChapter\`, \`activeParagraph\` on mobi) are also declared earlier in the function, so the hoist is safe.

Updated the docblock to note: \"Declared above the loading/error early-returns so the hook order stays stable across renders (react-hooks/rules-of-hooks).\" Anyone touching this code later sees the constraint.

No other behavioural change. Closure shape, dependency arrays, and consumer call site (\`<ReaderShell getActivationContext={getActivationContext} />\`) are unchanged.

## Verification

\`\`\`
\$ cd apps/mobile && pnpm lint
✖ 20 problems (0 errors, 20 warnings)
\`\`\`

vs main HEAD:

\`\`\`
\$ cd apps/mobile && pnpm lint
✖ 22 problems (2 errors, 20 warnings)
\`\`\`

Net change: -2 errors, warnings unchanged. The 20 remaining warnings are pre-existing main-branch lint debt (Array<T> vs T[], no-unused-expressions, etc.) and don't affect the CI gate.

\`pnpm exec tsc --noEmit\` from the mobile dir surfaces pre-existing dep-resolution errors in \`packages/shared/src/voice-chat/*.ts\` (\`xstate\`, \`effect\` not resolvable from mobile's tsconfig); these are unrelated to this PR — the mobile CI job only runs \`lint\`, not \`typecheck\`.

Closes #220.