### PR TITLE
chore(electron): manual cleanup of 38 remaining lint errors (#223)

### DIFF
--- a/apps/rishi-electron/src/main/ipc/highlights.ts
+++ b/apps/rishi-electron/src/main/ipc/highlights.ts
@@ -14,12 +14,13 @@ export function registerHighlightHandlers(): void {
       .all()
 
     // Map on-disk rows to the renderer-facing HighlightRow shape:
-    // - format defaults to 'epub' for legacy rows that predate v2 migration
+    // - format is NOT NULL with a default of 'epub' at the column level, so
+    //   legacy rows already read back as 'epub' from drizzle — no fallback needed.
     // - cfi_range '' (written by PDF rows to satisfy NOT NULL) becomes null
     // - locator passes through as-is (null for EPUB rows)
     return rows.map((row) => ({
       ...row,
-      format: (row.format ?? 'epub') as 'epub' | 'pdf',
+      format: row.format as 'epub' | 'pdf',
       cfiRange: row.cfiRange === '' ? null : row.cfiRange,
       locator: row.locator ?? null
     }))

--- a/apps/rishi-electron/src/renderer/src/components/epub/EpubView.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/epub/EpubView.tsx
@@ -91,7 +91,7 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
   // a stale id from a different format would otherwise be handed to epubjs,
   // which silently ignores it and opens at the start of the book.
   const resumeCfi = book.lastParagraph?.startsWith('epubcfi(') ? book.lastParagraph : null
-  const [currentLocation, setCurrentLocation] = useState<string>(resumeCfi ?? book.location ?? '0')
+  const [currentLocation, setCurrentLocation] = useState<string>(resumeCfi ?? book.location)
   // Sync with book.location when it changes from a refetch (e.g., returning from library).
   // Only sync before the rendition has settled to avoid overriding user navigation.
   const bookLocationRef = useRef(book.location)
@@ -451,7 +451,11 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
     const sync = (): void => {
       // epubjs Views exposes `first()` at runtime even though the typings
       // declare it only as `View[]`. Cast through unknown to access it.
-      const views = rendition.manager?.views as unknown as
+      // `manager` is not on the public Rendition type — go through unknown so
+      // we can probe defensively at runtime without TS treating the chain as
+      // always-defined.
+      const manager = (rendition as unknown as { manager?: { views?: unknown } }).manager
+      const views = manager?.views as
         | { first?: () => { iframe?: HTMLIFrameElement } | undefined }
         | undefined
       const iframe = views?.first?.()?.iframe

--- a/apps/rishi-electron/src/renderer/src/components/epub/EpubView.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/epub/EpubView.tsx
@@ -76,6 +76,7 @@ import { findParagraphForCfi } from '@/modules/cfi-to-paragraph'
 import { resolveLiveSelection } from '@/modules/resolve-live-selection'
 import { buildPartialFirst } from '@/modules/read-aloud-from'
 import { useTtsHighlightReconciler } from '@/hooks/useTtsHighlightReconciler'
+import { useVisibleEpubIframe } from '@/hooks/reader/useVisibleEpubIframe'
 import { createEpubTtsReconciler, type EpubTtsReconciler } from './reconcileTtsHighlight'
 
 function updateTheme(rendition: Rendition, theme: ThemeType) {
@@ -851,31 +852,25 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
   }, [])
 
   const epubTtsReconcilerRef = useRef<EpubTtsReconciler | null>(null)
-  const [epubContentIframe, setEpubContentIframe] = useState<HTMLIFrameElement | null>(null)
+
+  // Track the currently visible content iframe declaratively via
+  // useSyncExternalStore. Previously this was a setState-in-effect cascade
+  // (flagged by react-hooks/set-state-in-effect); the hook now produces the
+  // value during render and re-subscribes only when the rendition identity
+  // changes.
+  const epubContentIframe = useVisibleEpubIframe(rendition)
 
   // Build (or rebuild) the reconciler whenever the rendition instance changes.
+  // Kept in its own effect (separate concern from iframe tracking) — refs are
+  // fine inside effects, and there's no setState here so the React 19 rule
+  // doesn't apply.
   useEffect(() => {
     if (!rendition) {
       epubTtsReconcilerRef.current = null
-      setEpubContentIframe(null)
       return
     }
     epubTtsReconcilerRef.current = createEpubTtsReconciler(rendition)
-
-    // Resolve the epub.js content iframe via the shared helper, which
-    // correctly filters to the currently displayed view. We update the
-    // state on `rendered` so chapter swaps refresh the iframe reference.
-    const resolveIframe = (): void => {
-      const next = getVisibleIframe(rendition) ?? null
-      setEpubContentIframe((prev) => (prev === next ? prev : next))
-    }
-    resolveIframe()
-
-    // epub.js emits 'rendered' when a new view (chapter) is rendered.
-    rendition.on('rendered', resolveIframe)
-
     return () => {
-      rendition.off('rendered', resolveIframe)
       epubTtsReconcilerRef.current = null
     }
   }, [rendition])

--- a/apps/rishi-electron/src/renderer/src/components/epub/reconcileTtsHighlight.ts
+++ b/apps/rishi-electron/src/renderer/src/components/epub/reconcileTtsHighlight.ts
@@ -31,7 +31,7 @@ export function createEpubTtsReconciler(rendition: Rendition) {
     if (desiredIndex && currentTtsCfi !== desiredIndex) {
       const hash = encodeURI(desiredIndex + 'highlight')
       const internal = (rendition.annotations as { _annotations?: Record<string, unknown> })
-        ?._annotations
+        ._annotations
       const userOwnsIt = internal ? hash in internal : false
       void highlightRange(rendition, desiredIndex)
       if (!userOwnsIt) owned.add(desiredIndex)

--- a/apps/rishi-electron/src/renderer/src/components/highlights/createHighlightClickHandler.ts
+++ b/apps/rishi-electron/src/renderer/src/components/highlights/createHighlightClickHandler.ts
@@ -33,7 +33,13 @@ export function createHighlightClickHandler(
   return (cfiRange: string) => (e?: MouseEvent) => {
     const row = highlightsByRangeRef.current.get(cfiRange)
     if (!row) return
-    const view = renditionRef.current?.manager?.visible?.()?.[0]
+    // `manager` / `visible` aren't on epubjs's public Rendition type — go
+    // through unknown so each step is properly typed as possibly-undefined
+    // instead of `any` (which makes the no-unnecessary-condition rule blind).
+    const rendition = renditionRef.current as unknown as
+      | { manager?: { visible?: () => { element?: Element }[] | undefined } }
+      | null
+    const view = rendition?.manager?.visible?.()?.[0]
     const fallbackIframe = (view?.element?.querySelector('iframe') as HTMLElement | null) ?? null
     const { x, y } = computeHighlightClickPosition(e, fallbackIframe, viewport)
     setInlinePopover({

--- a/apps/rishi-electron/src/renderer/src/components/highlights/highlightClickPosition.ts
+++ b/apps/rishi-electron/src/renderer/src/components/highlights/highlightClickPosition.ts
@@ -18,9 +18,9 @@ export function computeHighlightClickPosition(
 ): { x: number; y: number } {
   const target = e?.target as Element | null | undefined
   const eventIframe =
-    (target?.ownerDocument?.defaultView?.frameElement as HTMLElement | null) ?? null
+    (target?.ownerDocument.defaultView?.frameElement as HTMLElement | null) ?? null
   const iframeEl = eventIframe ?? fallbackIframe ?? null
-  const rect = iframeEl?.getBoundingClientRect?.()
+  const rect = iframeEl?.getBoundingClientRect()
   if (rect && e && typeof e.clientX === 'number' && typeof e.clientY === 'number') {
     return { x: rect.left + e.clientX, y: rect.top + e.clientY }
   }

--- a/apps/rishi-electron/src/renderer/src/components/pdf/components/makeCustomTextRenderer.ts
+++ b/apps/rishi-electron/src/renderer/src/components/pdf/components/makeCustomTextRenderer.ts
@@ -1,0 +1,28 @@
+type Transform = [number, number, number, number, number, number]
+
+/**
+ * Pure factory for the PDF text-layer renderer. Extracted from the component
+ * closure so the declarative TTS-highlight behavior can be unit-tested
+ * without standing up a full `<PdfPage>` (which needs a real pdf.js page).
+ *
+ * Contract:
+ *  - If `highlightedParagraph` is null, returns plain text for every item.
+ *  - If `highlightedParagraph` is set and the text item's y-coordinate (the
+ *    6th entry of the transform matrix) falls within
+ *    `[dimensions.bottom, dimensions.top]`, wraps the text in `<mark>`.
+ *  - Items without a transform always pass through as plain text.
+ */
+export function makeCustomTextRenderer(
+  highlightedParagraph: { dimensions: { top: number; bottom: number } } | null
+) {
+  return ({ str, transform }: { str: string; transform: number[] | undefined }): string => {
+    if (!highlightedParagraph || !transform) return str
+    const t = transform as Transform
+    const isBelowOrEqualTop = t[5] <= highlightedParagraph.dimensions.top
+    const isAboveOrEqualBottom = t[5] >= highlightedParagraph.dimensions.bottom
+    if (isBelowOrEqualTop && isAboveOrEqualBottom) {
+      return `<mark style="background-color: rgb(255,255,204);">${str}</mark>`
+    }
+    return str
+  }
+}

--- a/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf-page.test.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf-page.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 
-import { makeCustomTextRenderer } from './pdf-page'
+import { makeCustomTextRenderer } from './makeCustomTextRenderer'
 import { usePdfStore } from '@/stores/pdfStore'
 
 // Regression: the PDF reader was migrated to a declarative TTS-highlight

--- a/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf-page.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf-page.tsx
@@ -17,36 +17,9 @@ import { HighlightLayer } from '../HighlightLayer'
 import type { HighlightRow } from '@/modules/highlight-storage'
 import type { ViewportLike } from '@/modules/pdf-locator'
 import { navigationHistoryActor } from '@/machines/navigationHistory/navigationHistoryActor'
-type Transform = [number, number, number, number, number, number]
+import { makeCustomTextRenderer } from './makeCustomTextRenderer'
 
 const PARAGRAPH_INDEX_PER_PAGE = 10000
-
-/**
- * Pure factory for the PDF text-layer renderer. Extracted from the component
- * closure so the declarative TTS-highlight behavior can be unit-tested
- * without standing up a full `<PdfPage>` (which needs a real pdf.js page).
- *
- * Contract:
- *  - If `highlightedParagraph` is null, returns plain text for every item.
- *  - If `highlightedParagraph` is set and the text item's y-coordinate (the
- *    6th entry of the transform matrix) falls within
- *    `[dimensions.bottom, dimensions.top]`, wraps the text in `<mark>`.
- *  - Items without a transform always pass through as plain text.
- */
-export function makeCustomTextRenderer(
-  highlightedParagraph: { dimensions: { top: number; bottom: number } } | null
-) {
-  return ({ str, transform }: { str: string; transform: number[] | undefined }): string => {
-    if (!highlightedParagraph || !transform) return str
-    const t = transform as Transform
-    const isBelowOrEqualTop = t[5] <= highlightedParagraph.dimensions.top
-    const isAboveOrEqualBottom = t[5] >= highlightedParagraph.dimensions.bottom
-    if (isBelowOrEqualTop && isAboveOrEqualBottom) {
-      return `<mark style="background-color: rgb(255,255,204);">${str}</mark>`
-    }
-    return str
-  }
-}
 
 function PageComponentInner({
   thispageNumber: pageNumber,

--- a/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf-page.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf-page.tsx
@@ -3,7 +3,6 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
   type MouseEvent as ReactMouseEvent
 } from 'react'
@@ -75,7 +74,13 @@ function PageComponentInner({
   const setIsPdfRendered = usePdfStore((s) => s.setIsPdfRendered)
   const setPageData = usePdfStore((s) => s.setPageData)
 
-  const wrapperRef = useRef<HTMLDivElement | null>(null)
+  // Callback-ref-as-state: tracking the wrapper as state (set via the JSX
+  // ref={setWrapper} callback) lets us read it during render to derive
+  // HighlightLayer's `pageEl` prop. A `useRef` would force us to read
+  // `wrapperRef.current` during render, which the new
+  // `react-hooks/refs` rule flags because React Compiler can't prove the
+  // ref's commit-time value is the one we'll see at the next render.
+  const [wrapper, setWrapper] = useState<HTMLDivElement | null>(null)
   const [pdfPage, setPdfPage] = useState<PDFPageProxy | null>(null)
 
   // Stable text renderer keyed on highlight inputs. react-pdf re-runs the
@@ -91,7 +96,7 @@ function PageComponentInner({
   useEffect(() => () => unregisterPdfCanvas(pageNumber), [pageNumber])
 
   const handleRenderSuccess = useCallback(() => {
-    const canvas = wrapperRef.current?.querySelector('canvas') ?? null
+    const canvas = wrapper?.querySelector('canvas') ?? null
     if (canvas instanceof HTMLCanvasElement) {
       registerPdfCanvas(pageNumber, canvas)
     }
@@ -103,7 +108,7 @@ function PageComponentInner({
       setIsPdfRendered(bookId, true)
     }
     onRenderComplete?.()
-  }, [pageNumber, bookId, setIsPdfRendered, onRenderComplete])
+  }, [pageNumber, bookId, setIsPdfRendered, onRenderComplete, wrapper])
 
   const handleGetTextSuccess = useCallback(
     (data: Parameters<NonNullable<Parameters<typeof Page>[0]['onGetTextSuccess']>>[0]) => {
@@ -115,10 +120,10 @@ function PageComponentInner({
   const handleLoadSuccess = useCallback(
     (page: PDFPageProxy) => {
       setPdfPage(page)
-      const pageEl = wrapperRef.current?.querySelector<HTMLElement>('.react-pdf__Page') ?? null
+      const pageEl = wrapper?.querySelector<HTMLElement>('.react-pdf__Page') ?? null
       if (pageEl && onPageReady) onPageReady(pageNumber, { pageEl, page })
     },
-    [pageNumber, onPageReady]
+    [pageNumber, onPageReady, wrapper]
   )
 
   // Intercept react-pdf annotation-layer link clicks before the default handler
@@ -153,7 +158,7 @@ function PageComponentInner({
   )
 
   return (
-    <div ref={wrapperRef} style={{ position: 'relative' }}>
+    <div ref={setWrapper} style={{ position: 'relative' }}>
       {/* onClickCapture intercepts annotation-layer link clicks before react-pdf's handler */}
       <div onClickCapture={handleAnnotationClick}>
         <Page
@@ -180,12 +185,10 @@ function PageComponentInner({
           onLoadSuccess={handleLoadSuccess}
         />
       </div>
-      {pdfPage && wrapperRef.current && highlights && onHighlightClick ? (
+      {pdfPage && wrapper && highlights && onHighlightClick ? (
         <HighlightLayer
           pageNumber={pageNumber}
-          pageEl={
-            wrapperRef.current.querySelector<HTMLElement>('.react-pdf__Page') ?? wrapperRef.current
-          }
+          pageEl={wrapper.querySelector<HTMLElement>('.react-pdf__Page') ?? wrapper}
           viewport={
             pdfPage.getViewport({
               // pdfjs page.view = [x0, y0, x1, y1]; native width = view[2], native height = view[3].

--- a/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf.tsx
@@ -133,22 +133,39 @@ export function PdfView({
     requireAuth: requireAuth as (feature: string, action: () => void) => void
   })
 
+  // Memoize the selection-hook callbacks so usePdfTextSelection's effect
+  // doesn't rebind document/container listeners on every PdfView render. The
+  // hook now lists these in its dep array (rather than reading from a
+  // render-time ref), so unstable identities here would cause the listeners
+  // to detach and reattach on every parent render — wasteful, plus the
+  // mouseup listener is briefly missing in the window between cleanup and
+  // re-attach.
+  const getSelectionPageElement = useCallback(
+    (n: number) => pageInfoRef.current.get(n)?.pageEl ?? null,
+    []
+  )
+  const getSelectionViewport = useCallback((n: number): ViewportLike | null => {
+    const info = pageInfoRef.current.get(n)
+    if (!info) return null
+    const scale = info.pageEl.getBoundingClientRect().width / info.page.view[2]
+    // pdfjs-dist types return `any[]` from convertToViewportPoint; cast via
+    // unknown to the structural ViewportLike which expects [number, number].
+    return info.page.getViewport({
+      scale
+    }) as unknown as ViewportLike
+  }, [])
+  const handleSelectionSelect = useCallback(
+    (sel: { locator: PdfLocator; text: string; anchorPos: { x: number; y: number } }) =>
+      setSelectionPopover({ locator: sel.locator, text: sel.text, anchorPos: sel.anchorPos }),
+    []
+  )
+  const handleSelectionClear = useCallback(() => setSelectionPopover(null), [])
   usePdfTextSelection({
     containerRef: scrollContainerRef,
-    getPageElement: (n) => pageInfoRef.current.get(n)?.pageEl ?? null,
-    getViewport: (n) => {
-      const info = pageInfoRef.current.get(n)
-      if (!info) return null
-      const scale = info.pageEl.getBoundingClientRect().width / info.page.view[2]
-      // pdfjs-dist types return `any[]` from convertToViewportPoint; cast via
-      // unknown to the structural ViewportLike which expects [number, number].
-      return info.page.getViewport({
-        scale
-      }) as unknown as ViewportLike
-    },
-    onSelect: (sel) =>
-      setSelectionPopover({ locator: sel.locator, text: sel.text, anchorPos: sel.anchorPos }),
-    onClear: () => setSelectionPopover(null)
+    getPageElement: getSelectionPageElement,
+    getViewport: getSelectionViewport,
+    onSelect: handleSelectionSelect,
+    onClear: handleSelectionClear
   })
 
   useScrolling(scrollContainerRef)

--- a/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/pdf/components/pdf.tsx
@@ -752,7 +752,7 @@ export function PdfView({
     try {
       const handle = await applyHighlightWithUndoPdf({
         target: {
-          applyVisual: async () => {
+          applyVisual: () => {
             setHighlights((prev) => [
               ...prev,
               {

--- a/apps/rishi-electron/src/renderer/src/components/tts/TTSControls.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/tts/TTSControls.tsx
@@ -180,15 +180,19 @@ export default function TTSControls({ bookId, disabled = false }: TTSControlsPro
   // `playingState` briefly drops to `loading` between paragraphs, we keep the
   // button mounted so the pill doesn't reflow every paragraph boundary.
   // Initial load (`stopped → loading → playing`) starts hidden because
-  // `showRepeat` is only set true on entering `playing`.
-  const [showRepeat, setShowRepeat] = useState(false)
-  useEffect(() => {
-    if (playingState === 'playing') {
-      setShowRepeat(true)
-    } else if (playingState !== 'loading') {
-      setShowRepeat(false)
-    }
-  }, [playingState])
+  // `showRepeat` is only true while the last non-`loading` state was `playing`.
+  //
+  // Implementation: track the most recent non-loading state and derive
+  // `showRepeat` from it during render. This is the React docs "adjust state
+  // when props change" pattern (https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes)
+  // — setting state during render with a guard is React's bail-out path and
+  // doesn't trigger the cascading-renders warning that the equivalent
+  // `useEffect` shape did.
+  const [lastNonLoadingState, setLastNonLoadingState] = useState<PlayerStoreState>(playingState)
+  if (playingState !== 'loading' && playingState !== lastNonLoadingState) {
+    setLastNonLoadingState(playingState)
+  }
+  const showRepeat = lastNonLoadingState === 'playing'
 
   // --- Waveform bars ---
   // Stable IDs let React reconcile bars across re-renders without

--- a/apps/rishi-electron/src/renderer/src/hooks/reader/useBookSyncId.ts
+++ b/apps/rishi-electron/src/renderer/src/hooks/reader/useBookSyncId.ts
@@ -23,10 +23,15 @@ export function useBookSyncId(bookId: number): {
   const [bookSyncId, setBookSyncId] = useState<string>('')
 
   useEffect(() => {
-    const state = { cancelled: false }
+    // Use a getter so each read crosses a function boundary that defeats TS's
+    // narrowing of `cancelled` to literal `false` (the previous shape
+    // `{ cancelled: boolean }` was correct but the IIFE's first
+    // `if (state.cancelled) return` then narrowed every later read to `false`).
+    let cancelled = false
+    const isCancelled = (): boolean => cancelled
     void (async () => {
       let syncId = await window.electron.booksGetSyncId(bookId)
-      if (state.cancelled) return
+      if (isCancelled()) return
       // B001: freshly imported books may have no syncId yet (the row is
       // inserted with `syncId: null` and the sync push backfills it later).
       // Without this fallback the ref stays null for the lifetime of the
@@ -34,11 +39,11 @@ export function useBookSyncId(bookId: number): {
       // useChat.ts: generate a UUID and persist it so callers see a stable id.
       if (!syncId) {
         const book = await window.electron.getBook(bookId)
-        if (state.cancelled) return
+        if (isCancelled()) return
         if (book) {
           syncId = crypto.randomUUID()
           await window.electron.saveBook({ ...book, syncId, isDirty: 1 })
-          if (state.cancelled) return
+          if (isCancelled()) return
         }
       }
       bookSyncIdRef.current = syncId
@@ -47,7 +52,7 @@ export function useBookSyncId(bookId: number): {
       }
     })()
     return () => {
-      state.cancelled = true
+      cancelled = true
     }
   }, [bookId])
 

--- a/apps/rishi-electron/src/renderer/src/hooks/reader/useVisibleEpubIframe.ts
+++ b/apps/rishi-electron/src/renderer/src/hooks/reader/useVisibleEpubIframe.ts
@@ -1,0 +1,49 @@
+import { useCallback, useSyncExternalStore } from 'react'
+import type { Rendition } from 'epubjs'
+import { getVisibleIframe } from '@/modules/epubwrapper'
+
+/**
+ * Track the currently-visible epub.js content iframe declaratively.
+ *
+ * `useSyncExternalStore` is the React-19 way to expose a mutable third-party
+ * subscription as a render value: it subscribes on mount, calls `getSnapshot`
+ * during render, and re-renders when the subscription's `onChange` is invoked.
+ *
+ * The previous shape lived inside an `useEffect` and called
+ * `setEpubContentIframe(...)` synchronously after the rendition mounted —
+ * which the `react-hooks/set-state-in-effect` rule flags as a cascading
+ * render. Lifting subscription + snapshot into this hook eliminates both the
+ * effect and the setState call: the iframe is read on every render via
+ * `getVisibleIframe`, and re-renders are triggered only by the actual epub.js
+ * `rendered` event (the same event the effect was using to refresh state).
+ *
+ * When `rendition` is null the hook returns null without subscribing.
+ */
+export function useVisibleEpubIframe(rendition: Rendition | null): HTMLIFrameElement | null {
+  // `subscribe` is keyed on the rendition identity. When the rendition swaps,
+  // React will re-subscribe to the new instance. `useCallback` keeps the
+  // identity stable across renders of the same rendition so we don't tear
+  // down + re-add the listener on every parent render.
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      if (!rendition) return () => {}
+      rendition.on('rendered', onChange)
+      return () => {
+        rendition.off('rendered', onChange)
+      }
+    },
+    [rendition]
+  )
+
+  // `getSnapshot` must be a referentially-stable function for a given
+  // rendition AND must return a referentially-stable value while the
+  // underlying iframe hasn't changed. `getVisibleIframe` already returns the
+  // live DOM node, which has stable identity until epub.js mounts a new view
+  // — so we can call it directly.
+  const getSnapshot = useCallback((): HTMLIFrameElement | null => {
+    if (!rendition) return null
+    return getVisibleIframe(rendition) ?? null
+  }, [rendition])
+
+  return useSyncExternalStore(subscribe, getSnapshot, () => null)
+}

--- a/apps/rishi-electron/src/renderer/src/hooks/usePdfReadAloudFromSelection.ts
+++ b/apps/rishi-electron/src/renderer/src/hooks/usePdfReadAloudFromSelection.ts
@@ -27,7 +27,7 @@ export function usePdfReadAloudFromSelection(params: UsePdfReadAloudFromSelectio
 
   useEffect(() => {
     const unsubscribe = window.electron.on('reader:readAloudFromSelection', () => {
-      const text = window.getSelection()?.toString()?.trim() ?? ''
+      const text = window.getSelection()?.toString().trim() ?? ''
       if (!text) return
 
       const playingState = usePlayerStore.getState().playingState

--- a/apps/rishi-electron/src/renderer/src/hooks/usePdfTextSelection.ts
+++ b/apps/rishi-electron/src/renderer/src/hooks/usePdfTextSelection.ts
@@ -50,8 +50,12 @@ export function usePdfTextSelection(params: UsePdfTextSelectionParams): void {
       if (!viewport) return
       const locator = selectionToPdfLocator(range, startInfo.el, viewport, startInfo.pageNumber)
       if (!locator) return
+      // `.at(0)` returns `DOMRect | undefined` regardless of the project's
+      // `noUncheckedIndexedAccess` setting — that's what lets the guard below
+      // be meaningful (plain `rects[0]` would be typed as `DOMRect` and the
+      // guard would be dead).
       const rects = Array.from(range.getClientRects())
-      const first = rects[0]
+      const first = rects.at(0)
       if (!first) return
       onSelect({
         locator,

--- a/apps/rishi-electron/src/renderer/src/hooks/usePdfTextSelection.ts
+++ b/apps/rishi-electron/src/renderer/src/hooks/usePdfTextSelection.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { selectionToPdfLocator, type ViewportLike } from '@/modules/pdf-locator'
 import type { PdfLocator } from '@/modules/highlight-storage'
 
@@ -29,15 +29,18 @@ function findPageInfo(node: Node | null): { el: HTMLElement; pageNumber: number 
 }
 
 export function usePdfTextSelection(params: UsePdfTextSelectionParams): void {
-  const paramsRef = useRef(params)
-  paramsRef.current = params
+  // Destructure once so the effect deps are the individual callbacks rather
+  // than the `params` object identity (which would churn every render). Call
+  // sites are expected to pass stable callbacks via `useCallback`; passing
+  // fresh closures here just rebinds the listeners on each render, which is
+  // safe but wasteful.
+  const { containerRef, onSelect, onClear, getPageElement, getViewport } = params
 
   useEffect(() => {
-    const container = params.containerRef.current
+    const container = containerRef.current
     if (!container) return
 
     const handleMouseUp = (): void => {
-      const { onSelect, getPageElement, getViewport } = paramsRef.current
       const sel = window.getSelection()
       if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return
       const range = sel.getRangeAt(0)
@@ -67,7 +70,7 @@ export function usePdfTextSelection(params: UsePdfTextSelectionParams): void {
     const handleSelectionChange = (): void => {
       const sel = window.getSelection()
       if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
-        paramsRef.current.onClear()
+        onClear()
       }
     }
 
@@ -77,5 +80,5 @@ export function usePdfTextSelection(params: UsePdfTextSelectionParams): void {
       container.removeEventListener('mouseup', handleMouseUp)
       document.removeEventListener('selectionchange', handleSelectionChange)
     }
-  }, [params.containerRef])
+  }, [containerRef, onSelect, onClear, getPageElement, getViewport])
 }

--- a/apps/rishi-electron/src/renderer/src/lib/visualHeuristic.ts
+++ b/apps/rishi-electron/src/renderer/src/lib/visualHeuristic.ts
@@ -111,7 +111,10 @@ function scanElement(el: Element, hits: VisualHit[]): void {
   // parent's textContent, so if a child owns the equation we don't also
   // attribute it to the parent.
   if (direct?.kind !== 'equation' && !childHasEquation) {
-    if (hasLatexEquation(el.textContent ?? '')) {
+    // `Element.textContent` is `string` (never null) — only `Document` /
+    // `DocumentType` nodes return null per the DOM spec, and we narrow to
+    // Element via the Node.ELEMENT_NODE check at the entry point.
+    if (hasLatexEquation(el.textContent)) {
       hits.push({ kind: 'equation', element: el, label: 'equation' })
     }
   }
@@ -168,9 +171,13 @@ export function summarizeVisuals(root: Element): VisualSummary {
     if (hit) {
       // Fix C: branch on hit.kind so SVG figures (and other non-<figure>-tag
       // elements that classifyElement returns as 'figure') are counted correctly.
+      // Note: `classifyElement` never returns `kind: 'image'` — large standalone
+      // <img> elements come back as `'figure'` and the inner branch reroutes
+      // them to `images++` when they aren't inside a <figure>.
       if (hit.kind === 'equation') {
         equations++
-      } else if (hit.kind === 'figure') {
+      } else {
+        // hit.kind === 'figure' (only remaining case)
         if (tag === 'img') {
           // A large <img> is a figure only when NOT inside a <figure> element;
           // when it IS inside <figure>, the parent already counted it.
@@ -181,8 +188,6 @@ export function summarizeVisuals(root: Element): VisualSummary {
         } else {
           figures++
         }
-      } else if (hit.kind === 'image') {
-        images++
       }
     }
     node = walker.nextNode() as Element | null
@@ -196,7 +201,8 @@ export function summarizeVisuals(root: Element): VisualSummary {
   )) {
     mathEl.parentNode?.removeChild(mathEl)
   }
-  const text = rootClone.textContent ?? ''
+  // `Element.textContent` is `string` (never null). See line 114 for rationale.
+  const text = rootClone.textContent
   for (const re of LATEX_DELIMS) {
     re.lastIndex = 0
     let m: RegExpExecArray | null

--- a/apps/rishi-electron/src/renderer/src/modules/epubwrapper.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/epubwrapper.ts
@@ -234,7 +234,13 @@ export function resolveCfiToRange(rendition: Rendition, cfiRange: string): Range
  * regardless of how many views the manager currently has mounted.
  */
 export function getVisibleIframe(rendition: Rendition): HTMLIFrameElement | null {
-  const view = rendition.manager.visible()[0]
+  // `manager` / `visible()` aren't on epubjs's public Rendition type. Type the
+  // boundary explicitly so the array-element narrows to `View | undefined`
+  // (rather than `any`), which is what allows the runtime guard to be
+  // recognised by no-unnecessary-condition.
+  const manager = (rendition as unknown as { manager?: { visible?: () => View[] | undefined } })
+    .manager
+  const view: View | undefined = manager?.visible?.()?.[0]
   if (!view?.element) return null
   return view.element.querySelector('iframe')
 }

--- a/apps/rishi-electron/src/renderer/src/modules/file-sync.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/file-sync.ts
@@ -115,16 +115,21 @@ export function formatUploadLimitMessage(payload: UploadUrlError): string {
 async function parseUploadLimitError(res: Response): Promise<UploadUrlError | null> {
   try {
     const data = (await res.clone().json()) as Partial<UploadUrlError>
+    // Treat `data` as an untrusted IPC/network payload — at runtime nothing
+    // forces it to actually be a member of `UploadUrlError['code']`, but TS
+    // sees the field as the exhaustive union and would otherwise narrow the
+    // `=== 'STORAGE_LIMIT_REACHED'` arm to a `"x" === "x"` tautology. Walking
+    // through `unknown` keeps the guard honest at the runtime boundary.
+    const codeValue = (data as { code?: unknown }).code
     if (
-      typeof data.code === 'string' &&
-      (data.code === 'FILE_TOO_LARGE' ||
-        data.code === 'BOOK_LIMIT_REACHED' ||
-        data.code === 'STORAGE_LIMIT_REACHED') &&
+      (codeValue === 'FILE_TOO_LARGE' ||
+        codeValue === 'BOOK_LIMIT_REACHED' ||
+        codeValue === 'STORAGE_LIMIT_REACHED') &&
       typeof data.limit === 'number'
     ) {
       return {
         error: typeof data.error === 'string' ? data.error : '',
-        code: data.code,
+        code: codeValue,
         limit: data.limit,
         current: typeof data.current === 'number' ? data.current : undefined
       }

--- a/apps/rishi-electron/src/renderer/src/modules/note-icon-overlay.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/note-icon-overlay.ts
@@ -53,7 +53,7 @@ export class NoteIconOverlay {
       const range = this.resolveRange(row.cfiRange)
       if (!range) continue
       const rects = range.getClientRects()
-      if (!rects || rects.length === 0) continue
+      if (rects.length === 0) continue
       // Anchor to the LAST rect — for multi-line ranges this is the bottom
       // line, mirroring Apple Books' end-of-text anchor.
       const rect = rects[rects.length - 1]

--- a/apps/rishi-electron/src/renderer/src/modules/read-aloud-from/index.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/read-aloud-from/index.ts
@@ -43,7 +43,9 @@ export function findSentenceStart(text: string, charOffset: number): number {
   // Fallback via matchAll iteration (no .exec calls).
   let lastStart = 0
   for (const m of text.matchAll(/[.!?]+\s+/g)) {
-    const candidate = (m.index ?? 0) + m[0].length
+    // `m.index` from a global `matchAll` regex is typed as `number` (the
+    // `undefined` arm only applies to `RegExp.exec` results without /g).
+    const candidate = m.index + m[0].length
     if (candidate > clamped) break
     lastStart = candidate
   }

--- a/apps/rishi-electron/src/renderer/src/modules/resolve-live-selection/index.ts
+++ b/apps/rishi-electron/src/renderer/src/modules/resolve-live-selection/index.ts
@@ -50,7 +50,7 @@ export function resolveLiveSelection(
     if (!sel || sel.rangeCount === 0) return
     const text = sel.toString()
     if (!text.trim()) return
-    const cfiFn = contents?.cfiFromRange
+    const cfiFn = contents.cfiFromRange
     if (typeof cfiFn !== 'function') return
     try {
       const range = sel.getRangeAt(0)

--- a/apps/rishi-electron/src/renderer/src/services/voice-chat/activation-program.ts
+++ b/apps/rishi-electron/src/renderer/src/services/voice-chat/activation-program.ts
@@ -375,7 +375,7 @@ export function makeActivationProgram(a: ActivationDeps): ActivationProgram {
               if (!recorder) return null
               const chunks: Blob[] = []
               recorder.ondataavailable = (e) => {
-                if (!e.data || e.data.size === 0) return
+                if (e.data.size === 0) return
                 chunks.push(e.data)
                 // Rolling cap: drop oldest chunks so long connect windows
                 // don't accumulate megabytes of audio.

--- a/apps/rishi-electron/src/renderer/src/services/voice-chat/local-vad.test.ts
+++ b/apps/rishi-electron/src/renderer/src/services/voice-chat/local-vad.test.ts
@@ -14,16 +14,20 @@ class FakeAnalyser {
   // amplitude that the test sets via FakeAudioContext.setAmplitude(). RMS of
   // a constant-amplitude buffer is just |amp|.
   amp = 0
-  connect(): void {}
-  disconnect(): void {}
+  // The production code calls .connect() / .disconnect() on the analyser for
+  // side-effect parity with the real Web Audio graph. vi.fn() satisfies the
+  // contract AND lets any future test assert call counts without rewriting
+  // the fake.
+  connect = vi.fn<(dest?: unknown) => void>()
+  disconnect = vi.fn<() => void>()
   getFloatTimeDomainData(out: Float32Array): void {
     out.fill(this.amp)
   }
 }
 
 class FakeStreamSource {
-  connect(_dest: unknown): void {}
-  disconnect(): void {}
+  connect = vi.fn<(dest: unknown) => void>()
+  disconnect = vi.fn<() => void>()
 }
 
 class FakeAudioContext {

--- a/apps/rishi-electron/src/renderer/src/stores/pdfStore.ts
+++ b/apps/rishi-electron/src/renderer/src/stores/pdfStore.ts
@@ -54,8 +54,10 @@ interface PdfState {
   isRenderedPageState: Record<number, boolean>
   hasNavigatedToPage: boolean
   isLookingForNextParagraph: boolean
-  /** Per-book running-footer detection result (#142). In-memory only. */
-  footerMaskByBookId: Record<number, FooterMask>
+  /** Per-book running-footer detection result (#142). In-memory only.
+   *  `Partial<Record>` so indexing an unknown bookId is typed as
+   *  `FooterMask | undefined` and callers must guard before use. */
+  footerMaskByBookId: Partial<Record<number, FooterMask>>
 
   setPageNumber: (n: number) => void
   setScrollPageNumber: (n: number) => void


### PR DESCRIPTION
## What

Closes #223 — the manual cleanup of the 38 lint errors that survived the auto-fix pass in #222. With this PR, \`Electron (lint + test + build)\` goes from **38 errors** to **0 errors** on a freshly-rebased main. Combined with #222, the full electron lint cleanup took main from 65 → 0.

**Hard rule observed throughout: no \`eslint-disable\` shortcuts.** Every fix restructures the actual code.

## Numbers

| Stage | Errors | Warnings |
|---|---|---|
| \`main\` HEAD after #222 merge | 38 | 37 |
| Batch A (mechanical singletons) | 32 | 37 |
| Batch B (no-unnecessary-condition) | 9 | 40 |
| Batch C+D (react-hooks refactors) | **0** | 40 |

Typecheck (both tsc projects) clean. 1329 / 1329 tests pass across 146 test files. (\`src/main/database/queries.test.ts\` has 12 better-sqlite3 ABI mismatch failures that are confirmed pre-existing on main HEAD — same failures with or without these changes.)

## Real bugs caught along the way

1. **\`lib/visualHeuristic.ts:184\` dead branch** — \`else if (hit.kind === 'image')\` was unreachable. \`classifyElement\` only returns \`'equation' | 'figure'\`; standalone \`<img>\` elements are classified as \`'figure'\` and routed to \`images++\` via an inner \`tag === 'img'\` check. Collapsed to \`else\` with a comment.
2. **\`modules/file-sync.ts:122\` unsound type narrowing** — \`data.code === 'STORAGE_LIMIT_REACHED'\` flagged as tautology. Root cause: \`data\` came from \`res.clone().json()\` and was typed as \`Partial<UploadUrlError>\`. But \`data\` is **untrusted** — a malformed worker response could carry any string. The prior typed narrowing was unsound. Restructured to read \`data.code\` through \`unknown\` so the runtime validation is honest.

## Type-widening fixes (real bugs hidden by stale narrowing)

- \`hooks/reader/useBookSyncId.ts:37,41\` — \`state.cancelled\` narrowed to literal \`false\` after first early-return. The cleanup mutation was invisible to TS. Switched to \`let cancelled\` + getter so reads cross a function boundary.
- \`stores/pdfStore.ts:220\` — \`Record<number, FooterMask>\` widened to \`Partial<Record<…>>\` so index access returns \`FooterMask | undefined\`.
- \`hooks/usePdfTextSelection.ts:55\` — \`rects[0]\` → \`rects.at(0)\` for proper \`T | undefined\`.

## Real React 19 refactors

- **EpubView.tsx** — extracted iframe tracking into \`useVisibleEpubIframe(rendition)\` using \`useSyncExternalStore\`. Subscribe handles \`rendition.on('rendered')\`; snapshot derives via \`getVisibleIframe\`. Returns null when rendition is null. Eliminates the sync setState that triggered the rule. Gains concurrent-mode tearing safety.
- **TTSControls.tsx** — replaced \`useEffect\`-based sticky state with the React docs "track input that drives derived value" pattern. Stores \`lastNonLoadingState\`; derives \`showRepeat\` during render. Conditional setState during render is the bail-out path (not cascading).
- **usePdfTextSelection.ts + pdf.tsx** — dropped \`paramsRef\` shim, destructured callbacks at hook top, added 4 \`useCallback\`s at the call site so the listener doesn't rebind on every parent render. The right fix (stable boundary callbacks), not a ref hack.
- **pdf-page.tsx** — converted \`useRef<HTMLDivElement>\` to \`useState + callback ref\`. Render reads state instead of \`.current\`; callbacks include the state in their deps. Initial render still gates HighlightLayer correctly.

## Mechanical singletons (still real fixes)

- \`pdf.tsx:755\` \`async\` → sync (\`require-await\`). The \`HighlightTarget.applyVisual\` interface already accepts \`() => Promise<void> | void\`; sync return type is valid.
- \`local-vad.test.ts\` empty mock methods → \`vi.fn()\` arrow properties. Satisfies interface AND makes them spyable.
- \`pdf-page.tsx\` \`makeCustomTextRenderer\` extracted to its own file (\`react-refresh/only-export-components\`). The function was already documented as "extracted from the component closure for unit testing"; moving it to its own module follows through on that intent.

## New file

- \`apps/rishi-electron/src/renderer/src/hooks/reader/useVisibleEpubIframe.ts\` — declarative wrapper around \`rendition.on('rendered')\` + \`getVisibleIframe\` using \`useSyncExternalStore\`. ~49 lines.

## What's NOT in this PR

- The 40 remaining lint warnings (out of scope; tracked separately if anyone cares to clean them up).
- The Mobile + Worker fixes (already merged via #224 and #225).
- The advisory finding from #222 about EpubView.tsx:94 nav-history bootstrapping (#226 — separate scope).
- Any change to the lint config or rule severity.

Closes #223. Once merged, \`Electron (lint + test + build)\` will be fully green on main, unblocking the 10 in-flight electron PRs (#29, #210–#218).