### PR TITLE
fix(mobile/tts): debounce play spinner across cached inter-paragraph dips (#236)

### DIFF
--- a/apps/mobile/__tests__/components/player/MiniPlayer.test.tsx
+++ b/apps/mobile/__tests__/components/player/MiniPlayer.test.tsx
@@ -560,9 +560,21 @@ describe('MiniPlayer — play spinner debounce (#236)', () => {
   function playPauseLabel(
     tree: TestRenderer.ReactTestRenderer,
   ): string | undefined {
-    const node = findByTestID(tree, 'mini-player-play-pause')
-    return (node?.props as { accessibilityLabel?: string } | null)
-      ?.accessibilityLabel
+    // The play-pause testID is passed through PillIconButton (the React
+    // component) to its inner <Pressable> host element — so TestRenderer
+    // returns BOTH matches. The component-level match exposes
+    // `label` (the PillIconButton prop name), the host match exposes
+    // `accessibilityLabel`. We want the host-level a11y prop, which is
+    // what VoiceOver/TalkBack actually reads in production.
+    const matches = tree.root.findAll(
+      (n) => (n.props as { testID?: string } | null)?.testID === 'mini-player-play-pause',
+    )
+    for (const node of matches) {
+      const label = (node.props as { accessibilityLabel?: string } | null)
+        ?.accessibilityLabel
+      if (typeof label === 'string') return label
+    }
+    return undefined
   }
 
   function mountAndExpand(): TestRenderer.ReactTestRenderer {

--- a/apps/mobile/__tests__/components/player/MiniPlayer.test.tsx
+++ b/apps/mobile/__tests__/components/player/MiniPlayer.test.tsx
@@ -524,3 +524,183 @@ describe('MiniPlayer (mobile)', () => {
     expect(findByTestID(treeOn, 'mini-player-repeat')).not.toBeNull()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Play-spinner debounce (#236) — mobile mirror of electron PR #235 (#232).
+//
+// `playerMachine` dips through 'loading' (and the broader
+// 'waitingForParagraphs' / 'pageNavigating' / 'republishingParagraphs')
+// at every paragraph boundary even when the next paragraph's audio is
+// already cached. The raw signal flickers the ActivityIndicator on every
+// boundary. The fix is an asymmetric debounce: delay-show the spinner by
+// `SPINNER_DEBOUNCE_MS` (200ms) ONLY when the predecessor was an
+// active-playback state; cold-start (idle → loading) and pause→resume
+// (paused → loading) MUST show the spinner immediately so users get
+// feedback that their explicit action registered. Hide is always immediate.
+//
+// Asserts via `accessibilityLabel` + ActivityIndicator testID — no
+// snapshots, no internal-state probes.
+// ---------------------------------------------------------------------------
+
+describe('MiniPlayer — play spinner debounce (#236)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  function spinnerCount(tree: TestRenderer.ReactTestRenderer): number {
+    return tree.root.findAll(
+      (n) =>
+        (n.props as { testID?: string } | null)?.testID === 'activity-indicator',
+    ).length
+  }
+
+  function playPauseLabel(
+    tree: TestRenderer.ReactTestRenderer,
+  ): string | undefined {
+    const node = findByTestID(tree, 'mini-player-play-pause')
+    return (node?.props as { accessibilityLabel?: string } | null)
+      ?.accessibilityLabel
+  }
+
+  function mountAndExpand(): TestRenderer.ReactTestRenderer {
+    let tree!: TestRenderer.ReactTestRenderer
+    act(() => {
+      tree = TestRenderer.create(<MiniPlayer bookId="b1" />)
+    })
+    const orb = findByTestID(tree, 'mini-player-orb')
+    if (orb) {
+      act(() => {
+        ;(orb.props as { onPress: () => void }).onPress()
+      })
+    }
+    return tree
+  }
+
+  it('does not flicker the spinner on a cached playing → loading → playing transition', () => {
+    playerState.playingState = 'playing'
+    const tree = mountAndExpand()
+    expect(spinnerCount(tree)).toBe(0)
+
+    // Cached inter-paragraph dip: ~50ms in 'loading' before snapping back.
+    playerState.playingState = 'loading'
+    act(() => {
+      tree.update(<MiniPlayer bookId="b1" />)
+    })
+    expect(spinnerCount(tree)).toBe(0)
+    expect(playPauseLabel(tree)).not.toBe('Loading')
+
+    act(() => {
+      jest.advanceTimersByTime(50)
+    })
+    expect(spinnerCount(tree)).toBe(0)
+    expect(playPauseLabel(tree)).not.toBe('Loading')
+
+    playerState.playingState = 'playing'
+    act(() => {
+      tree.update(<MiniPlayer bookId="b1" />)
+    })
+    expect(spinnerCount(tree)).toBe(0)
+    // Pause icon (since we're playing) should remain the accessible label.
+    expect(playPauseLabel(tree)).toBe('Pause')
+  })
+
+  it('shows the spinner after the debounce window when load genuinely stalls', () => {
+    playerState.playingState = 'playing'
+    const tree = mountAndExpand()
+
+    playerState.playingState = 'loading'
+    act(() => {
+      tree.update(<MiniPlayer bookId="b1" />)
+    })
+    // Below the debounce window: still no spinner.
+    act(() => {
+      jest.advanceTimersByTime(150)
+    })
+    expect(spinnerCount(tree)).toBe(0)
+    expect(playPauseLabel(tree)).not.toBe('Loading')
+
+    // Cross the debounce threshold: spinner appears and label flips.
+    act(() => {
+      jest.advanceTimersByTime(100)
+    })
+    expect(spinnerCount(tree)).toBeGreaterThan(0)
+    expect(playPauseLabel(tree)).toBe('Loading')
+  })
+
+  it('shows the spinner immediately on cold-start (idle → loading, no debounce)', () => {
+    // The component renders null while idle, so mount directly in loading —
+    // mirrors the existing `playingState="loading"` test at L388. Per ship
+    // condition #4, seeding `lastNonLoadingState` to `'idle'` (not
+    // `playingState`) keeps cold-start cameFromActivePlayback === false.
+    playerState.playingState = 'loading'
+    const tree = mountAndExpand()
+    // No timer advance.
+    expect(spinnerCount(tree)).toBeGreaterThan(0)
+    expect(playPauseLabel(tree)).toBe('Loading')
+  })
+
+  it('shows the spinner immediately on pause → resume (paused.clean → loading, no debounce)', () => {
+    playerState.playingState = 'paused.clean'
+    const tree = mountAndExpand()
+
+    playerState.playingState = 'loading'
+    act(() => {
+      tree.update(<MiniPlayer bookId="b1" />)
+    })
+    // Predecessor `paused.clean` is not in ACTIVE_PLAYBACK_STATES — spinner
+    // is immediate.
+    expect(spinnerCount(tree)).toBeGreaterThan(0)
+    expect(playPauseLabel(tree)).toBe('Loading')
+  })
+
+  it('hides the spinner immediately when loading ends after the debounce fired', () => {
+    playerState.playingState = 'playing'
+    const tree = mountAndExpand()
+
+    playerState.playingState = 'loading'
+    act(() => {
+      tree.update(<MiniPlayer bookId="b1" />)
+    })
+    act(() => {
+      jest.advanceTimersByTime(300)
+    })
+    expect(spinnerCount(tree)).toBeGreaterThan(0)
+
+    // Hide is immediate — no delay-hide.
+    playerState.playingState = 'playing'
+    act(() => {
+      tree.update(<MiniPlayer bookId="b1" />)
+    })
+    expect(spinnerCount(tree)).toBe(0)
+    expect(playPauseLabel(tree)).toBe('Pause')
+  })
+
+  it('suppresses the spinner across a cached playing → waitingForParagraphs → playing dip', () => {
+    // `waitingForParagraphs` is one of the loading-like states the latch
+    // must treat as "loading" (otherwise the predecessor on a subsequent
+    // 'loading' would leak the wrong value). Mobile inherits the same
+    // shared playerMachine state list, including `waitingForParagraphs`
+    // and `pageNavigating`.
+    playerState.playingState = 'playing'
+    const tree = mountAndExpand()
+
+    playerState.playingState = 'waitingForParagraphs'
+    act(() => {
+      tree.update(<MiniPlayer bookId="b1" />)
+    })
+    act(() => {
+      jest.advanceTimersByTime(50)
+    })
+    expect(spinnerCount(tree)).toBe(0)
+
+    playerState.playingState = 'playing'
+    act(() => {
+      tree.update(<MiniPlayer bookId="b1" />)
+    })
+    expect(spinnerCount(tree)).toBe(0)
+    expect(playPauseLabel(tree)).toBe('Pause')
+  })
+})

--- a/apps/mobile/components/player/MiniPlayer.tsx
+++ b/apps/mobile/components/player/MiniPlayer.tsx
@@ -2,6 +2,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from 'react'
 import {
@@ -40,7 +41,7 @@ import * as Haptics from 'expo-haptics'
 // exactly this purpose; see its file header.
 import { ReaderShellContext } from '@/components/reader/ReaderShellContext'
 import { shadow, useTheme, zIndex } from '@/lib/theme'
-import { usePlayerStore } from '@/lib/stores/playerStore'
+import { usePlayerStore, type PlayerStoreState } from '@/lib/stores/playerStore'
 import { computeMiniPlayerTranslateX } from './miniPlayerMorph'
 import { useAutoCollapseTimer } from './useAutoCollapseTimer'
 
@@ -66,6 +67,33 @@ const AUTO_COLLAPSE_MS = 4000
 // `BOTTOM_BAR_HEIGHT = 44` undercounted the bar by ~34pt on notched iPhones,
 // so the MiniPlayer floated INTO the bar.
 const BOTTOM_BAR_MIN = 44
+
+// --- Play-spinner debounce (#236) — mirror of electron #232 ----------------
+//
+// `playerMachine` dips through `'loading'` (and the broader
+// `'waitingForParagraphs'` / `'pageNavigating'` / `'republishingParagraphs'`)
+// at every paragraph boundary — even when the next paragraph's audio is
+// already cached and plays immediately. The raw signal would flicker the
+// play-button <ActivityIndicator> on every boundary.
+//
+// Asymmetric debounce: when arriving in a loading-like state FROM an
+// active-playback state, delay showing the spinner by SPINNER_DEBOUNCE_MS.
+// Hide is always immediate. Cold-start (idle → loading) and pause→resume
+// (paused.* → loading) must show the spinner immediately so users get
+// feedback that their explicit action registered.
+const SPINNER_DEBOUNCE_MS = 200
+const ACTIVE_PLAYBACK_STATES: ReadonlySet<PlayerStoreState> = new Set([
+  'loading',
+  'playing',
+  'waitingForParagraphs',
+  'pageNavigating',
+  'republishingParagraphs',
+])
+const LOADING_LIKE_STATES: ReadonlySet<PlayerStoreState> = new Set([
+  'loading',
+  'waitingForParagraphs',
+  'pageNavigating',
+])
 
 function PillIconButton({
   iconName,
@@ -151,10 +179,107 @@ export function MiniPlayer({
   const isPlaying = playingState === 'playing'
   const isPaused =
     playingState === 'paused.clean' || playingState === 'paused.stale'
-  const isLoading =
-    playingState === 'loading' ||
-    playingState === 'waitingForParagraphs' ||
-    playingState === 'pageNavigating'
+
+  // --- Play-spinner debounce (#236) ----------------------------------------
+  //
+  // Latch the last steady (non-loading-like) state so we can ask, when we
+  // arrive in a loading-like state: "did we just come from active playback?"
+  // If yes, this is most likely an inter-paragraph cache hit and we should
+  // delay-show the spinner; if no (idle / paused.*), the user explicitly
+  // started playback and deserves immediate feedback.
+  //
+  // Seed initializer to `'idle'` (NOT `playingState`) so cold-start
+  // (mount directly in 'loading' — see MiniPlayer.test.tsx:388) lands with
+  // `lastNonLoadingState === 'idle'` → `cameFromActivePlayback === false`
+  // → spinner shown immediately. Without this seed the new debounce would
+  // gate the spinner under cold-start and break that test.
+  //
+  // Widen the latch predicate to `!LOADING_LIKE_STATES.has(...)` (not just
+  // `!== 'loading'`) so the latch isn't polluted by a transient
+  // `waitingForParagraphs` predecessor leaking through as "active playback".
+  const [lastNonLoadingState, setLastNonLoadingState] =
+    useState<PlayerStoreState>('idle')
+  if (
+    !LOADING_LIKE_STATES.has(playingState) &&
+    playingState !== lastNonLoadingState
+  ) {
+    // Render-set-state with guard: cheap, doesn't loop, runs once per
+    // distinct steady state. Avoids a useEffect cascade that would lag the
+    // derived `cameFromActivePlayback` by one render.
+    setLastNonLoadingState(playingState)
+  }
+  const cameFromActivePlayback =
+    ACTIVE_PLAYBACK_STATES.has(lastNonLoadingState)
+
+  // `debounceElapsed` flips true SPINNER_DEBOUNCE_MS after we entered a
+  // loading-like state from an active-playback predecessor. Reset eagerly
+  // via the same render-set-state-with-guard pattern when we leave the
+  // loading-like window.
+  const [debounceElapsed, setDebounceElapsed] = useState(false)
+  const spinnerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  if (!LOADING_LIKE_STATES.has(playingState) && debounceElapsed) {
+    setDebounceElapsed(false)
+  }
+
+  const showSpinner =
+    LOADING_LIKE_STATES.has(playingState) &&
+    (!cameFromActivePlayback || debounceElapsed)
+
+  useEffect(() => {
+    // Only arm the debounce on the cached-dip path. Cold-start /
+    // pause→resume show the spinner immediately via `showSpinner` derived
+    // above — no timer needed.
+    if (!LOADING_LIKE_STATES.has(playingState) || !cameFromActivePlayback) {
+      return
+    }
+    spinnerTimerRef.current = setTimeout(() => {
+      spinnerTimerRef.current = null
+      setDebounceElapsed(true)
+    }, SPINNER_DEBOUNCE_MS)
+    return () => {
+      if (spinnerTimerRef.current !== null) {
+        clearTimeout(spinnerTimerRef.current)
+        spinnerTimerRef.current = null
+      }
+    }
+  }, [playingState, cameFromActivePlayback])
+
+  // Unmount cleanup belt-and-braces (the effect cleanup above already covers
+  // re-renders, but unmount mid-debounce must not leak a timer).
+  useEffect(() => {
+    return () => {
+      if (spinnerTimerRef.current !== null) {
+        clearTimeout(spinnerTimerRef.current)
+        spinnerTimerRef.current = null
+      }
+    }
+  }, [])
+
+  // `effectiveState` drives BOTH the visible icon AND the accessibilityLabel
+  // so VoiceOver / TalkBack stay coupled to the rendered icon. While a
+  // loading dip is being suppressed, the play button continues to advertise
+  // the last steady state (Pause / Play) instead of flipping to "Loading".
+  // Prev/Next/Stop gates intentionally read raw `playingState` — they don't
+  // accept `disabled` today, so this is moot for now; the rule is preserved
+  // for the day we add real gating (ship condition #9).
+  const effectiveState: PlayerStoreState =
+    LOADING_LIKE_STATES.has(playingState) && !showSpinner
+      ? lastNonLoadingState
+      : playingState
+
+  // `playButtonLabel` derives from `effectiveState` (not raw `isPlaying`) so
+  // the screen-reader name matches what's drawn. Adds a "Loading" branch —
+  // a strict a11y improvement over the previous Play/Pause spam on every
+  // paragraph dip (ship condition #7).
+  const playButtonLabel =
+    effectiveState === 'loading' ||
+    effectiveState === 'waitingForParagraphs' ||
+    effectiveState === 'pageNavigating' ||
+    effectiveState === 'republishingParagraphs'
+      ? 'Loading'
+      : effectiveState === 'playing'
+        ? 'Pause'
+        : 'Play'
 
   const resolvedTabBarHeight =
     variant === 'global' ? (tabBarHeight ?? 49) : 0
@@ -477,10 +602,10 @@ export function MiniPlayer({
             onPress={() => dispatch({ type: 'PREV' })}
           />
           <PillIconButton
-            iconName={isPlaying ? 'pause' : 'play'}
-            label={isPlaying ? 'Pause' : 'Play'}
+            iconName={effectiveState === 'playing' ? 'pause' : 'play'}
+            label={playButtonLabel}
             color={iconColor}
-            loading={isLoading}
+            loading={showSpinner}
             testID="mini-player-play-pause"
             onPress={handlePlayPause}
           />


### PR DESCRIPTION
## Summary

- Mirrors electron PR #235 into mobile's `MiniPlayer.tsx`: asymmetric 200ms delay-show / immediate-hide debounce on the play-button `ActivityIndicator`.
- Suppresses the spinner during brief cached inter-paragraph transitions while preserving it for cold-start, pause→resume, and genuinely-slow loads.
- Adds a "Loading" branch to the play-button `accessibilityLabel` so screen reader name stays in sync with the visual.

## Testability

TDD. Red commit `15445bcb`, green commit `28136ec8`.

The new `describe('MiniPlayer — play spinner debounce (#236)')` block exercises six scenarios:

- cached playing → loading → playing dip (no spinner, no label flip)
- genuine stall (spinner appears after 200ms threshold)
- cold-start `idle → loading` (spinner immediate, `lastNonLoadingState` seed)
- pause → resume `paused.clean → loading` (spinner immediate)
- immediate hide after debounce fired (no delay-hide)
- cached `waitingForParagraphs` dip (latch widened to all loading-like states)

Existing real-timer test at L388 (`renders ActivityIndicator when playingState="loading"`) continues to pass thanks to the `'idle'` seed.

## Local CI

```
typecheck: PASS  (cmd: cd apps/mobile && pnpm exec tsc --noEmit)
                  — 150 pre-existing errors in packages/shared/src/voice-chat/*
                    (effect/xstate module resolution), 0 in changed files;
                    identical count on baseline (origin/main).
test:      PASS  (cmd: cd apps/mobile && pnpm exec jest — 1042 tests passed,
                  13 suite-level failures all pre-existing module-resolution
                  errors in packages/shared, identical on baseline)
lint:      PASS  (cmd: pnpm -F rishi-mobile lint — 0 errors, 20 warnings, all
                  pre-existing including the unused `View` import in MiniPlayer)
format:    SKIP  (no project-wide prettier script wired into mobile)
build:     SKIP  (heavy RN build; CI handles it)
```

The single targeted test file passes cleanly: `pnpm exec jest --runTestsByPath __tests__/components/player/MiniPlayer.test.tsx` → 20/20 tests passed.

Closes #236