### PR TITLE
fix(electron/tts): debounce play spinner across cached inter-paragraph dips (#232)

### DIFF
--- a/apps/rishi-electron/src/renderer/src/components/tts/TTSControls.test.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/tts/TTSControls.test.tsx
@@ -230,3 +230,124 @@ describe('TTSControls — Repeat button', () => {
     })
   })
 })
+
+// ---------------------------------------------------------------------------
+// Play-button spinner debounce (#232)
+//
+// The TTS player dips through `loading` at every paragraph boundary even when
+// the next paragraph's audio is already cached. Showing the spinner during
+// these sub-200ms dips makes the play-button icon flicker. The fix is an
+// asymmetric debounce: delay the spinner ~200ms when arriving from an active
+// playback state, hide immediately, and never delay on cold-start /
+// pause→resume.
+// ---------------------------------------------------------------------------
+
+describe('TTSControls — play spinner debounce (#232)', () => {
+  beforeEach(() => {
+    sendMock.mockReset()
+    vi.useFakeTimers()
+    usePlayerStore.setState({ playingState: 'idle', errors: [] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not show the spinner during a cached playing → loading → playing transition', () => {
+    act(() => usePlayerStore.setState({ playingState: 'playing' }))
+    const { container } = render(<TTSControls bookId="book-1" />)
+    act(() => {
+      expandPill()
+    })
+
+    // Cached-paragraph dip: ~50ms in 'loading' before snapping back.
+    act(() => usePlayerStore.setState({ playingState: 'loading' }))
+    expect(screen.queryByLabelText('Loading')).toBeNull()
+    expect(container.querySelector('.animate-spin')).toBeNull()
+
+    act(() => vi.advanceTimersByTime(50))
+    expect(screen.queryByLabelText('Loading')).toBeNull()
+    expect(container.querySelector('.animate-spin')).toBeNull()
+
+    act(() => usePlayerStore.setState({ playingState: 'playing' }))
+    expect(screen.queryByLabelText('Loading')).toBeNull()
+    expect(container.querySelector('.animate-spin')).toBeNull()
+
+    // Pause icon should remain steady throughout.
+    expect(screen.getByLabelText('Pause')).toBeInTheDocument()
+  })
+
+  it('shows the spinner after the debounce window when load genuinely stalls', () => {
+    act(() => usePlayerStore.setState({ playingState: 'playing' }))
+    const { container } = render(<TTSControls bookId="book-1" />)
+    act(() => {
+      expandPill()
+    })
+
+    act(() => usePlayerStore.setState({ playingState: 'loading' }))
+    // Before debounce fires: still steady.
+    act(() => vi.advanceTimersByTime(150))
+    expect(container.querySelector('.animate-spin')).toBeNull()
+
+    // After debounce fires: spinner appears.
+    act(() => vi.advanceTimersByTime(150))
+    expect(container.querySelector('.animate-spin')).not.toBeNull()
+    expect(screen.getByLabelText('Loading')).toBeInTheDocument()
+  })
+
+  it('shows the spinner immediately on cold-start (idle → loading, no debounce)', () => {
+    const { container } = render(<TTSControls bookId="book-1" />)
+    act(() => {
+      expandPill()
+    })
+
+    act(() => usePlayerStore.setState({ playingState: 'loading' }))
+    // No timer advance — spinner should be visible right away because the
+    // predecessor (`idle`) is NOT an active-playback state.
+    expect(container.querySelector('.animate-spin')).not.toBeNull()
+    expect(screen.getByLabelText('Loading')).toBeInTheDocument()
+  })
+
+  it('shows the spinner immediately on pause → resume (paused.clean → loading, no debounce)', () => {
+    act(() => usePlayerStore.setState({ playingState: 'paused.clean' }))
+    const { container } = render(<TTSControls bookId="book-1" />)
+    act(() => {
+      expandPill()
+    })
+
+    act(() => usePlayerStore.setState({ playingState: 'loading' }))
+    // Predecessor `paused.clean` is not active playback — spinner is immediate.
+    expect(container.querySelector('.animate-spin')).not.toBeNull()
+    expect(screen.getByLabelText('Loading')).toBeInTheDocument()
+  })
+
+  it('hides the spinner immediately when loading ends after the debounce fired', () => {
+    act(() => usePlayerStore.setState({ playingState: 'playing' }))
+    const { container } = render(<TTSControls bookId="book-1" />)
+    act(() => {
+      expandPill()
+    })
+
+    act(() => usePlayerStore.setState({ playingState: 'loading' }))
+    act(() => vi.advanceTimersByTime(300))
+    expect(container.querySelector('.animate-spin')).not.toBeNull()
+
+    // When loading completes, hide is immediate — no delay-hide.
+    act(() => usePlayerStore.setState({ playingState: 'playing' }))
+    expect(container.querySelector('.animate-spin')).toBeNull()
+  })
+
+  it('keeps Prev/Next disabled while raw playingState === "loading" (independent of spinner debounce)', () => {
+    act(() => usePlayerStore.setState({ playingState: 'playing' }))
+    render(<TTSControls bookId="book-1" />)
+    act(() => {
+      expandPill()
+    })
+
+    act(() => usePlayerStore.setState({ playingState: 'loading' }))
+    // Even though the spinner is suppressed, the Prev/Next gates must still
+    // honour the raw loading state (real races, e.g. mid-load nav).
+    expect(screen.getByLabelText('Previous')).toBeDisabled()
+    expect(screen.getByLabelText('Next')).toBeDisabled()
+  })
+})

--- a/apps/rishi-electron/src/renderer/src/components/tts/TTSControls.test.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/tts/TTSControls.test.tsx
@@ -83,7 +83,11 @@ describe('TTSControls auto-collapse', () => {
       vi.advanceTimersByTime(5_000)
     })
 
-    expect(screen.getByLabelText('Play')).toBeInTheDocument()
+    // After #232: cold-start (idle → loading) shows spinner immediately, so
+    // the play-button accessible name is "Loading" (not "Play"). The intent
+    // of this test is that the pill is still expanded — the Play/Pause/Loading
+    // button being present at all proves that.
+    expect(screen.getByLabelText('Loading')).toBeInTheDocument()
   })
 
   it('keeps the pill expanded across playing → pageNavigating → playing', () => {

--- a/apps/rishi-electron/src/renderer/src/components/tts/TTSControls.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/tts/TTSControls.tsx
@@ -62,6 +62,14 @@ const ACTIVE_PLAYBACK_STATES: ReadonlySet<PlayerStoreState> = new Set([
   'republishingParagraphs'
 ])
 
+/**
+ * Debounce window (#232) for showing the play-button spinner when the player
+ * dips from an active-playback state into `loading`. Most inter-paragraph
+ * loads with a cache hit clear in <100ms; a 200ms delay-show window
+ * suppresses the flicker without making genuinely slow loads feel laggy.
+ */
+const SPINNER_DEBOUNCE_MS = 200
+
 export default function TTSControls({ bookId, disabled = false }: TTSControlsProps) {
   const prefersReducedMotion = usePrefersReducedMotion()
   const [showError, setShowError] = useState(false)
@@ -192,18 +200,6 @@ export default function TTSControls({ bookId, disabled = false }: TTSControlsPro
     })
   }
 
-  const getPlayIcon = () => {
-    if (playingState === 'loading') {
-      return <Loader2 size={24} className="animate-spin text-black/60" />
-    }
-    if (playingState === 'playing') {
-      return <Pause size={24} className="text-black/60" />
-    }
-    return <Play size={24} className="text-black/60" />
-  }
-
-  const isPlaying = playingState === 'playing'
-
   // Show the Repeat button across a continuous playback session. While
   // `playingState` briefly drops to `loading` between paragraphs, we keep the
   // button mounted so the pill doesn't reflow every paragraph boundary.
@@ -221,6 +217,99 @@ export default function TTSControls({ bookId, disabled = false }: TTSControlsPro
     setLastNonLoadingState(playingState)
   }
   const showRepeat = lastNonLoadingState === 'playing'
+
+  // --- Play-spinner debounce (#232) ---
+  //
+  // playerMachine briefly transitions through 'loading' at every paragraph
+  // boundary even when the next paragraph's audio is already cached
+  // (packages/shared/src/machines/playerMachine.ts:374,385,432). The raw
+  // signal would flicker <Loader2 /> on every boundary. We debounce the
+  // spinner only when the predecessor was an active-playback state (cached
+  // inter-paragraph dip); cold-start (idle → loading) and pause→resume
+  // (paused → loading) MUST show the spinner immediately so users get
+  // feedback that their explicit action registered.
+  //
+  // Asymmetric: delay-show by SPINNER_DEBOUNCE_MS, hide immediately. Hiding
+  // immediately is important — leaving a stuck spinner after a failed load
+  // would be worse than the flicker we're fixing.
+  //
+  // `debounceElapsed` is the only piece of state we actually need to track —
+  // it's flipped true once the debounce timer fires. The immediate-show paths
+  // (cold-start / pause→resume) are derived purely from `playingState` and
+  // `lastNonLoadingState` during render, so we don't trigger the
+  // react-x/no-set-state-in-effect lint (the same reason `lastNonLoadingState`
+  // uses the render-set-state-with-guard pattern above).
+  const [debounceElapsed, setDebounceElapsed] = useState(false)
+  const spinnerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const cameFromActivePlayback = ACTIVE_PLAYBACK_STATES.has(lastNonLoadingState)
+
+  // Reset the elapsed flag the moment we leave 'loading' — same
+  // render-set-state-with-guard pattern as `lastNonLoadingState` above. This
+  // keeps the effect below free of cascading setState calls.
+  if (playingState !== 'loading' && debounceElapsed) {
+    setDebounceElapsed(false)
+  }
+
+  const showSpinner = playingState === 'loading' && (!cameFromActivePlayback || debounceElapsed)
+
+  useEffect(() => {
+    // Only arm the debounce on the cached-dip path. Cold-start /
+    // pause→resume show the spinner immediately via `showSpinner` derived
+    // above — no timer needed. When we're not in 'loading' there's nothing
+    // to do here; the render-guard above already reset `debounceElapsed`.
+    if (playingState !== 'loading' || !cameFromActivePlayback) {
+      return
+    }
+
+    spinnerTimerRef.current = setTimeout(() => {
+      spinnerTimerRef.current = null
+      setDebounceElapsed(true)
+    }, SPINNER_DEBOUNCE_MS)
+
+    return () => {
+      if (spinnerTimerRef.current !== null) {
+        clearTimeout(spinnerTimerRef.current)
+        spinnerTimerRef.current = null
+      }
+    }
+  }, [playingState, cameFromActivePlayback])
+
+  // Unmount cleanup belt-and-braces (the effect cleanup above already covers
+  // re-renders, but unmount mid-debounce must not leak a timer).
+  useEffect(() => {
+    return () => {
+      if (spinnerTimerRef.current !== null) {
+        clearTimeout(spinnerTimerRef.current)
+        spinnerTimerRef.current = null
+      }
+    }
+  }, [])
+
+  // `effectiveState` is the play-button's user-facing state: it preserves the
+  // last steady icon during a suppressed loading dip so the icon AND the
+  // aria-label (TTSControls.tsx:359) stay coupled. Prev/Next/Stop `disabled`
+  // gates intentionally read raw `playingState` — those guard real races.
+  const effectiveState: PlayerStoreState =
+    playingState === 'loading' && !showSpinner ? lastNonLoadingState : playingState
+
+  const getPlayIcon = () => {
+    if (effectiveState === 'loading') {
+      // The accessible label lives on the parent <button> (`playButtonLabel`);
+      // the SVG itself is decorative so we leave aria-hidden=true (Lucide's
+      // default) to avoid the "multiple elements with text" duplicate that
+      // would otherwise confuse both screen readers and Testing Library
+      // queries.
+      return <Loader2 size={24} className="animate-spin text-black/60" />
+    }
+    if (effectiveState === 'playing') {
+      return <Pause size={24} className="text-black/60" />
+    }
+    return <Play size={24} className="text-black/60" />
+  }
+
+  const isPlaying = playingState === 'playing'
+  const playButtonLabel =
+    effectiveState === 'loading' ? 'Loading' : effectiveState === 'playing' ? 'Pause' : 'Play'
 
   // --- Waveform bars ---
   // Stable IDs let React reconcile bars across re-renders without
@@ -356,7 +445,7 @@ export default function TTSControls({ bookId, disabled = false }: TTSControlsPro
             <button
               onClick={handlePlay}
               disabled={disabled}
-              aria-label={isPlaying ? 'Pause' : 'Play'}
+              aria-label={playButtonLabel}
               className="flex items-center justify-center rounded-full cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed transition-transform duration-150 hover:scale-105 active:scale-95"
               style={{ ...glassButton, width: 50, height: 50 }}
             >


### PR DESCRIPTION
## Summary
- Suppress the play-button spinner flicker that fired on every paragraph boundary by adding an asymmetric 200ms delay-show debounce to the cached-dip path while keeping cold-start and pause→resume immediate.
- Route both `getPlayIcon()` and the play-button `aria-label` through a single `effectiveState` so screen readers no longer announce "Loading" while the icon stays steady; introduces a "Loading" accessible name on the play button.
- Extends the existing `lastNonLoadingState` latch instead of adding a parallel one. Prev/Next/Stop `disabled` props stay coupled to raw `playingState` because they guard real races.

## Testability
TDD — red-then-green.
- Red commit: `ad59da74` — `test(electron/tts): red — assert play spinner suppressed on cached paragraph transition (#232)`
- Green commit: `b99933b4` — `fix(electron/tts): green — debounce play spinner across cached inter-paragraph dips (#232)`

Six new tests under `TTSControls — play spinner debounce (#232)`:
1. cached `playing → loading → playing` (~50ms) → spinner never appears
2. stalled load (>250ms in `loading`) → spinner appears after debounce
3. cold-start (`idle → loading`) → spinner immediate, no debounce
4. pause→resume (`paused.clean → loading`) → spinner immediate, no debounce
5. hide-immediately when `loading` ends after spinner showed
6. Prev/Next stay disabled while raw `playingState === 'loading'`

## Local CI
```
typecheck: PASS  (cmd: cd apps/rishi-electron && NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit -p tsconfig.web.json --composite false && ... tsconfig.node.json ...)
test:      PASS  (cmd: cd apps/rishi-electron && pnpm test)  1406/1406 passed
lint:      PASS  (cmd: pnpm -F rishi-electron lint)          0 errors (66 pre-existing warnings unrelated to this diff)
format:    PASS  (cmd: prettier --check on the 2 changed files)
build:     SKIP  (heavy electron build; CI handles it)
```

## Scope
Two files only, per the validation funnel's ship conditions:
- `apps/rishi-electron/src/renderer/src/components/tts/TTSControls.tsx`
- `apps/rishi-electron/src/renderer/src/components/tts/TTSControls.test.tsx`

No changes to `playerMachine.ts`, `usePlayerMachine.ts`, `service.ts`, mobile, or shared.

Closes #232