### PR TITLE
mobile(library/index): Reading Now pill shows progress (#41)

### DIFF
--- a/apps/mobile/__tests__/__snapshots__/library-screen.test.tsx.snap
+++ b/apps/mobile/__tests__/__snapshots__/library-screen.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`LibraryScreen (#41: Reading Now progress subline) matches the Reading Now pill snapshot with progress subline 1`] = `"Page 7 of 100"`;

--- a/apps/mobile/__tests__/chat/reader-routes.test.ts
+++ b/apps/mobile/__tests__/chat/reader-routes.test.ts
@@ -20,6 +20,7 @@ function bookFromFormat(format: Book['format']): Book {
     format,
     currentCfi: null,
     currentPage: null,
+    lastProgressPercent: null,
     createdAt: 0,
   }
 }

--- a/apps/mobile/__tests__/lib/reading-now-progress.test.ts
+++ b/apps/mobile/__tests__/lib/reading-now-progress.test.ts
@@ -1,0 +1,176 @@
+/**
+ * #41 — Library "Reading Now" pill needs a progress subline.
+ *
+ * The pill on `app/(tabs)/index.tsx` (the `lastReadBook && (...)` block)
+ * previously rendered only title + author. Acceptance criteria call for a
+ * format-aware progress subline:
+ *   - PDF / DJVU  → "Page X of Y" when total is known, else "Page X"
+ *   - EPUB / MOBI → "X%" derived from a stored progress float, or null
+ *                   when no progress has been recorded yet (legacy books)
+ *   - Fallback    → "X%" from `lastProgressPercent` for any format
+ *   - No data at all → null (don't render a stale or misleading subline)
+ *
+ * This file pins the pure formatter that the screen will call. Mounting
+ * the screen lives in `library-screen.test.tsx`.
+ */
+
+import { formatReadingNowProgress } from '@/lib/reading-now-progress'
+
+describe('#41 — formatReadingNowProgress', () => {
+  describe('PDF', () => {
+    it('renders "Page X of Y" when both currentPage and totalPages-derived progress are known', () => {
+      expect(
+        formatReadingNowProgress({
+          format: 'pdf',
+          currentPage: 42,
+          lastProgressPercent: 42 / 100, // implies total=100
+        }),
+      ).toBe('Page 42 of 100')
+    })
+
+    it('renders "Page X" when currentPage is known but progress is null', () => {
+      expect(
+        formatReadingNowProgress({
+          format: 'pdf',
+          currentPage: 17,
+          lastProgressPercent: null,
+        }),
+      ).toBe('Page 17')
+    })
+
+    it('returns null when no progress data is known (legacy book, never opened post-migration)', () => {
+      expect(
+        formatReadingNowProgress({
+          format: 'pdf',
+          currentPage: null,
+          lastProgressPercent: null,
+        }),
+      ).toBeNull()
+    })
+  })
+
+  describe('DJVU', () => {
+    it('renders "Page X of Y" when both currentPage and progress are known', () => {
+      expect(
+        formatReadingNowProgress({
+          format: 'djvu',
+          currentPage: 10,
+          lastProgressPercent: 0.1,
+        }),
+      ).toBe('Page 10 of 100')
+    })
+
+    it('renders "Page X" when only currentPage is known', () => {
+      expect(
+        formatReadingNowProgress({
+          format: 'djvu',
+          currentPage: 5,
+          lastProgressPercent: null,
+        }),
+      ).toBe('Page 5')
+    })
+  })
+
+  describe('EPUB', () => {
+    it('renders "X%" derived from lastProgressPercent', () => {
+      expect(
+        formatReadingNowProgress({
+          format: 'epub',
+          currentPage: null,
+          lastProgressPercent: 0.42,
+        }),
+      ).toBe('42%')
+    })
+
+    it('rounds to the nearest whole percent', () => {
+      expect(
+        formatReadingNowProgress({
+          format: 'epub',
+          currentPage: null,
+          lastProgressPercent: 0.4249,
+        }),
+      ).toBe('42%')
+      expect(
+        formatReadingNowProgress({
+          format: 'epub',
+          currentPage: null,
+          lastProgressPercent: 0.425,
+        }),
+      ).toBe('43%')
+    })
+
+    it('returns null when no progress is recorded yet', () => {
+      expect(
+        formatReadingNowProgress({
+          format: 'epub',
+          currentPage: null,
+          lastProgressPercent: null,
+        }),
+      ).toBeNull()
+    })
+  })
+
+  describe('MOBI', () => {
+    it('renders "X%" from lastProgressPercent', () => {
+      expect(
+        formatReadingNowProgress({
+          format: 'mobi',
+          currentPage: null,
+          lastProgressPercent: 0.73,
+        }),
+      ).toBe('73%')
+    })
+
+    it('returns null when no progress data is available', () => {
+      expect(
+        formatReadingNowProgress({
+          format: 'mobi',
+          currentPage: null,
+          lastProgressPercent: null,
+        }),
+      ).toBeNull()
+    })
+  })
+
+  describe('AZW3', () => {
+    it('formats like MOBI ("X%" from lastProgressPercent)', () => {
+      expect(
+        formatReadingNowProgress({
+          format: 'azw3',
+          currentPage: null,
+          lastProgressPercent: 0.5,
+        }),
+      ).toBe('50%')
+    })
+  })
+
+  describe('boundary conditions', () => {
+    it('clamps lastProgressPercent into [0, 1]', () => {
+      // epubjs occasionally emits 1.0000001 at the end of the spine.
+      expect(
+        formatReadingNowProgress({
+          format: 'epub',
+          currentPage: null,
+          lastProgressPercent: 1.0001,
+        }),
+      ).toBe('100%')
+      expect(
+        formatReadingNowProgress({
+          format: 'epub',
+          currentPage: null,
+          lastProgressPercent: -0.01,
+        }),
+      ).toBe('0%')
+    })
+
+    it('ignores NaN lastProgressPercent (epubjs pre-locations-ready)', () => {
+      expect(
+        formatReadingNowProgress({
+          format: 'epub',
+          currentPage: null,
+          lastProgressPercent: Number.NaN,
+        }),
+      ).toBeNull()
+    })
+  })
+})

--- a/apps/mobile/__tests__/library-screen.test.tsx
+++ b/apps/mobile/__tests__/library-screen.test.tsx
@@ -859,3 +859,141 @@ describe('LibraryScreen (#32: row de-duplication + horizontal layout)', () => {
     expect(flattened.flexDirection).toBe('row')
   })
 })
+
+/**
+ * #41 — "Reading Now" pill needs a progress subline.
+ *
+ * Before the fix, the pill rendered only title + author. We pin three
+ * observable consequences on the pill content after the fix:
+ *   1. A `library-reading-now-progress` Text element is mounted under
+ *      the pill when the last-read book has progress data.
+ *   2. Its content is format-aware:
+ *        - PDF with both `currentPage` and `lastProgressPercent` → "Page X of Y"
+ *        - EPUB with `lastProgressPercent` only → "X%"
+ *   3. When the last-read book has NO progress data (legacy row), the
+ *      subline element is NOT rendered (we don't show a stale label).
+ *   4. The pill matches its snapshot (acceptance criterion: "snapshot
+ *      test verifies the new field is present").
+ */
+describe('LibraryScreen (#41: Reading Now progress subline)', () => {
+  beforeEach(() => {
+    mockBooks.length = 0
+    mockLastReadBook = null
+  })
+
+  function findAllByID(
+    tree: TestRenderer.ReactTestRenderer,
+    testID: string,
+  ): TestRenderer.ReactTestInstance[] {
+    return tree.root.findAll(
+      (n) =>
+        typeof n.type === 'string' &&
+        (n.props as { testID?: string }).testID === testID,
+    )
+  }
+
+  function collectText(node: TestRenderer.ReactTestInstance): string {
+    return node.children
+      .map((child) =>
+        typeof child === 'string'
+          ? child
+          : collectText(child as TestRenderer.ReactTestInstance),
+      )
+      .join('')
+  }
+
+  it('renders "Page X of Y" for a PDF last-read book with page + progress', () => {
+    const lastBook = {
+      id: 'pdf1',
+      title: 'On Photography',
+      author: 'Susan Sontag',
+      format: 'pdf',
+      filePath: '/tmp/op.pdf',
+      coverPath: null,
+      currentCfi: null,
+      currentPage: 42,
+      lastProgressPercent: 0.42,
+      createdAt: 0,
+    }
+    mockBooks.push(lastBook)
+    mockLastReadBook = lastBook
+    let tree!: TestRenderer.ReactTestRenderer
+    act(() => {
+      tree = TestRenderer.create(<LibraryScreen />)
+    })
+    const subline = findAllByID(tree, 'library-reading-now-progress')
+    expect(subline.length).toBeGreaterThan(0)
+    expect(collectText(subline[0])).toBe('Page 42 of 100')
+  })
+
+  it('renders "X%" for an EPUB last-read book with stored progress', () => {
+    const lastBook = {
+      id: 'ep1',
+      title: 'The Brothers Karamazov',
+      author: 'Dostoyevsky',
+      format: 'epub',
+      filePath: '/tmp/bk.epub',
+      coverPath: null,
+      currentCfi: 'epubcfi(/6/4!/4/2/2)',
+      currentPage: null,
+      lastProgressPercent: 0.18,
+      createdAt: 0,
+    }
+    mockBooks.push(lastBook)
+    mockLastReadBook = lastBook
+    let tree!: TestRenderer.ReactTestRenderer
+    act(() => {
+      tree = TestRenderer.create(<LibraryScreen />)
+    })
+    const subline = findAllByID(tree, 'library-reading-now-progress')
+    expect(subline.length).toBeGreaterThan(0)
+    expect(collectText(subline[0])).toBe('18%')
+  })
+
+  it('omits the subline for a legacy book with no progress data', () => {
+    const lastBook = {
+      id: 'legacy1',
+      title: 'Anna Karenina',
+      author: 'Tolstoy',
+      format: 'epub',
+      filePath: '/tmp/ak.epub',
+      coverPath: null,
+      currentCfi: 'epubcfi(/6/4)',
+      currentPage: null,
+      lastProgressPercent: null,
+      createdAt: 0,
+    }
+    mockBooks.push(lastBook)
+    mockLastReadBook = lastBook
+    let tree!: TestRenderer.ReactTestRenderer
+    act(() => {
+      tree = TestRenderer.create(<LibraryScreen />)
+    })
+    const subline = findAllByID(tree, 'library-reading-now-progress')
+    expect(subline.length).toBe(0)
+  })
+
+  it('matches the Reading Now pill snapshot with progress subline', () => {
+    const lastBook = {
+      id: 'snap1',
+      title: 'Snapshot Title',
+      author: 'Snapshot Author',
+      format: 'pdf',
+      filePath: '/tmp/snap.pdf',
+      coverPath: null,
+      currentCfi: null,
+      currentPage: 7,
+      lastProgressPercent: 0.07,
+      createdAt: 0,
+    }
+    mockBooks.push(lastBook)
+    mockLastReadBook = lastBook
+    let tree!: TestRenderer.ReactTestRenderer
+    act(() => {
+      tree = TestRenderer.create(<LibraryScreen />)
+    })
+    const sublines = findAllByID(tree, 'library-reading-now-progress')
+    expect(sublines.length).toBe(1)
+    expect(collectText(sublines[0])).toMatchSnapshot()
+  })
+})

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -28,6 +28,7 @@ import {
 import { Book } from '@/types/book'
 import { useTourTargetLayout } from '@/lib/onboarding/useTourTarget'
 import { useTheme } from '@/lib/theme'
+import { formatReadingNowProgress } from '@/lib/reading-now-progress'
 
 /**
  * Library tab (P0-I).
@@ -423,6 +424,33 @@ export default function LibraryScreen() {
             >
               {lastReadBook.author}
             </Text>
+            {(() => {
+              // #41 — Format-aware progress subline. The formatter returns
+              // null for legacy rows with no progress data; in that case
+              // we render no extra Text node so we don't surface a stale
+              // or misleading "0%" label.
+              const progressSubline = formatReadingNowProgress({
+                format: lastReadBook.format,
+                currentPage: lastReadBook.currentPage,
+                lastProgressPercent: lastReadBook.lastProgressPercent,
+              })
+              if (!progressSubline) return null
+              return (
+                <Text
+                  testID="library-reading-now-progress"
+                  accessibilityLabel={`Progress: ${progressSubline}`}
+                  numberOfLines={1}
+                  style={{
+                    fontSize: typography.scale.caption.fontSize,
+                    lineHeight: typography.scale.caption.lineHeight,
+                    color: colors.label.tertiary,
+                    marginTop: 2,
+                  }}
+                >
+                  {progressSubline}
+                </Text>
+              )
+            })()}
           </View>
           <IconSymbol
             name="chevron.right"

--- a/apps/mobile/app/reader/[id].tsx
+++ b/apps/mobile/app/reader/[id].tsx
@@ -7,7 +7,11 @@ import { useFileSystem } from '@/lib/epub/file-system-adapter'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { getBookForReading, updateBookCfi } from '@/lib/book-storage'
+import {
+  getBookForReading,
+  updateBookCfi,
+  updateBookProgress,
+} from '@/lib/book-storage'
 import { loadReaderSettings, saveReaderSettings } from '@/lib/reader-settings'
 import { safeBack } from '@/lib/navigation'
 import { insertHighlight, getHighlightsByBookId, updateHighlight, deleteHighlight, restoreHighlight } from '@/lib/highlight-storage'
@@ -317,6 +321,13 @@ function ReaderContent({ book }: { book: Book }) {
         cfiSaveTimeoutRef.current = setTimeout(() => {
           if (book.id && currentCfiRef.current) {
             updateBookCfi(book.id, currentCfiRef.current)
+            // #41 — Persist progress alongside CFI so the library
+            // "Reading Now" pill subline can render "X%" once the
+            // reader closes. epubjs's progress arg is a 0..1 float
+            // already — `updateBookProgress` clamps + NaN-guards.
+            if (Number.isFinite(progress)) {
+              updateBookProgress(book.id, progress)
+            }
           }
         }, 500)
       }

--- a/apps/mobile/app/reader/djvu/[id].tsx
+++ b/apps/mobile/app/reader/djvu/[id].tsx
@@ -14,7 +14,11 @@ import { useLocalSearchParams, useRouter } from 'expo-router'
 import { WebView } from 'react-native-webview'
 import { File as ExpoFile } from 'expo-file-system'
 import { IconSymbol } from '@/components/ui/icon-symbol'
-import { getBookForReading, updateBookPage } from '@/lib/book-storage'
+import {
+  getBookForReading,
+  updateBookPage,
+  updateBookProgress,
+} from '@/lib/book-storage'
 import { Book } from '@/types/book'
 import { TTSVisualCue } from '@/components/TTSVisualCue'
 import { useVisualCueStore } from '@/lib/tts/visual-cue'
@@ -229,6 +233,10 @@ export default function DjvuReaderScreen() {
 
   const webViewRef = useRef<WebView>(null)
   const currentPageRef = useRef(1)
+  // #41 — Mirrors `pageCount` so the bridged-message handler can
+  // compute `current / total` for `updateBookProgress` without
+  // waiting for React to re-render with the new state.
+  const pageCountRef = useRef(0)
 
   // Mount the player machine for TTS read-aloud (Batch 7). The DJVU
   // extractor (chunker.getChunks for 'djvu') only returns paragraphs if
@@ -383,6 +391,12 @@ export default function DjvuReaderScreen() {
       if (nextState === 'background' || nextState === 'inactive') {
         if (book?.id) {
           updateBookPage(book.id, currentPageRef.current)
+          // #41 — Mirror progress for the library "Reading Now" pill
+          // ("Page X of Y").
+          const total = pageCountRef.current
+          if (total > 0) {
+            updateBookProgress(book.id, currentPageRef.current / total)
+          }
         }
       }
     }
@@ -395,6 +409,10 @@ export default function DjvuReaderScreen() {
       const msg = JSON.parse(event.nativeEvent.data)
       if (msg.type === 'loaded') {
         setPageCount(msg.total)
+        // #41 — Mirror into the ref so handleMessage's subsequent
+        // 'page' events can compute progress without waiting for
+        // React to re-render with the new state.
+        pageCountRef.current = typeof msg.total === 'number' ? msg.total : 0
         // Render the saved page
         webViewRef.current?.postMessage(
           JSON.stringify({ type: 'goto', page: currentPageRef.current })
@@ -404,6 +422,12 @@ export default function DjvuReaderScreen() {
         currentPageRef.current = msg.current
         if (book?.id) {
           updateBookPage(book.id, msg.current)
+          // #41 — Persist progress so the library pill subline can
+          // render "Page X of Y" after the reader closes.
+          const total = pageCountRef.current
+          if (total > 0) {
+            updateBookProgress(book.id, msg.current / total)
+          }
         }
       } else if (msg.type === 'selection') {
         // P1-K — DJVU canvas selection bridge. In practice the canvas
@@ -547,6 +571,11 @@ export default function DjvuReaderScreen() {
   const handleBack = useCallback(() => {
     if (book?.id) {
       updateBookPage(book.id, currentPageRef.current)
+      // #41 — Persist progress (see handleMessage / handleAppStateChange).
+      const total = pageCountRef.current
+      if (total > 0) {
+        updateBookProgress(book.id, currentPageRef.current / total)
+      }
     }
     safeBack(router)
   }, [book?.id, router])

--- a/apps/mobile/app/reader/mobi/[id].tsx
+++ b/apps/mobile/app/reader/mobi/[id].tsx
@@ -14,7 +14,11 @@ import { useLocalSearchParams, useRouter } from 'expo-router'
 import { WebView } from 'react-native-webview'
 import { File as ExpoFile } from 'expo-file-system'
 import { IconSymbol } from '@/components/ui/icon-symbol'
-import { getBookForReading, updateBookPage } from '@/lib/book-storage'
+import {
+  getBookForReading,
+  updateBookPage,
+  updateBookProgress,
+} from '@/lib/book-storage'
 import { Book } from '@/types/book'
 import { TTSVisualCue } from '@/components/TTSVisualCue'
 import { useVisualCueStore } from '@/lib/tts/visual-cue'
@@ -289,6 +293,10 @@ export default function MobiReaderScreen() {
 
   const webViewRef = useRef<WebView>(null)
   const currentChapterRef = useRef(0)
+  // #41 — Mirrors `chapterCount` state so the bridged-message handler
+  // (which can be invoked before React re-renders with the latest
+  // count) can compute `current / total` for `updateBookProgress`.
+  const chapterCountRef = useRef(0)
   // RDR-024 — set by the chapter postMessage from the WebView. Most MOBI
   // chapters lack `[data-paragraph-index]` ids, so the per-TTS-step
   // injectJavaScript hop below would always be a no-op. We probe once
@@ -363,6 +371,19 @@ export default function MobiReaderScreen() {
       if (nextState === 'background' || nextState === 'inactive') {
         if (book?.id) {
           updateBookPage(book.id, currentChapterRef.current)
+          // #41 — Mirror progress for the library "Reading Now" pill.
+          // MOBI uses chapters as its progress denominator (the format
+          // has no global page count); the pill renders the result as
+          // "X%".
+          const total = chapterCountRef.current
+          if (total > 0) {
+            // currentChapter is 0-indexed; add 1 so a reader who has
+            // started the last chapter shows 100% rather than (N-1)/N.
+            updateBookProgress(
+              book.id,
+              Math.min(1, (currentChapterRef.current + 1) / total),
+            )
+          }
         }
       }
     }
@@ -375,6 +396,10 @@ export default function MobiReaderScreen() {
       const msg = JSON.parse(event.nativeEvent.data)
       if (msg.type === 'loaded') {
         setChapterCount(msg.total)
+        // #41 — mirror into the ref so handleMessage can compute
+        // progress on the next 'chapter' event without waiting for
+        // React to re-render with the new state.
+        chapterCountRef.current = typeof msg.total === 'number' ? msg.total : 0
         // Navigate to saved chapter
         webViewRef.current?.postMessage(
           JSON.stringify({ type: 'goto', chapter: currentChapterRef.current })
@@ -388,6 +413,15 @@ export default function MobiReaderScreen() {
         hasParagraphIdsRef.current = msg.hasParagraphIds === true
         if (book?.id) {
           updateBookPage(book.id, msg.current)
+          // #41 — Persist progress so the library pill subline can
+          // render "X%" after the reader closes.
+          const total = chapterCountRef.current
+          if (total > 0) {
+            updateBookProgress(
+              book.id,
+              Math.min(1, (msg.current + 1) / total),
+            )
+          }
         }
       } else if (msg.type === 'selection') {
         // P1-K — WebView reports the current text selection. We hold it
@@ -530,6 +564,14 @@ export default function MobiReaderScreen() {
   const handleBack = useCallback(() => {
     if (book?.id) {
       updateBookPage(book.id, currentChapterRef.current)
+      // #41 — Persist progress (see handleMessage / handleAppStateChange).
+      const total = chapterCountRef.current
+      if (total > 0) {
+        updateBookProgress(
+          book.id,
+          Math.min(1, (currentChapterRef.current + 1) / total),
+        )
+      }
     }
     safeBack(router)
   }, [book?.id, router])

--- a/apps/mobile/app/reader/pdf/[id].tsx
+++ b/apps/mobile/app/reader/pdf/[id].tsx
@@ -36,7 +36,11 @@ import {
   type PdfOutlineItem,
 } from '@/components/pdf/pdf-webview-bridge'
 import { usePdfStore, BookNavigationState } from '@/lib/stores/pdfStore'
-import { getBookForReading, updateBookPage } from '@/lib/book-storage'
+import {
+  getBookForReading,
+  updateBookPage,
+  updateBookProgress,
+} from '@/lib/book-storage'
 import { Book, ReaderSettings } from '@/types/book'
 import { loadReaderSettings, saveReaderSettings } from '@/lib/reader-settings'
 import { READER_THEMES } from '@/constants/reader-themes'
@@ -215,11 +219,19 @@ export default function PdfReaderScreen() {
     const handler = (next: AppStateStatus) => {
       if ((next === 'background' || next === 'inactive') && book?.id && pageNumber > 0) {
         updateBookPage(book.id, pageNumber)
+        // #41 — Mirror the page save with a progress percent so the
+        // library "Reading Now" pill subline can render "Page X of Y"
+        // post-close. `pageCount` may be 0 during a backgrounding
+        // race before the WebView finished `handleLoad`; the guard
+        // keeps us from poisoning the column with NaN.
+        if (pageCount > 0) {
+          updateBookProgress(book.id, pageNumber / pageCount)
+        }
       }
     }
     const sub = AppState.addEventListener('change', handler)
     return () => sub.remove()
-  }, [book?.id, pageNumber])
+  }, [book?.id, pageNumber, pageCount])
 
   // ---- WebView events ----
   const handleLoad = useCallback(
@@ -245,9 +257,18 @@ export default function PdfReaderScreen() {
       setScrollPageNumber(page)
       // Persist with a soft debounce — we save on background change too, so
       // this just makes scrolling-then-killing-the-app safe.
-      if (book?.id) updateBookPage(book.id, page)
+      if (book?.id) {
+        updateBookPage(book.id, page)
+        // #41 — Persist progress so the library pill subline can show
+        // "Page X of Y". `pageCount` is set in `handleLoad` from
+        // `pdfjs.numPages` before the first user-driven page change,
+        // but we guard for the cold-start race anyway.
+        if (pageCount > 0) {
+          updateBookProgress(book.id, page / pageCount)
+        }
+      }
     },
-    [book?.id, setScrollPageNumber]
+    [book?.id, pageCount, setScrollPageNumber]
   )
 
   const handleSelection = useCallback(
@@ -608,9 +629,15 @@ export default function PdfReaderScreen() {
   // safeBack: deep-link cold-start has an empty stack, so a bare
   // router.back() no-ops and strands the user (P1-B).
   const handleBack = useCallback(() => {
-    if (book?.id && pageNumber > 0) updateBookPage(book.id, pageNumber)
+    if (book?.id && pageNumber > 0) {
+      updateBookPage(book.id, pageNumber)
+      // #41 — Mirror progress for the library pill (see handlePageChange).
+      if (pageCount > 0) {
+        updateBookProgress(book.id, pageNumber / pageCount)
+      }
+    }
     safeBack(router)
-  }, [book?.id, pageNumber, router])
+  }, [book?.id, pageNumber, pageCount, router])
 
   // CHT-002 — voice-chat activation context. PDF doesn't ship rendered
   // page text back across the WebView bridge synchronously, so we use a

--- a/apps/mobile/lib/book-import/index.ts
+++ b/apps/mobile/lib/book-import/index.ts
@@ -61,6 +61,7 @@ export function createMobileBookImportService(opts: {
       format,
       currentCfi: null,
       currentPage: format === "pdf" ? 1 : null,
+      lastProgressPercent: null,
       createdAt: Date.now(),
     }),
     bookIdOf: (book) => book.id,

--- a/apps/mobile/lib/book-storage.ts
+++ b/apps/mobile/lib/book-storage.ts
@@ -112,6 +112,32 @@ export function updateBookPage(id: string, page: number): void {
   triggerSyncOnWrite()
 }
 
+/**
+ * #41 — Persist a format-honest 0..1 progress float so the library
+ * "Reading Now" pill can render a subline (Page X of Y / X%) AFTER the
+ * reader has been closed. Callers are reader screens (EPUB / PDF /
+ * DJVU / MOBI / AZW3); each derives the float in a format-appropriate
+ * way and hands it off here.
+ *
+ * Boundary handling: values outside [0, 1] (epubjs can emit 1.0000001)
+ * and NaN are clamped/dropped before persistence so the database never
+ * holds a garbage value that the formatter would then have to defend
+ * against on every read.
+ *
+ * This update does NOT bump `isDirty` — progress is a mobile-only UI
+ * affordance, never pushed to D1, so there is nothing to sync. We do
+ * still touch `updatedAt` so `getLastReadBook()`'s `ORDER BY` keeps
+ * the most-recently-read book at the top.
+ */
+export function updateBookProgress(id: string, percent: number): void {
+  if (Number.isNaN(percent)) return
+  const clamped = percent < 0 ? 0 : percent > 1 ? 1 : percent
+  db.update(books)
+    .set({ lastProgressPercent: clamped, updatedAt: Date.now() })
+    .where(eq(books.id, id))
+    .run()
+}
+
 export function deleteBook(id: string): void {
   db.update(books)
     .set({ isDeleted: true, updatedAt: Date.now(), isDirty: true })
@@ -161,6 +187,11 @@ function mapRowToBook(row: typeof books.$inferSelect): Book {
     format: row.format as Book['format'],
     currentCfi: row.currentCfi,
     currentPage: row.currentPage,
+    // #41 — Project the persisted progress float so the library
+    // "Reading Now" pill can render its subline. Older rows that
+    // pre-date the migration carry null here and the pill omits the
+    // subline instead of showing a misleading "0%".
+    lastProgressPercent: row.lastProgressPercent ?? null,
     createdAt: row.createdAt,
     // Extra field — typed as optional on the Book interface.
     coverExtractionFailed: failed,

--- a/apps/mobile/lib/db.ts
+++ b/apps/mobile/lib/db.ts
@@ -45,6 +45,11 @@ const columnsToAdd: [string, string][] = [
   // atomic `tmpFile.move()` fails in `downloadBookFile`. UI uses it (via
   // the download-error-store) to surface a retry affordance.
   ['file_needs_redownload', 'INTEGER DEFAULT 0'],
+  // #41 — Persisted 0..1 progress float for the library "Reading Now"
+  // pill subline. Nullable: legacy rows that pre-date the migration
+  // (and rows that have never been opened in a reader) stay null and
+  // the pill omits the subline rather than showing a stale "0%".
+  ['last_progress_percent', 'REAL'],
 ]
 
 for (const [col, type] of columnsToAdd) {

--- a/apps/mobile/lib/file-import.ts
+++ b/apps/mobile/lib/file-import.ts
@@ -175,6 +175,7 @@ async function runImportWithService(opts: {
       format: opts.format,
       currentCfi: null,
       currentPage: opts.format === "pdf" ? 1 : null,
+      lastProgressPercent: null,
       createdAt: Date.now(),
     },
   };
@@ -434,6 +435,7 @@ export async function importBookFromFile(opts: {
     format: opts.format,
     currentCfi: null,
     currentPage: opts.format === "pdf" ? 1 : null,
+    lastProgressPercent: null,
     createdAt: Date.now(),
   };
 }

--- a/apps/mobile/lib/reading-now-progress.ts
+++ b/apps/mobile/lib/reading-now-progress.ts
@@ -10,16 +10,15 @@
  *                   total are known, else "Page X" when only page is set.
  *                   Returns null when neither is set.
  *   - EPUB / MOBI / AZW3 → "X%" from `lastProgressPercent` (a 0..1 float).
- *                          Returns null when no progress recorded yet.
+ *                          Returns null when no progress has been recorded
+ *                          yet (legacy row, never opened post-migration).
  *
  * Boundary behaviour:
  *   - Clamps `lastProgressPercent` into [0, 1] (epubjs sometimes emits
- *     1.0000001 at the spine boundary).
- *   - NaN / undefined progress is treated as "no data" (null).
- *
- * Stub for the red commit: returns null for every input so the test
- * assertions fail with real comparisons rather than module-not-found
- * errors. The green commit replaces this with the real implementation.
+ *     1.0000001 at the spine boundary, and a malformed PDF could divide
+ *     to slightly > 1).
+ *   - NaN / undefined progress is treated as "no data" (null) so the
+ *     pill stays empty rather than rendering "NaN%".
  */
 
 export interface ReadingNowProgressInput {
@@ -28,10 +27,43 @@ export interface ReadingNowProgressInput {
   lastProgressPercent: number | null
 }
 
+/**
+ * Clamp a 0..1 float into the closed interval, returning null when the
+ * value is NaN / undefined / null. Internal helper.
+ */
+function normalizeProgress(value: number | null | undefined): number | null {
+  if (value === null || value === undefined) return null
+  if (Number.isNaN(value)) return null
+  if (value < 0) return 0
+  if (value > 1) return 1
+  return value
+}
+
 export function formatReadingNowProgress(
-  _input: ReadingNowProgressInput,
+  input: ReadingNowProgressInput,
 ): string | null {
-  // Stub: return null so jest exercises the real value/null comparisons
-  // rather than a module-resolution error.
-  return null
+  const { format, currentPage, lastProgressPercent } = input
+  const progress = normalizeProgress(lastProgressPercent)
+
+  if (format === 'pdf' || format === 'djvu') {
+    // Paginated formats: prefer "Page X of Y" when we can derive Y from
+    // (page / percent). Fall back to just "Page X" when only the page
+    // is known. Render nothing when neither is recorded.
+    if (currentPage !== null && currentPage > 0) {
+      if (progress !== null && progress > 0) {
+        const total = Math.round(currentPage / progress)
+        if (Number.isFinite(total) && total >= currentPage) {
+          return `Page ${currentPage} of ${total}`
+        }
+      }
+      return `Page ${currentPage}`
+    }
+    return null
+  }
+
+  // EPUB / MOBI / AZW3: percent-based. epubjs gives us the float
+  // directly; MOBI/AZW3 readers compute current/total chapters at save
+  // time and store the resulting float here.
+  if (progress === null) return null
+  return `${Math.round(progress * 100)}%`
 }

--- a/apps/mobile/lib/reading-now-progress.ts
+++ b/apps/mobile/lib/reading-now-progress.ts
@@ -1,0 +1,37 @@
+/**
+ * #41 — Library "Reading Now" pill needs a progress subline.
+ *
+ * Pure formatter consumed by the Reading Now pill on
+ * `app/(tabs)/index.tsx`. Returns a format-aware human-readable
+ * progress string, or `null` when there is no progress data to show.
+ *
+ * Format mapping:
+ *   - PDF / DJVU  → "Page X of Y" when both `currentPage` and a derivable
+ *                   total are known, else "Page X" when only page is set.
+ *                   Returns null when neither is set.
+ *   - EPUB / MOBI / AZW3 → "X%" from `lastProgressPercent` (a 0..1 float).
+ *                          Returns null when no progress recorded yet.
+ *
+ * Boundary behaviour:
+ *   - Clamps `lastProgressPercent` into [0, 1] (epubjs sometimes emits
+ *     1.0000001 at the spine boundary).
+ *   - NaN / undefined progress is treated as "no data" (null).
+ *
+ * Stub for the red commit: returns null for every input so the test
+ * assertions fail with real comparisons rather than module-not-found
+ * errors. The green commit replaces this with the real implementation.
+ */
+
+export interface ReadingNowProgressInput {
+  format: 'epub' | 'pdf' | 'mobi' | 'azw3' | 'djvu'
+  currentPage: number | null
+  lastProgressPercent: number | null
+}
+
+export function formatReadingNowProgress(
+  _input: ReadingNowProgressInput,
+): string | null {
+  // Stub: return null so jest exercises the real value/null comparisons
+  // rather than a module-resolution error.
+  return null
+}

--- a/apps/mobile/types/book.ts
+++ b/apps/mobile/types/book.ts
@@ -7,6 +7,16 @@ export interface Book {
   format: 'epub' | 'pdf' | 'mobi' | 'azw3' | 'djvu'
   currentCfi: string | null // ePubCFI string for EPUB reading position
   currentPage: number | null // Page number for PDF reading position
+  /**
+   * #41 — Persisted format-honest progress, a 0..1 float, used to render
+   * the "Reading Now" pill subline on the library tab AFTER the reader
+   * has been closed. EPUB sources this from epubjs's onRelocated progress
+   * arg; PDF/DJVU compute `currentPage / total`; MOBI/AZW3 compute
+   * `currentChapter / chapterCount`. `null` for legacy rows that haven't
+   * been opened post-migration — the pill omits the subline in that case
+   * rather than showing a stale or "0%" label.
+   */
+  lastProgressPercent: number | null
   createdAt: number // Unix timestamp ms
   /**
    * P1-AC: true when cover extraction was attempted at import time and

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, real } from "drizzle-orm/sqlite-core";
 
 // ─── Books table ───────────────────────────────────────────────────────────────
 // Matches mobile SQLite schema columns (snake_case) plus sync-specific columns.
@@ -14,6 +14,14 @@ export const books = sqliteTable("books", {
   format: text("format").notNull().default("epub"),
   currentCfi: text("current_cfi"), // EPUB reading position
   currentPage: integer("current_page"), // PDF reading position
+  // #41 — Persisted 0..1 progress float used to render the library
+  // "Reading Now" pill subline AFTER the reader has been closed. EPUB
+  // sources this from epubjs's onRelocated progress arg; PDF/DJVU and
+  // MOBI/AZW3 derive it at save time from their own page/chapter
+  // counts. Stored as SQLite REAL (drizzle `real()`); mobile-only —
+  // never pushed to D1 (the server can reconstruct progress from
+  // page/cfi if needed and we don't want to widen the wire payload).
+  lastProgressPercent: real("last_progress_percent"), // 0..1 float or null
   fileHash: text("file_hash"), // SHA-256 for R2 dedup
   fileR2Key: text("file_r2_key"), // R2 object key for book file
   coverR2Key: text("cover_r2_key"), // R2 object key for cover image


### PR DESCRIPTION
## Summary

- Library tab's "Reading Now" hero pill now renders a format-aware progress subline beneath the author line: "Page X of Y" for PDF/DJVU, "X%" for EPUB/MOBI/AZW3. Legacy rows with no recorded progress omit the subline rather than show a misleading "0%".
- Persists a `lastProgressPercent` 0..1 float on the books table (mobile-only column, never pushed to D1). Each reader (EPUB / PDF / MOBI / DJVU) writes it alongside its existing CFI/page save. Migration is idempotent via the existing `columnsToAdd` pattern in `lib/db.ts`.
- Pure formatter `lib/reading-now-progress.ts` is fully unit-tested; the pill itself is render-tested + snapshot-tested under the existing `__tests__/library-screen.test.tsx` suite.

## Testability

**TDD path**:
- Red commit `c446d38d` — `test(library/index): red — Reading Now pill should show progress subline (#41)`. Lands a stub `formatReadingNowProgress` that returns null so the 13 unit assertions and 4 render/snapshot assertions all fail on real comparisons (not module-not-found).
- Green commit `1596dcb5` — `fix(library/index): green — render progress subline in Reading Now pill (#41)`. Implements the formatter + wires the data path; all 17 #41 assertions pass.

Test files:
- `apps/mobile/__tests__/lib/reading-now-progress.test.ts` (pure formatter, 13 specs)
- `apps/mobile/__tests__/library-screen.test.tsx` (`LibraryScreen (#41: ...)` describe block, 4 specs including snapshot)
- `apps/mobile/__tests__/__snapshots__/library-screen.test.tsx.snap` (pinned "Page 7 of 100")

## Local CI

```
typecheck: PASS  (cmd: cd apps/mobile && pnpm exec tsc --noEmit) — 131 pre-existing errors (all in packages/shared/voice-chat/tts and unrelated tests); identical count on origin/main, zero introduced by this diff
test:      PASS  (cmd: cd apps/mobile && pnpm exec jest __tests__/storage/book-storage.test.ts __tests__/library-screen.test.tsx __tests__/lib/reading-now-progress.test.ts __tests__/components/reader/) — 28 suites, 250 tests passed. Full `pnpm exec jest` runs against 166 suites and times out on this machine; spot-checked the suites that exercise modified files. Pre-existing FAILs (`tts/*`, `voice-chat/*`, `vector.test.ts`, `book-import/file-import.test.ts`) reproduce identically on origin/main — they're `Cannot find module 'effect' / 'epubjs' / 'expo-sqlite'` infrastructure issues, not regressions from this diff.
lint:      PASS  (cmd: cd apps/mobile && pnpm lint) — 20 warnings, 0 errors; identical to origin/main baseline
format:    SKIP  (no prettier/biome config detected in apps/mobile)
build:     SKIP  (Expo build is not <60s)
```

## Closes

Closes #41

## Test plan

- [ ] On a fresh install, import a PDF → open it → read past page 1 → back to library. Verify the Reading Now pill subline reads "Page N of M" where M matches `pdfjs.numPages`.
- [ ] Import an EPUB → read for a few seconds → back to library. Verify the subline reads "X%" matching the bottom-bar progress pill in the reader.
- [ ] Import a MOBI → swipe past chapter 1 → back. Verify subline reads "X%".
- [ ] Import a DJVU → flip past page 1 → back. Verify subline reads "Page N of M".
- [ ] Verify VoiceOver reads the subline (the Text has `accessibilityLabel="Progress: <subline>"`).
- [ ] Verify a freshly imported, never-opened book on the Reading Now pill (currentCfi null path doesn't trigger Reading Now, but verify legacy rows behave — open a pre-migration book and confirm the subline doesn't render until you've actually paged forward).
- [ ] Upgrade test: confirm an existing user's books are not broken by the migration — the `last_progress_percent` column is added idempotently and defaults to null.