### PR TITLE
fix(ci): pin setup-bun to SHA + explicit bun-version (#221)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: oven-sh/setup-bun@v2  # 0c5077e51419868618aeaa5fe8019c62421857d6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # pinned-by-SHA + explicit bun-version skips the GitHub tags-API resolve that returns 401 (#221)
+        with:
+          bun-version: 1.1.42
 
       - uses: actions/cache@v4
         with:
@@ -90,7 +92,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: oven-sh/setup-bun@v2  # 0c5077e51419868618aeaa5fe8019c62421857d6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # pinned-by-SHA + explicit bun-version skips the GitHub tags-API resolve that returns 401 (#221)
+        with:
+          bun-version: 1.1.42
 
       - uses: actions/cache@v4
         with:
@@ -118,7 +122,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: oven-sh/setup-bun@v2  # 0c5077e51419868618aeaa5fe8019c62421857d6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # pinned-by-SHA + explicit bun-version skips the GitHub tags-API resolve that returns 401 (#221)
+        with:
+          bun-version: 1.1.42
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -25,7 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: oven-sh/setup-bun@v2  # 0c5077e51419868618aeaa5fe8019c62421857d6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # pinned-by-SHA + explicit bun-version skips the GitHub tags-API resolve that returns 401 (#221)
+        with:
+          bun-version: 1.1.42
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -40,7 +40,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: oven-sh/setup-bun@v2  # 0c5077e51419868618aeaa5fe8019c62421857d6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # pinned-by-SHA + explicit bun-version skips the GitHub tags-API resolve that returns 401 (#221)
+        with:
+          bun-version: 1.1.42
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Problem (#221)

\`oven-sh/setup-bun@v2\` was failing on every CI run with:

\`\`\`
Error: Failed to fetch url https://api.github.com/repos/oven-sh/bun/git/refs/tags.
(status code: 401, status text: Unauthorized)
\`\`\`

When \`bun-version\` is not supplied, setup-bun's tag-resolution logic hits the GitHub API to pick \"latest\". That endpoint started returning 401, blocking the Worker typecheck job (and likely also the other 3 setup-bun usages we have).

## Fix

Sidestep the resolve entirely:

1. **Pin the action by SHA** (\`@0c5077e51419868618aeaa5fe8019c62421857d6\`). The SHA was already sitting in a trailing comment — likely the intent of a prior commit that never applied it.
2. **Specify \`bun-version: 1.1.42\`** explicitly. With a concrete version supplied, the action skips the tags-API call entirely.

Applied to all 4 setup-bun usages:

| File | Line | Job |
|---|---|---|
| \`.github/workflows/ci.yml\` | 59 | (job above the worker block — appears to be mobile/web) |
| \`.github/workflows/ci.yml\` | 93 | (next job) |
| \`.github/workflows/ci.yml\` | 121 | Worker (typecheck) |
| \`.github/workflows/deploy-worker.yml\` | 28 | Worker deploy |

## Verification

This is a CI-only change — can't verify locally. The PR's own CI run is the proof. Expected: \`Worker (typecheck)\` proceeds past setup and actually runs \`bunx tsc --noEmit\` for the first time in days, which either passes or surfaces real type errors that have been hidden behind the setup failure.

## Notes

- **Version choice (1.1.42).** The repo doesn't pin Bun anywhere (no \`.bun-version\`, no \`engines.bun\`), so this is the first explicit version pin. If something the worker uses requires a newer Bun, bump the version in a follow-up. Safe to start conservative.
- **Why both SHA + version pin.** Belt-and-braces. Pinning the action alone wouldn't help if the API call is in the action's logic (which it is). Pinning the bun-version alone would work, but leaving \`@v2\` is bad CI hygiene (the tag can be moved).
- **Other setup-bun usages updated.** \`ci.yml\` has three setup-bun lines (one per job that needs bun). Fixed all three with the same treatment, so we don't get the failure on other jobs once one is debugged.

Closes #221.