### PR TITLE
mobile(reader): inject theme CSS into MOBI/DJVU/PDF WebViews (#47)

### DIFF
--- a/apps/mobile/__tests__/components/reader/webview-theme-injection.test.ts
+++ b/apps/mobile/__tests__/components/reader/webview-theme-injection.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Issue #47 — MOBI / DJVU / PDF reader theme changes were ignored by the
+ * WebView. `handleSettingsChange` persisted `themeName` but no `useEffect`
+ * forwarded the theme into the WebView, so dark-mode users still saw
+ * white pages.
+ *
+ * Acceptance criteria (from issue):
+ *   1. Each reader has a `useEffect` keyed on `settings.themeName` (or
+ *      equivalent) that injects CSS into the WebView matching the active
+ *      theme.
+ *   2. Snapshot test toggles theme and verifies `injectJavaScript` is
+ *      called with theme-specific CSS.
+ *
+ * Source-grep is the established pattern for these reader screens (see
+ * `mobi-active-paragraph-inject.test.ts`) — mounting the screens pulls in
+ * WebView, expo-file-system, the player store, expo-router, etc. Grep is
+ * the cheapest reliable way to pin the theme-injection wiring without a
+ * full RN test runtime.
+ *
+ * We also import the canonical `READER_THEMES` map and require each
+ * reader's source to mention the theme's `background` color literal for
+ * every supported theme — this is the "theme-specific CSS" part of
+ * acceptance bullet 2 and the bit that catches a regression where a
+ * future refactor injects a static stylesheet instead of one keyed on
+ * the active theme.
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+import { READER_THEMES } from '../../../constants/reader-themes'
+import type { ThemeName } from '../../../types/book'
+
+const MOBILE_ROOT = join(__dirname, '..', '..', '..')
+
+function readReader(format: 'mobi' | 'djvu' | 'pdf'): string {
+  return readFileSync(
+    join(MOBILE_ROOT, 'app', 'reader', format, '[id].tsx'),
+    'utf-8',
+  )
+}
+
+const THEME_NAMES: ThemeName[] = ['white', 'dark', 'yellow']
+
+describe('Issue #47 — readers inject theme CSS into the WebView', () => {
+  describe.each([
+    ['mobi', 'webViewRef.current?.injectJavaScript'],
+    ['djvu', 'webViewRef.current?.injectJavaScript'],
+  ] as const)('%s reader', (format, injectCall) => {
+    const src = readReader(format)
+
+    it('has a useEffect that depends on settings.themeName', () => {
+      // The dependency array of *some* useEffect must include
+      // `settings.themeName` (or `settings` itself, which would also
+      // re-run on theme changes). We accept both, but require that
+      // `themeName` appears somewhere in a useEffect dependency list.
+      const useEffectThemeName = /useEffect\([\s\S]*?\}, \[[^\]]*settings\.themeName[^\]]*\]\)/
+      const useEffectSettings = /useEffect\([\s\S]*?\}, \[[^\]]*\bsettings\b[^\]]*\]\)/
+      expect(
+        useEffectThemeName.test(src) || useEffectSettings.test(src),
+      ).toBe(true)
+    })
+
+    it('uses READER_THEMES to resolve the active theme', () => {
+      expect(src).toMatch(/READER_THEMES/)
+    })
+
+    it('calls injectJavaScript on the WebView ref to apply the theme', () => {
+      // The MOBI / DJVU readers own the WebView directly, so the theme
+      // effect must reach into the ref and inject JS that touches the
+      // document — anything weaker (e.g. only persisting to settings)
+      // is the bug this issue tracks.
+      expect(src).toContain(injectCall)
+    })
+
+    it.each(THEME_NAMES)(
+      'references the %s theme background color literal',
+      (name) => {
+        const bg = READER_THEMES[name].background
+        // The background literal must appear in the source so the theme
+        // effect can hand WebView CSS that visibly differs between
+        // themes. Pinning the literals catches the failure mode in the
+        // issue (theme persisted but never forwarded).
+        expect(src).toContain(bg)
+      },
+    )
+  })
+
+  describe('pdf reader', () => {
+    const src = readReader('pdf')
+
+    it('has a useEffect that depends on settings.themeName', () => {
+      const useEffectThemeName = /useEffect\([\s\S]*?\}, \[[^\]]*settings\.themeName[^\]]*\]\)/
+      const useEffectSettings = /useEffect\([\s\S]*?\}, \[[^\]]*\bsettings\b[^\]]*\]\)/
+      expect(
+        useEffectThemeName.test(src) || useEffectSettings.test(src),
+      ).toBe(true)
+    })
+
+    it('uses READER_THEMES to resolve the active theme', () => {
+      expect(src).toMatch(/READER_THEMES/)
+    })
+
+    it('forwards the theme to the PdfWebReader via readerRef', () => {
+      // PDF wraps the WebView in `PdfWebReader` and exposes an
+      // imperative handle (`PdfWebReaderHandle`). The reader screen
+      // must call a theme-applying method on that handle — anything
+      // weaker (e.g. only persisting to settings) is the bug.
+      expect(src).toMatch(/readerRef\.current\??\.setTheme/)
+    })
+
+    it.each(THEME_NAMES)(
+      'references the %s theme background color literal',
+      (name) => {
+        const bg = READER_THEMES[name].background
+        expect(src).toContain(bg)
+      },
+    )
+  })
+
+  describe('PdfWebReader exposes a setTheme on its imperative handle', () => {
+    const src = readFileSync(
+      join(MOBILE_ROOT, 'components', 'pdf', 'PdfWebReader.tsx'),
+      'utf-8',
+    )
+
+    it('declares setTheme on PdfWebReaderHandle', () => {
+      // The reader screen needs a typed way to forward theme CSS into
+      // the PDF WebView. Pin the handle so the screen's call doesn't
+      // become an `as any` cast.
+      expect(src).toMatch(/setTheme\s*\(/)
+    })
+
+    it('calls injectJavaScript when setTheme runs', () => {
+      // The setTheme implementation must reach into the WebView ref
+      // and inject CSS — otherwise the theme is silently dropped.
+      expect(src).toMatch(/injectJavaScript/)
+    })
+  })
+})

--- a/apps/mobile/__tests__/components/reader/webview-theme-injection.test.ts
+++ b/apps/mobile/__tests__/components/reader/webview-theme-injection.test.ts
@@ -29,7 +29,7 @@ import { readFileSync } from 'fs'
 import { join } from 'path'
 
 import { READER_THEMES } from '../../../constants/reader-themes'
-import type { ThemeName } from '../../../types/book'
+import type { ReaderTheme, ThemeName } from '../../../types/book'
 
 const MOBILE_ROOT = join(__dirname, '..', '..', '..')
 
@@ -43,10 +43,7 @@ function readReader(format: 'mobi' | 'djvu' | 'pdf'): string {
 const THEME_NAMES: ThemeName[] = ['white', 'dark', 'yellow']
 
 describe('Issue #47 — readers inject theme CSS into the WebView', () => {
-  describe.each([
-    ['mobi', 'webViewRef.current?.injectJavaScript'],
-    ['djvu', 'webViewRef.current?.injectJavaScript'],
-  ] as const)('%s reader', (format, injectCall) => {
+  describe.each(['mobi', 'djvu'] as const)('%s reader', (format) => {
     const src = readReader(format)
 
     it('has a useEffect that depends on settings.themeName', () => {
@@ -69,21 +66,20 @@ describe('Issue #47 — readers inject theme CSS into the WebView', () => {
       // The MOBI / DJVU readers own the WebView directly, so the theme
       // effect must reach into the ref and inject JS that touches the
       // document — anything weaker (e.g. only persisting to settings)
-      // is the bug this issue tracks.
-      expect(src).toContain(injectCall)
+      // is the bug this issue tracks. We accept both the optional and
+      // non-optional chaining forms; the effect guards against a null
+      // ref above the call, so the literal form is implementation
+      // freedom.
+      expect(src).toMatch(/webViewRef\.current\??\.injectJavaScript/)
     })
 
-    it.each(THEME_NAMES)(
-      'references the %s theme background color literal',
-      (name) => {
-        const bg = READER_THEMES[name].background
-        // The background literal must appear in the source so the theme
-        // effect can hand WebView CSS that visibly differs between
-        // themes. Pinning the literals catches the failure mode in the
-        // issue (theme persisted but never forwarded).
-        expect(src).toContain(bg)
-      },
-    )
+    it('hands the active theme into a theme-CSS builder', () => {
+      // The shared helper carries the per-theme literals so we don't
+      // have to repeat them at every call site. Pin the call shape so
+      // a future refactor that drops the helper can't quietly inject a
+      // static stylesheet.
+      expect(src).toMatch(/buildReaderThemeInjection\s*\(/)
+    })
   })
 
   describe('pdf reader', () => {
@@ -108,14 +104,6 @@ describe('Issue #47 — readers inject theme CSS into the WebView', () => {
       // weaker (e.g. only persisting to settings) is the bug.
       expect(src).toMatch(/readerRef\.current\??\.setTheme/)
     })
-
-    it.each(THEME_NAMES)(
-      'references the %s theme background color literal',
-      (name) => {
-        const bg = READER_THEMES[name].background
-        expect(src).toContain(bg)
-      },
-    )
   })
 
   describe('PdfWebReader exposes a setTheme on its imperative handle', () => {
@@ -135,6 +123,51 @@ describe('Issue #47 — readers inject theme CSS into the WebView', () => {
       // The setTheme implementation must reach into the WebView ref
       // and inject CSS — otherwise the theme is silently dropped.
       expect(src).toMatch(/injectJavaScript/)
+    })
+  })
+
+  describe('shared reader-theme CSS helper', () => {
+    // The helper is plain TypeScript, so we exercise it directly to
+    // satisfy acceptance bullet 2 (theme-specific CSS). For each
+    // ThemeName, the injected snippet must contain the matching
+    // background colour literal — proving that a theme toggle yields
+    // CSS that visibly differs between themes.
+    let buildReaderThemeInjection: (theme: ReaderTheme) => string
+
+    beforeAll(async () => {
+      const mod = await import('../../../lib/reader-theme-css')
+      buildReaderThemeInjection = mod.buildReaderThemeInjection
+    })
+
+    it.each(THEME_NAMES)(
+      'embeds the %s theme background literal in the injected JS',
+      (name) => {
+        const theme = READER_THEMES[name]
+        const snippet = buildReaderThemeInjection(theme)
+        expect(snippet).toContain(theme.background)
+        expect(snippet).toContain(theme.color)
+      },
+    )
+
+    it('produces different output when the theme toggles', () => {
+      // Snapshot-style assertion for acceptance bullet 2: toggling
+      // theme must yield distinct injected CSS. We compare the white
+      // → dark transition specifically because dark mode is the
+      // failure mode called out in the issue.
+      const light = buildReaderThemeInjection(READER_THEMES.white)
+      const dark = buildReaderThemeInjection(READER_THEMES.dark)
+      expect(light).not.toEqual(dark)
+      expect(dark).toContain(READER_THEMES.dark.background)
+      expect(dark).not.toContain(READER_THEMES.white.background)
+    })
+
+    it('ends with a trailing `true;` expression', () => {
+      // react-native-webview's injectJavaScript requires the snippet
+      // to end with a JS expression; omitting it triggers an iOS
+      // runtime warning. Pin the contract so the helper can't quietly
+      // drop the sentinel during a refactor.
+      const snippet = buildReaderThemeInjection(READER_THEMES.white)
+      expect(snippet.trim().endsWith('true;')).toBe(true)
     })
   })
 })

--- a/apps/mobile/app/reader/djvu/[id].tsx
+++ b/apps/mobile/app/reader/djvu/[id].tsx
@@ -28,6 +28,8 @@ import { seedPlayerParagraphsFromChunks } from '@/lib/tts/seed-paragraphs'
 import { resolvePlainTextReadFromSelection } from '@/lib/reader-selection'
 import { useRequireAuth } from '@/components/auth/useRequireAuth'
 import { loadReaderSettings, saveReaderSettings } from '@/lib/reader-settings'
+import { buildReaderThemeInjection } from '@/lib/reader-theme-css'
+import { READER_THEMES } from '@/constants/reader-themes'
 import { safeBack } from '@/lib/navigation'
 import type { ReaderSettings } from '@/types/book'
 import {
@@ -529,6 +531,16 @@ export default function DjvuReaderScreen() {
     saveReaderSettings(next)
     setSettings(next)
   }, [])
+
+  // Issue #47 — forward the active theme into the WebView whenever it
+  // changes. DJVU is canvas-only today so the perceived effect is the
+  // body background swap behind the canvas; without the hop, the
+  // AppearanceSheet's theme picker is a no-op for DJVU users.
+  useEffect(() => {
+    if (!bookLoaded || !webViewRef.current) return
+    const theme = READER_THEMES[settings.themeName]
+    webViewRef.current.injectJavaScript(buildReaderThemeInjection(theme))
+  }, [bookLoaded, settings.themeName])
 
   // safeBack: guards against deep-link cold-start where the nav stack is
   // empty and a bare router.back() would strand the user (P1-B).

--- a/apps/mobile/app/reader/mobi/[id].tsx
+++ b/apps/mobile/app/reader/mobi/[id].tsx
@@ -28,6 +28,8 @@ import { seedPlayerParagraphsFromChunks } from '@/lib/tts/seed-paragraphs'
 import { resolvePlainTextReadFromSelection } from '@/lib/reader-selection'
 import { useRequireAuth } from '@/components/auth/useRequireAuth'
 import { loadReaderSettings, saveReaderSettings } from '@/lib/reader-settings'
+import { buildReaderThemeInjection } from '@/lib/reader-theme-css'
+import { READER_THEMES } from '@/constants/reader-themes'
 import { safeBack } from '@/lib/navigation'
 import type { ReaderSettings } from '@/types/book'
 import {
@@ -512,6 +514,16 @@ export default function MobiReaderScreen() {
     saveReaderSettings(next)
     setSettings(next)
   }, [])
+
+  // Issue #47 — forward the active theme into the WebView whenever it
+  // changes. Without this hop the AppearanceSheet persists `themeName`
+  // but the rendered HTML keeps its initial (white) stylesheet, so
+  // dark-mode users see white pages.
+  useEffect(() => {
+    if (!bookLoaded || !webViewRef.current) return
+    const theme = READER_THEMES[settings.themeName]
+    webViewRef.current.injectJavaScript(buildReaderThemeInjection(theme))
+  }, [bookLoaded, settings.themeName])
 
   // safeBack: guards against deep-link cold-start where the nav stack is
   // empty and a bare router.back() would strand the user (P1-B).

--- a/apps/mobile/app/reader/pdf/[id].tsx
+++ b/apps/mobile/app/reader/pdf/[id].tsx
@@ -39,6 +39,7 @@ import { usePdfStore, BookNavigationState } from '@/lib/stores/pdfStore'
 import { getBookForReading, updateBookPage } from '@/lib/book-storage'
 import { Book, ReaderSettings } from '@/types/book'
 import { loadReaderSettings, saveReaderSettings } from '@/lib/reader-settings'
+import { READER_THEMES } from '@/constants/reader-themes'
 import { safeBack } from '@/lib/navigation'
 import {
   insertPdfHighlight,
@@ -591,6 +592,18 @@ export default function PdfReaderScreen() {
     saveReaderSettings(next)
     setSettings(next)
   }, [])
+
+  // Issue #47 — forward the active theme into the pdfjs WebView. We
+  // gate on `pageCount > 0` so the first call runs after pdfjs has
+  // parsed the document and the viewer DOM exists; the readerRef's
+  // setTheme is idempotent so re-runs on subsequent renders are
+  // cheap. Without this hop the AppearanceSheet's theme picker is a
+  // no-op for PDF users.
+  useEffect(() => {
+    if (pageCount <= 0) return
+    const theme = READER_THEMES[settings.themeName]
+    readerRef.current?.setTheme(theme)
+  }, [pageCount, settings.themeName])
 
   // safeBack: deep-link cold-start has an empty stack, so a bare
   // router.back() no-ops and strands the user (P1-B).

--- a/apps/mobile/components/pdf/PdfWebReader.tsx
+++ b/apps/mobile/components/pdf/PdfWebReader.tsx
@@ -38,6 +38,8 @@ import {
   type PdfWebViewIncomingMessage,
   type PdfWebViewOutgoingMessage,
 } from './pdf-webview-bridge'
+import { buildReaderThemeInjection } from '@/lib/reader-theme-css'
+import type { ReaderTheme } from '@/types/book'
 import type { PdfLocator } from '@rishi/shared/types/pdf-locator'
 
 export interface PdfWebReaderHandle {
@@ -58,6 +60,11 @@ export interface PdfWebReaderHandle {
    * WebView responds with the matching `requestId`. Times out after 5s.
    */
   getPageText(pageNumber: number): Promise<Array<{ index: string; text: string }>>
+  /**
+   * Issue #47 — swap the active reader theme inside the pdfjs WebView.
+   * Idempotent: repeated calls replace the previous stylesheet.
+   */
+  setTheme(theme: ReaderTheme): void
 }
 
 export interface PdfWebReaderProps {
@@ -210,6 +217,14 @@ export const PdfWebReader = forwardRef<PdfWebReaderHandle, PdfWebReaderProps>(
             pageTextWaitersRef.current.set(requestId, { resolve, reject, timer })
             sendToWebView({ type: 'getPageText', requestId, pageNumber })
           })
+        },
+        setTheme(theme) {
+          // Issue #47 — fire-and-forget JS injection. Goes through the
+          // raw `injectJavaScript` API (not the postMessage bridge)
+          // because the WebView template owns the stylesheet, not the
+          // pdfjs viewer code path — there's nothing the bridge needs
+          // to mediate.
+          webViewRef.current?.injectJavaScript(buildReaderThemeInjection(theme))
         },
       }),
       [sendToWebView]

--- a/apps/mobile/lib/reader-theme-css.ts
+++ b/apps/mobile/lib/reader-theme-css.ts
@@ -1,0 +1,70 @@
+/**
+ * Build the CSS + `injectJavaScript` snippet used by the MOBI / DJVU /
+ * PDF WebView readers to apply a reader theme.
+ *
+ * Issue #47 — the WebView-backed readers (MOBI, DJVU, PDF) used to
+ * persist a theme via `saveReaderSettings` but never forwarded it into
+ * the WebView. Dark-mode users were stuck on the white default. This
+ * helper centralises the CSS so every reader injects an identical
+ * stylesheet keyed by the active `ThemeName`.
+ *
+ * Design notes:
+ *   - We render via a `<style id="rishi-theme">` element so repeated
+ *     injections replace the previous stylesheet instead of stacking.
+ *   - We touch `body` background/color *and* the canvas wrapper used by
+ *     DJVU (`body` is the canvas container) and the pdfjs viewer
+ *     (`#viewerContainer`, `.pdfViewer`) so all three readers visibly
+ *     re-theme on a single helper call.
+ *   - The returned snippet ends in `true;` — react-native-webview
+ *     requires `injectJavaScript` to end in a JS expression, and
+ *     omitting the trailing expression triggers a runtime warning on
+ *     iOS (verified against react-native-webview 13.x).
+ */
+
+import type { ReaderTheme } from '@/types/book'
+
+/**
+ * Return a JavaScript snippet that, when injected via
+ * `WebView.injectJavaScript`, swaps the active reader theme inside the
+ * WebView. The snippet is idempotent — repeated calls replace the
+ * `<style id="rishi-theme">` element rather than appending new ones.
+ */
+export function buildReaderThemeInjection(theme: ReaderTheme): string {
+  const css = buildReaderThemeCss(theme)
+  // JSON.stringify handles escaping (quotes, newlines, backslashes) so
+  // the injected JS literal is always valid no matter what colour
+  // syntax future themes use.
+  const cssLiteral = JSON.stringify(css)
+  return [
+    '(function(){',
+    '  try {',
+    '    var id = "rishi-theme";',
+    '    var existing = document.getElementById(id);',
+    '    if (existing) existing.parentNode.removeChild(existing);',
+    '    var style = document.createElement("style");',
+    '    style.id = id;',
+    `    style.textContent = ${cssLiteral};`,
+    '    (document.head || document.documentElement).appendChild(style);',
+    '  } catch (e) { /* swallow — best-effort theme swap */ }',
+    '})();',
+    'true;',
+  ].join('\n')
+}
+
+/**
+ * Build the raw CSS for a theme. Exported separately so callers can
+ * embed it inline in a static HTML template (initial load) while still
+ * using the same colour values as runtime updates.
+ */
+export function buildReaderThemeCss(theme: ReaderTheme): string {
+  const bg = theme.background
+  const fg = theme.color
+  return [
+    `html, body { background: ${bg} !important; color: ${fg} !important; }`,
+    // pdfjs viewer chrome — keep page chrome consistent with body.
+    `#viewerContainer, .pdfViewer { background: ${bg} !important; }`,
+    // MOBI parser content wrapper.
+    `#content, #content * { color: ${fg} !important; }`,
+    `#content a { color: ${fg} !important; }`,
+  ].join('\n')
+}


### PR DESCRIPTION
Closes #47

## Summary

The MOBI, DJVU, and PDF readers persisted `themeName` through `saveReaderSettings` but never forwarded the new theme into the underlying WebView, so dark-mode users were stuck on white pages. Each reader now runs a `useEffect` keyed on `settings.themeName` that calls `injectJavaScript` (or `readerRef.setTheme` for PDF) with a `<style id="rishi-theme">` element built by a shared helper (`lib/reader-theme-css.ts`). The helper is idempotent — repeated calls replace the previous stylesheet rather than stacking — and emits per-theme CSS so toggling between Light/Dark/Sepia yields visibly different output.

For PDF the imperative `PdfWebReaderHandle` gains a typed `setTheme(theme)` so the reader screen can forward CSS through the wrapper without an `as any` cast.

## Testability

TDD

- Red commit: `3c533b4b` — `test(reader): red — theme injection for mobi/djvu/pdf webview (#47)`
- Green commit: `6e7e4f1a` — `fix(reader): green — inject theme CSS into mobi/djvu/pdf webview (#47)`

The new `__tests__/components/reader/webview-theme-injection.test.ts` mixes source-grep (mirrors the existing `mobi-active-paragraph-inject` pattern, since mounting the readers pulls in WebView, expo-file-system, the player store, expo-router) with direct exercise of the shared helper. The helper tests satisfy acceptance bullet 2 explicitly: toggling theme (`white` → `dark`) yields distinct injected JS, and each theme's background/color literal appears in the output.

## Local CI

- typecheck: PASS  (cmd: `pnpm exec tsc --noEmit` — 131 pre-existing errors in `packages/shared/voice-chat`, 0 new errors in changed files)
- test:      PASS  (cmd: `pnpm exec jest __tests__/components/reader/` — 25 suites, 209 tests; full suite has 13 pre-existing FAILs from drizzle-orm/effect/xstate module resolution in packages/shared, unrelated to this change)
- lint:      PASS  (cmd: `pnpm exec eslint <changed-files>` — 0 errors, 3 pre-existing array-type warnings in `PdfWebReader.tsx`)
- format:    SKIP  (no `.prettierrc` in `apps/mobile`; baseline files don't conform to prettier defaults either, so prettier isn't a real gate in this package)
- build:     SKIP  (reason: RN app heavy build)