### PR TITLE
fix(electron/chat): activate voice chat in pdf reader (#233)

### DIFF
--- a/apps/rishi-electron/e2e/ai-chat-pdf.spec.ts
+++ b/apps/rishi-electron/e2e/ai-chat-pdf.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, type Page } from '@playwright/test'
+import {
+  PDF_FIXTURE,
+  closeApp,
+  closeOverlays,
+  deleteAllBooks,
+  importBook,
+  launchApp,
+  openBook,
+  type LaunchedApp
+} from './helpers/electron-app'
+
+/**
+ * Parity coverage for the PDF reader's voice-chat launcher (#233).
+ *
+ * The launcher's auth gate fires BEFORE the chat-activation subscription, so
+ * the premium dialog appears on click regardless of the underlying
+ * subscription wiring — this spec therefore mainly guards the observable
+ * surface (button present, dialog opens, "Maybe later" dismisses). The real
+ * regression guard for the missing subscription lives in pdfStore.test.ts
+ * (`voice chat activation (#233)`).
+ *
+ * Mirrors the EPUB version in `ai-chat.spec.ts` exactly so any future drift
+ * between the two reader paths is immediately visible.
+ */
+test.describe('Voice chat / premium gate (PDF)', () => {
+  let app: LaunchedApp
+  let bookId: number
+  let bookPage: Page
+
+  test.beforeAll(async () => {
+    app = await launchApp()
+    const book = await importBook(app.page, {
+      fixturePath: PDF_FIXTURE,
+      kind: 'pdf',
+      title: 'Voice Chat PDF Spec'
+    })
+    bookId = book.id
+    bookPage = await openBook(app.page, bookId)
+    await expect(bookPage.locator('[aria-label="Start voice chat"]').first()).toBeVisible({
+      timeout: 30000
+    })
+  })
+
+  test.afterAll(async () => {
+    await deleteAllBooks(app.page)
+    await closeApp(app)
+  })
+
+  test.beforeEach(async () => {
+    await closeOverlays(bookPage)
+  })
+
+  test('voice chat launcher renders in the pdf reader', async () => {
+    await expect(bookPage.locator('[aria-label="Start voice chat"]').first()).toBeVisible({
+      timeout: 15000
+    })
+  })
+
+  test('clicking voice chat without auth opens the premium dialog', async () => {
+    await bookPage.locator('[aria-label="Start voice chat"]').first().click()
+    const dialog = bookPage.locator("[data-slot='dialog-content']")
+    await expect(dialog).toBeVisible({ timeout: 5000 })
+    await expect(dialog.locator('text=Sign in').first()).toBeVisible()
+  })
+
+  test('"Maybe later" closes the premium dialog', async () => {
+    await bookPage.locator('[aria-label="Start voice chat"]').first().click()
+    await expect(bookPage.locator("[data-slot='dialog-content']")).toBeVisible({ timeout: 5000 })
+    await bookPage.locator('text=Maybe later').first().click()
+    await expect(bookPage.locator("[data-slot='dialog-content']")).toHaveCount(0)
+  })
+})

--- a/apps/rishi-electron/src/renderer/src/components/FileComponent.test.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/FileComponent.test.tsx
@@ -15,10 +15,24 @@ vi.mock('@/modules/ttsPrefetch', () => ({
   prefetchTTSForBooks: vi.fn(async () => {})
 }))
 
-// Stub services used in useEffect side-effects
+// Stub services used in useEffect side-effects. pdfStore now eagerly imports
+// chatStore (#233), so the voice-chat stub must cover the lifecycle methods
+// chatStore wires at module init (onChatStatus, onStateChange, onEndedByAgent,
+// getState, getError).
 vi.mock('@/services', () => ({
   getBookImportService: () => ({ importBatch: vi.fn(async () => []) }),
-  getVoiceChatService: () => ({ prewarmKey: vi.fn() })
+  getVoiceChatService: () => ({
+    prewarmKey: vi.fn(),
+    activate: vi.fn().mockResolvedValue(undefined),
+    deactivate: vi.fn(),
+    dispose: vi.fn(),
+    getState: vi.fn().mockReturnValue('idle' as const),
+    getError: vi.fn().mockReturnValue(null),
+    dismissError: vi.fn(),
+    onStateChange: vi.fn().mockReturnValue(() => {}),
+    onChatStatus: vi.fn().mockReturnValue(() => {}),
+    onEndedByAgent: vi.fn().mockReturnValue(() => {})
+  })
 }))
 
 // Stub reader caches (their internals require a Worker setup)

--- a/apps/rishi-electron/src/renderer/src/stores/pdfStore.test.ts
+++ b/apps/rishi-electron/src/renderer/src/stores/pdfStore.test.ts
@@ -1,6 +1,71 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Mock the voice-chat service before importing the stores so chatStore's
+// module-scope getVoiceChatService() call resolves to a spy. Same pattern as
+// chatStore.test.ts.
+const { fakeVoice } = vi.hoisted(() => ({
+  fakeVoice: {
+    start: vi.fn(),
+    stop: vi.fn(),
+    activate: vi.fn().mockResolvedValue(undefined),
+    preconnect: vi.fn().mockResolvedValue(undefined),
+    deactivate: vi.fn(),
+    dispose: vi.fn(),
+    prewarmKey: vi.fn(),
+    getState: vi.fn().mockReturnValue('idle' as const),
+    getError: vi.fn().mockReturnValue(null),
+    dismissError: vi.fn(),
+    onStateChange: vi.fn().mockReturnValue(() => {}),
+    onChatStatus: vi.fn().mockReturnValue(() => {}),
+    onEndedByAgent: vi.fn().mockReturnValue(() => {})
+  }
+}))
+
+vi.mock('@/services', () => ({
+  getVoiceChatService: () => fakeVoice
+}))
+
+const { FakeOfflineError } = vi.hoisted(() => ({
+  FakeOfflineError: class OfflineError extends Error {
+    constructor() {
+      super('offline')
+      this.name = 'OfflineError'
+    }
+  }
+}))
+
+vi.mock('@/services/voice-chat', () => ({
+  OfflineError: FakeOfflineError
+}))
+
+vi.mock('@/utils/sentry', () => ({ captureError: vi.fn() }))
+
+vi.mock('@/modules/pageCapture', () => ({
+  summarizeCurrentPage: vi.fn().mockReturnValue({ equations: 0, figures: 0, images: 0 })
+}))
+
+import type { Book } from '@/lib/api'
 import { usePdfStore, BookNavigationState } from './pdfStore'
 import { usePrefsStore } from './prefsStore'
+import { useChatStore } from './chatStore'
+
+const makeBook = (overrides: Partial<Book> = {}): Book => ({
+  id: 42,
+  kind: 'pdf',
+  cover: [],
+  title: 'Test',
+  author: 'Test Author',
+  publisher: '',
+  filepath: '/tmp/test.pdf',
+  location: '1',
+  coverKind: '',
+  version: 0,
+  format: 'pdf',
+  syncVersion: 0,
+  isDirty: 0,
+  isDeleted: 0,
+  ...overrides
+})
 
 describe('pdfStore', () => {
   beforeEach(() => {
@@ -10,6 +75,11 @@ describe('pdfStore', () => {
     // pdfFooterDetection is read by getFooterMaskForPage — keep it on by
     // default so existing tests aren't surprised by the gate.
     usePrefsStore.setState({ pdfFooterDetection: true })
+    // chatStore is a module-scope singleton — reset its mutable state and
+    // the voice-service spies so subscription tests can observe a clean
+    // false→true transition.
+    useChatStore.setState({ isChatting: false, chatStatus: 'idle' })
+    vi.clearAllMocks()
   })
 
   it('should set page number', () => {
@@ -141,5 +211,50 @@ describe('pdfStore', () => {
       false
     )
     expect(usePdfStore.getState().footerMaskByBookId[1]).toBeUndefined()
+  })
+
+  // --- #233 PDF voice-chat activation ---------------------------------------
+  // The EPUB reader gets voice-chat activation via a useChatStore.subscribe in
+  // epubStore.ts:251 that calls chatStore.startChat(bookId) on false→true.
+  // The PDF reader has no equivalent subscription, so flipping isChatting in
+  // the launcher only flips the UI flag and never opens a realtime session.
+  // pdfStore.ts must register a parallel subscription, guarded by
+  // book.kind === 'pdf' so it doesn't double-fire alongside the EPUB
+  // subscription for EPUBs (the route stuffs the loaded Book into
+  // pdfStore.book for every kind — see routes/books.$id.lazy.tsx:48).
+
+  describe('voice chat activation (#233)', () => {
+    it('startChat is called with the PDF book id when isChatting flips true', async () => {
+      usePdfStore.getState().setBook(makeBook({ id: 42, kind: 'pdf' }))
+
+      useChatStore.getState().setIsChatting(true)
+
+      // startChat → voice.activate is async; flush the microtask.
+      await Promise.resolve()
+
+      expect(fakeVoice.activate).toHaveBeenCalledTimes(1)
+      expect(fakeVoice.activate).toHaveBeenCalledWith(42, expect.any(Object))
+    })
+
+    it('does NOT call startChat when book.kind === "epub" (avoids double-fire with epubStore)', async () => {
+      // Simulate the route having stuffed an EPUB into pdfStore.book.
+      usePdfStore.getState().setBook(makeBook({ id: 7, kind: 'epub' }))
+
+      useChatStore.getState().setIsChatting(true)
+
+      await Promise.resolve()
+
+      expect(fakeVoice.activate).not.toHaveBeenCalled()
+    })
+
+    it('does NOT call startChat when book is null', async () => {
+      usePdfStore.getState().setBook(null)
+
+      useChatStore.getState().setIsChatting(true)
+
+      await Promise.resolve()
+
+      expect(fakeVoice.activate).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apps/rishi-electron/src/renderer/src/stores/pdfStore.ts
+++ b/apps/rishi-electron/src/renderer/src/stores/pdfStore.ts
@@ -253,7 +253,7 @@ useChatStore.subscribe(
   (isChatting) => {
     if (!isChatting) return
     const book = usePdfStore.getState().book
-    if (!book || book.kind !== 'pdf') return
+    if (book?.kind !== 'pdf') return
     useChatStore.getState().startChat(book.id)
   }
 )

--- a/apps/rishi-electron/src/renderer/src/stores/pdfStore.ts
+++ b/apps/rishi-electron/src/renderer/src/stores/pdfStore.ts
@@ -7,6 +7,7 @@ import type { ParagraphWithIndex } from '@/models/player_control'
 import type { Book } from '@/lib/api'
 import type { FooterMask } from '@/components/pdf/utils/buildFooterMask'
 import { usePrefsStore } from '@/stores/prefsStore'
+import { useChatStore } from '@/stores/chatStore'
 
 /** PDF view uses `Virtualizer<HTMLDivElement, Element>` — the second arg is
  *  the item element type, which @tanstack/react-virtual leaves as Element
@@ -234,5 +235,25 @@ usePdfStore.subscribe(
     if (usePdfStore.getState().bookNavigationState !== BookNavigationState.Navigating) {
       usePdfStore.setState({ pageNumber: scrollPageNumber })
     }
+  }
+)
+
+// Side effect (#233): when isChatting turns on and a PDF book is loaded, start
+// the realtime voice-chat session. This mirrors the EPUB-side subscription in
+// epubStore.ts (initEpubSubscriptions → useChatStore.subscribe on isChatting).
+// Without this, VoiceChatLauncher in the PDF reader only flips the UI flag and
+// never calls voice.activate(), so the launcher appears to do nothing.
+//
+// Guard on book.kind === 'pdf' is critical: routes/books.$id.lazy.tsx sets
+// pdfStore.book for ALL book kinds (PDF, EPUB, MOBI, AZW3), so without this
+// guard the subscription would double-fire alongside epubStore's subscription
+// for EPUBs.
+useChatStore.subscribe(
+  (state) => state.isChatting,
+  (isChatting) => {
+    if (!isChatting) return
+    const book = usePdfStore.getState().book
+    if (!book || book.kind !== 'pdf') return
+    useChatStore.getState().startChat(book.id)
   }
 )


### PR DESCRIPTION
## Summary

Closes #233. `VoiceChatLauncher.setIsChatting(true)` only flips a UI flag — the actual `voice.activate(bookId, …)` call lives in `chatStore.startChat()`, invoked exclusively from `useChatStore.subscribe` in `epubStore.ts:250-261`. PDFs had no equivalent subscription, so the launcher rendered, opened the auth/premium gate, and then silently no-op'd after sign-in.

This PR adds a module-scope `useChatStore.subscribe` in `pdfStore.ts` that mirrors the EPUB-side subscription, guarded by `book.kind === 'pdf'` to avoid double-firing alongside the EPUB subscription (since `routes/books.$id.lazy.tsx:48` stuffs every loaded `Book` into `pdfStore.book` regardless of kind).

## Testability

TDD red → green:

- Red: `2d8785fc test(electron/store): red — pdf voice chat activation subscription (#233)` — adds 3 failing pdfStore unit tests (1 positive: PDF + `isChatting` false→true → `startChat(book.id)`; 2 negative: EPUB stuffed into `pdfStore.book` must NOT call `startChat`; null book must NOT call `startChat`). Confirmed failing for the right reason (no subscription installed yet).
- Red (e2e parity): `037756a4 test(electron/e2e): pdf voice chat launcher + premium dialog (#233)` — adds `e2e/ai-chat-pdf.spec.ts` mirroring `ai-chat.spec.ts` exactly for the PDF reader. Note: the launcher's auth gate fires BEFORE the activation subscription, so the premium dialog opens regardless of subscription wiring — this spec mainly guards the observable surface (button present, dialog opens, "Maybe later" dismisses). The real regression guard for the missing subscription is the pdfStore unit test.
- Green: `9fdcd086 fix(electron/chat): activate voice chat in pdf reader via pdfStore subscription (#233)` — adds the subscription in `pdfStore.ts` mirroring `epubStore.ts:250-261`, guarded on `book?.kind !== 'pdf'`. All 3 new tests pass.
- Follow-up: `43565cc0 fix(electron/chat): lint optional-chain + extend FileComponent test mock (#233)` — switch the new guard from `!book || book.kind !== 'pdf'` to `book?.kind !== 'pdf'` to satisfy `@typescript-eslint/prefer-optional-chain`, and extend `FileComponent.test.tsx`'s `getVoiceChatService` stub to cover the lifecycle methods chatStore wires at module init (`onChatStatus`, `onStateChange`, `onEndedByAgent`, `getState`, `getError`) — required now that `pdfStore` eagerly imports `chatStore`.

## Local CI

```
typecheck: PASS (pnpm typecheck)
test:      PASS (pnpm test) — 1403 tests, 155 files; same flakiness as origin/main on parser.mobi / thumbnail-sidebar / useBookEmbeddings (unrelated)
lint:      PASS (pnpm lint) — 0 errors, 66 pre-existing warnings (none in changed files)
format:    PASS (pnpm exec prettier --check on changed files)
build:     PASS (pnpm build) — electron-vite output succeeded
```

Playwright e2e was not exercised end-to-end in this run: the Electron harness can't launch a window in this sandboxed environment (`app.firstWindow()` returns undefined, even for the existing `smoke.spec.ts`). Both `e2e/ai-chat.spec.ts` (EPUB) and the new `e2e/ai-chat-pdf.spec.ts` are structurally identical so any drift in CI will surface in either spec; unit-test coverage in `pdfStore.test.ts` is the load-bearing regression guard.

## Architectural smell (out of scope)

The parallel per-format subscription is a smell — a single launcher-side activation flow keyed on the loaded book (or a `bookStore` discriminated union across PDF/EPUB/MOBI/AZW3) would be cleaner than maintaining one `useChatStore.subscribe` per reader path. Left for a follow-up to keep this PR minimal and focused on the reported bug.