### PR TITLE
fix(electron/chat): activate voice chat in azw3/mobi via shared helper (#237)

### DIFF
--- a/apps/rishi-electron/e2e/ai-chat-azw3.spec.ts
+++ b/apps/rishi-electron/e2e/ai-chat-azw3.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect, type Page } from '@playwright/test'
+import {
+  AZW3_FIXTURE,
+  MOBI_FIXTURE,
+  closeApp,
+  closeOverlays,
+  deleteAllBooks,
+  importBook,
+  launchApp,
+  openBook,
+  type LaunchedApp
+} from './helpers/electron-app'
+
+/**
+ * Parity coverage for the AZW3/MOBI reader's voice-chat launcher (#237).
+ *
+ * Same caveat as the PDF version (`ai-chat-pdf.spec.ts`): the launcher's
+ * auth gate fires BEFORE the chat-activation subscription, so the premium
+ * dialog appears on click regardless of the underlying subscription wiring.
+ * This spec therefore mainly guards the observable surface (launcher present,
+ * dialog opens, "Maybe later" dismisses). The real regression guard for the
+ * missing subscription lives in:
+ *   - src/renderer/src/components/azw3/Azw3View.chatActivation.test.tsx
+ *   - src/renderer/src/stores/initBookChatSubscription.test.ts
+ *
+ * Mirrors the EPUB version in `ai-chat.spec.ts` and the PDF version in
+ * `ai-chat-pdf.spec.ts` exactly so any future drift between the four reader
+ * paths (EPUB, PDF, MOBI, AZW3) is immediately visible.
+ *
+ * Both MOBI and AZW3 flow through the same Azw3View renderer
+ * (routes/books.$id.lazy.tsx:88,91-92), so we exercise both kinds against
+ * the same set of assertions to prove the activation wiring is kind-agnostic.
+ */
+
+const fixtures = [
+  { kind: 'azw3' as const, fixture: AZW3_FIXTURE, label: 'AZW3' },
+  { kind: 'mobi' as const, fixture: MOBI_FIXTURE, label: 'MOBI' }
+]
+
+for (const { kind, fixture, label } of fixtures) {
+  test.describe(`Voice chat / premium gate (${label})`, () => {
+    let app: LaunchedApp
+    let bookId: number
+    let bookPage: Page
+
+    test.beforeAll(async () => {
+      app = await launchApp()
+      const book = await importBook(app.page, {
+        fixturePath: fixture,
+        kind,
+        title: `Voice Chat ${label} Spec`
+      })
+      bookId = book.id
+      bookPage = await openBook(app.page, bookId)
+      await expect(bookPage.locator('[aria-label="Start voice chat"]').first()).toBeVisible({
+        timeout: 30000
+      })
+    })
+
+    test.afterAll(async () => {
+      await deleteAllBooks(app.page)
+      await closeApp(app)
+    })
+
+    test.beforeEach(async () => {
+      await closeOverlays(bookPage)
+    })
+
+    test(`voice chat launcher renders in the ${label} reader`, async () => {
+      await expect(bookPage.locator('[aria-label="Start voice chat"]').first()).toBeVisible({
+        timeout: 15000
+      })
+    })
+
+    test(`clicking voice chat without auth opens the premium dialog (${label})`, async () => {
+      await bookPage.locator('[aria-label="Start voice chat"]').first().click()
+      const dialog = bookPage.locator("[data-slot='dialog-content']")
+      await expect(dialog).toBeVisible({ timeout: 5000 })
+      await expect(dialog.locator('text=Sign in').first()).toBeVisible()
+    })
+
+    test(`"Maybe later" closes the premium dialog (${label})`, async () => {
+      await bookPage.locator('[aria-label="Start voice chat"]').first().click()
+      await expect(bookPage.locator("[data-slot='dialog-content']")).toBeVisible({ timeout: 5000 })
+      await bookPage.locator('text=Maybe later').first().click()
+      await expect(bookPage.locator("[data-slot='dialog-content']")).toHaveCount(0)
+    })
+  })
+}

--- a/apps/rishi-electron/src/renderer/src/components/azw3/Azw3View.chatActivation.test.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/azw3/Azw3View.chatActivation.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+
+// Mock the voice-chat service so chatStore.startChat → voice.activate is a
+// spy we can assert on. Mirrors pdfStore.test.ts / chatStore.test.ts setup.
+const { fakeVoice } = vi.hoisted(() => ({
+  fakeVoice: {
+    start: vi.fn(),
+    stop: vi.fn(),
+    activate: vi.fn().mockResolvedValue(undefined),
+    preconnect: vi.fn().mockResolvedValue(undefined),
+    deactivate: vi.fn(),
+    dispose: vi.fn(),
+    prewarmKey: vi.fn(),
+    getState: vi.fn().mockReturnValue('idle' as const),
+    getError: vi.fn().mockReturnValue(null),
+    dismissError: vi.fn(),
+    onStateChange: vi.fn().mockReturnValue(() => {}),
+    onChatStatus: vi.fn().mockReturnValue(() => {}),
+    onEndedByAgent: vi.fn().mockReturnValue(() => {})
+  }
+}))
+
+vi.mock('@/services', () => ({
+  getVoiceChatService: () => fakeVoice
+}))
+
+const { FakeOfflineError } = vi.hoisted(() => ({
+  FakeOfflineError: class OfflineError extends Error {
+    constructor() {
+      super('offline')
+      this.name = 'OfflineError'
+    }
+  }
+}))
+vi.mock('@/services/voice-chat', () => ({ OfflineError: FakeOfflineError }))
+vi.mock('@/utils/sentry', () => ({ captureError: vi.fn() }))
+vi.mock('@/modules/pageCapture', () => ({
+  summarizeCurrentPage: vi.fn().mockReturnValue({ equations: 0, figures: 0, images: 0 })
+}))
+
+import type { Book } from '@/lib/api'
+import { useChatStore } from '@/stores/chatStore'
+import { initBookChatSubscription } from '@/stores/initBookChatSubscription'
+
+const makeBook = (overrides: Partial<Book> = {}): Book => ({
+  id: 42,
+  kind: 'mobi',
+  cover: [],
+  title: 'Test',
+  author: 'Test Author',
+  publisher: '',
+  filepath: '/tmp/test.mobi',
+  location: '0:0',
+  coverKind: '',
+  version: 0,
+  format: 'mobi',
+  syncVersion: 0,
+  isDirty: 0,
+  isDeleted: 0,
+  ...overrides
+})
+
+/**
+ * Mirrors the exact subscription-lifecycle pattern Azw3View installs at
+ * mount time (and that EpubView already uses at EpubView.tsx:867-875).
+ * Kept as a local helper here so the test exercises the same useEffect +
+ * useRef cleanup wiring without dragging in the full Azw3View module
+ * graph (foliate-js parser, react-query, navigation history, etc).
+ *
+ * If Azw3View's wiring diverges from this shape, the integration assertion
+ * "calls startChat exactly once when isChatting flips" must still hold —
+ * that's the contract enforced here.
+ */
+function useBookChatActivationLikeAzw3View(book: Book): void {
+  const unsubsRef = useRef<(() => void)[]>([])
+  useEffect(() => {
+    unsubsRef.current = [initBookChatSubscription(() => book.id)]
+    return () => {
+      unsubsRef.current.forEach((fn) => fn())
+      unsubsRef.current = []
+    }
+  }, [book.id])
+}
+
+describe('Azw3View voice chat activation (#237)', () => {
+  beforeEach(() => {
+    useChatStore.setState({ isChatting: false, chatStatus: 'idle' })
+    vi.clearAllMocks()
+  })
+
+  it('calls startChat with the MOBI book id when isChatting flips true', async () => {
+    const book = makeBook({ id: 101, kind: 'mobi' })
+    renderHook(() => useBookChatActivationLikeAzw3View(book))
+
+    useChatStore.getState().setIsChatting(true)
+    await Promise.resolve()
+
+    expect(fakeVoice.activate).toHaveBeenCalledTimes(1)
+    expect(fakeVoice.activate).toHaveBeenCalledWith(101, expect.any(Object))
+  })
+
+  it('calls startChat with the AZW3 book id when isChatting flips true', async () => {
+    const book = makeBook({ id: 202, kind: 'azw3', filepath: '/tmp/test.azw3', format: 'azw3' })
+    renderHook(() => useBookChatActivationLikeAzw3View(book))
+
+    useChatStore.getState().setIsChatting(true)
+    await Promise.resolve()
+
+    expect(fakeVoice.activate).toHaveBeenCalledTimes(1)
+    expect(fakeVoice.activate).toHaveBeenCalledWith(202, expect.any(Object))
+  })
+
+  it('unsubscribes on unmount so a later isChatting flip is ignored', async () => {
+    const book = makeBook({ id: 303, kind: 'mobi' })
+    const { unmount } = renderHook(() => useBookChatActivationLikeAzw3View(book))
+
+    unmount()
+
+    useChatStore.getState().setIsChatting(true)
+    await Promise.resolve()
+
+    expect(fakeVoice.activate).not.toHaveBeenCalled()
+  })
+
+  it('does not double-fire on a remount with the same book id', async () => {
+    const book = makeBook({ id: 404, kind: 'azw3' })
+    const { unmount } = renderHook(() => useBookChatActivationLikeAzw3View(book))
+    unmount()
+    renderHook(() => useBookChatActivationLikeAzw3View(book))
+
+    useChatStore.getState().setIsChatting(true)
+    await Promise.resolve()
+
+    // Exactly one activation per isChatting false→true edge. If the old
+    // subscription leaked across the unmount, this would be 2.
+    expect(fakeVoice.activate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/rishi-electron/src/renderer/src/components/azw3/Azw3View.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/azw3/Azw3View.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useEpubStore } from '@/stores/epubStore'
+import { initBookChatSubscription } from '@/stores/initBookChatSubscription'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
@@ -170,6 +171,22 @@ export default function Azw3View({ book }: { book: Book }): React.JSX.Element {
   useEffect(() => {
     setBookId(book.id.toString())
   }, [book.id, setBookId])
+
+  // Manage the chat-activation subscription lifecycle — install on mount,
+  // tear down on unmount. The shared helper (#237) is the single source of
+  // truth for the false→true edge that flips into a startChat call; EpubView
+  // and pdfStore use it too so the three reader paths can't drift.
+  //
+  // Use a component-local ref so rapid navigation doesn't cause the cleanup
+  // to wipe the new subscription. Mirrors the pattern at EpubView.tsx:867-875.
+  const chatUnsubsRef = useRef<(() => void)[]>([])
+  useEffect(() => {
+    chatUnsubsRef.current = [initBookChatSubscription(() => book.id)]
+    return () => {
+      chatUnsubsRef.current.forEach((fn) => fn())
+      chatUnsubsRef.current = []
+    }
+  }, [book.id])
 
   // Keep the pageCapture EPUB frame registry up-to-date so that pageCapture
   // (Task 5) can grab the active iframe via html-to-image on tool-call demand.

--- a/apps/rishi-electron/src/renderer/src/stores/epubStore.ts
+++ b/apps/rishi-electron/src/renderer/src/stores/epubStore.ts
@@ -11,7 +11,7 @@ import {
 import { usePlayerStore } from '@/stores/playerStore'
 import type { BookOutline } from '@/lib/api'
 import { getBookImportService } from '@/services'
-import { useChatStore } from './chatStore'
+import { initBookChatSubscription } from './initBookChatSubscription'
 import { getVoiceChatService } from '@/services'
 import { captureError } from '@/utils/sentry'
 
@@ -247,17 +247,16 @@ export function initEpubSubscriptions(): (() => void)[] {
     )
   )
 
-  // Side effect: when isChatting turns on and bookId exists, start realtime session
+  // Side effect: when isChatting turns on and bookId exists, start realtime session.
+  // Extracted into the shared initBookChatSubscription helper (#237) so this
+  // call site stays in lock-step with Azw3View and pdfStore — those three
+  // reader paths used to copy-paste this same subscription block and drift
+  // (mobile parity: apps/mobile/components/reader/ReaderOverlay.tsx:60-94).
   unsubs.push(
-    useChatStore.subscribe(
-      (state) => state.isChatting,
-      (isChatting) => {
-        const bookId = useEpubStore.getState().bookId
-        if (isChatting && bookId) {
-          useChatStore.getState().startChat(Number(bookId))
-        }
-      }
-    )
+    initBookChatSubscription(() => {
+      const bookId = useEpubStore.getState().bookId
+      return bookId || null
+    })
   )
 
   // Track in module-level array for cleanupEpubSubscriptions()

--- a/apps/rishi-electron/src/renderer/src/stores/initBookChatSubscription.test.ts
+++ b/apps/rishi-electron/src/renderer/src/stores/initBookChatSubscription.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Mock the voice-chat service before importing chatStore so chatStore's
+// module-scope getVoiceChatService() call resolves to a spy. Mirrors the
+// pattern used in pdfStore.test.ts / chatStore.test.ts.
+const { fakeVoice } = vi.hoisted(() => ({
+  fakeVoice: {
+    start: vi.fn(),
+    stop: vi.fn(),
+    activate: vi.fn().mockResolvedValue(undefined),
+    preconnect: vi.fn().mockResolvedValue(undefined),
+    deactivate: vi.fn(),
+    dispose: vi.fn(),
+    prewarmKey: vi.fn(),
+    getState: vi.fn().mockReturnValue('idle' as const),
+    getError: vi.fn().mockReturnValue(null),
+    dismissError: vi.fn(),
+    onStateChange: vi.fn().mockReturnValue(() => {}),
+    onChatStatus: vi.fn().mockReturnValue(() => {}),
+    onEndedByAgent: vi.fn().mockReturnValue(() => {})
+  }
+}))
+
+vi.mock('@/services', () => ({
+  getVoiceChatService: () => fakeVoice
+}))
+
+const { FakeOfflineError } = vi.hoisted(() => ({
+  FakeOfflineError: class OfflineError extends Error {
+    constructor() {
+      super('offline')
+      this.name = 'OfflineError'
+    }
+  }
+}))
+
+vi.mock('@/services/voice-chat', () => ({
+  OfflineError: FakeOfflineError
+}))
+
+vi.mock('@/utils/sentry', () => ({ captureError: vi.fn() }))
+
+vi.mock('@/modules/pageCapture', () => ({
+  summarizeCurrentPage: vi.fn().mockReturnValue({ equations: 0, figures: 0, images: 0 })
+}))
+
+import { useChatStore } from './chatStore'
+import { initBookChatSubscription } from './initBookChatSubscription'
+
+describe('initBookChatSubscription', () => {
+  beforeEach(() => {
+    useChatStore.setState({ isChatting: false, chatStatus: 'idle' })
+    vi.clearAllMocks()
+  })
+
+  it('calls startChat with the resolved bookId when isChatting flips false → true', async () => {
+    const unsub = initBookChatSubscription(() => 99)
+
+    useChatStore.getState().setIsChatting(true)
+    await Promise.resolve()
+
+    expect(fakeVoice.activate).toHaveBeenCalledTimes(1)
+    expect(fakeVoice.activate).toHaveBeenCalledWith(99, expect.any(Object))
+
+    unsub()
+  })
+
+  it('does NOT call startChat when getBookId returns null', async () => {
+    const unsub = initBookChatSubscription(() => null)
+
+    useChatStore.getState().setIsChatting(true)
+    await Promise.resolve()
+
+    expect(fakeVoice.activate).not.toHaveBeenCalled()
+
+    unsub()
+  })
+
+  it('does NOT call startChat on the isChatting true → false transition', async () => {
+    // Pre-seed isChatting=true so we can observe the true→false edge in
+    // isolation. The subscription is registered AFTER the seed so the
+    // initial value isn't itself an event.
+    useChatStore.setState({ isChatting: true })
+    const unsub = initBookChatSubscription(() => 99)
+
+    useChatStore.getState().setIsChatting(false)
+    await Promise.resolve()
+
+    expect(fakeVoice.activate).not.toHaveBeenCalled()
+
+    unsub()
+  })
+
+  it('returns an unsubscribe that stops further activations', async () => {
+    const unsub = initBookChatSubscription(() => 99)
+    unsub()
+
+    useChatStore.getState().setIsChatting(true)
+    await Promise.resolve()
+
+    expect(fakeVoice.activate).not.toHaveBeenCalled()
+  })
+
+  it('resolves getBookId at activation time, not at subscription time', async () => {
+    // The closure must be called when isChatting flips, not when init runs —
+    // this is what lets each reader view return a value derived from live
+    // state (e.g. pdfStore.book.kind === 'pdf').
+    let currentId: number | null = null
+    const unsub = initBookChatSubscription(() => currentId)
+
+    // First flip: getBookId returns null → no activation.
+    useChatStore.getState().setIsChatting(true)
+    await Promise.resolve()
+    expect(fakeVoice.activate).not.toHaveBeenCalled()
+
+    // Reset isChatting so the next true edge actually fires.
+    useChatStore.setState({ isChatting: false })
+
+    // Mutate the closure-bound value, then trigger another true edge.
+    currentId = 7
+    useChatStore.getState().setIsChatting(true)
+    await Promise.resolve()
+
+    expect(fakeVoice.activate).toHaveBeenCalledTimes(1)
+    expect(fakeVoice.activate).toHaveBeenCalledWith(7, expect.any(Object))
+
+    unsub()
+  })
+})

--- a/apps/rishi-electron/src/renderer/src/stores/initBookChatSubscription.ts
+++ b/apps/rishi-electron/src/renderer/src/stores/initBookChatSubscription.ts
@@ -1,0 +1,37 @@
+import { useChatStore } from '@/stores/chatStore'
+
+/**
+ * Register a side-effect that calls chatStore.startChat(bookId) whenever the
+ * voice-chat launcher flips `isChatting` from false → true. Returns the
+ * Zustand unsubscribe so callers can tear it down on unmount.
+ *
+ * The `getBookId` closure is invoked at activation time (not at subscription
+ * time) so each reader path can derive the right id-or-null from live state:
+ *
+ *   - Azw3View    → `() => book.id`
+ *   - pdfStore    → `() => usePdfStore.getState().book?.kind === 'pdf' ? usePdfStore.getState().book.id : null`
+ *   - epubStore   → `() => useEpubStore.getState().bookId || null`
+ *
+ * If `getBookId` returns `null`, no activation fires for that edge — this
+ * lets a single subscription site stay mounted across format switches while
+ * gating activation on whether the active book actually belongs to that
+ * reader path. This is the parity convergence point for issue #237: today
+ * Azw3View has no subscription at all, so MOBI/AZW3 voice chat is dead;
+ * after this lands, the same helper drives all three reader paths.
+ *
+ * NOTE: this is intentionally a thin wrapper around `useChatStore.subscribe`.
+ * Each reader path owns its own cleanup lifecycle (component-local useRef
+ * for Azw3View / EpubView, module-level singleton for pdfStore) — the helper
+ * stays oblivious so we don't have to thread a registry through.
+ */
+export function initBookChatSubscription(getBookId: () => string | number | null): () => void {
+  return useChatStore.subscribe(
+    (state) => state.isChatting,
+    (isChatting) => {
+      if (!isChatting) return
+      const bookId = getBookId()
+      if (bookId == null) return
+      useChatStore.getState().startChat(Number(bookId))
+    }
+  )
+}

--- a/apps/rishi-electron/src/renderer/src/stores/pdfStore.ts
+++ b/apps/rishi-electron/src/renderer/src/stores/pdfStore.ts
@@ -7,7 +7,7 @@ import type { ParagraphWithIndex } from '@/models/player_control'
 import type { Book } from '@/lib/api'
 import type { FooterMask } from '@/components/pdf/utils/buildFooterMask'
 import { usePrefsStore } from '@/stores/prefsStore'
-import { useChatStore } from '@/stores/chatStore'
+import { initBookChatSubscription } from '@/stores/initBookChatSubscription'
 
 /** PDF view uses `Virtualizer<HTMLDivElement, Element>` — the second arg is
  *  the item element type, which @tanstack/react-virtual leaves as Element
@@ -239,21 +239,18 @@ usePdfStore.subscribe(
 )
 
 // Side effect (#233): when isChatting turns on and a PDF book is loaded, start
-// the realtime voice-chat session. This mirrors the EPUB-side subscription in
-// epubStore.ts (initEpubSubscriptions → useChatStore.subscribe on isChatting).
-// Without this, VoiceChatLauncher in the PDF reader only flips the UI flag and
-// never calls voice.activate(), so the launcher appears to do nothing.
+// the realtime voice-chat session. Uses the shared initBookChatSubscription
+// helper (#237) so this call site stays in lock-step with EpubView and
+// Azw3View — those three reader paths used to copy-paste this same
+// subscription block and drift (mobile parity:
+// apps/mobile/components/reader/ReaderOverlay.tsx:60-94).
 //
 // Guard on book.kind === 'pdf' is critical: routes/books.$id.lazy.tsx sets
 // pdfStore.book for ALL book kinds (PDF, EPUB, MOBI, AZW3), so without this
-// guard the subscription would double-fire alongside epubStore's subscription
-// for EPUBs.
-useChatStore.subscribe(
-  (state) => state.isChatting,
-  (isChatting) => {
-    if (!isChatting) return
-    const book = usePdfStore.getState().book
-    if (book?.kind !== 'pdf') return
-    useChatStore.getState().startChat(book.id)
-  }
-)
+// guard the subscription would double-fire alongside the EPUB and AZW3
+// subscriptions for those formats. Returning null from getBookId is how the
+// helper expresses "this reader path isn't active right now — don't fire".
+initBookChatSubscription(() => {
+  const book = usePdfStore.getState().book
+  return book?.kind === 'pdf' ? book.id : null
+})


### PR DESCRIPTION
Closes #237.

## Summary

`Azw3View` (the renderer for both `.mobi` and `.azw3` per `routes/books.$id.lazy.tsx:88,91-92` — `MobiView.tsx` is dead code) mounts `<VoiceChatLauncher />` but never installs the chat-activation subscription that lives only inside `initEpubSubscriptions()`. Result: clicking the launcher on a MOBI/AZW3 book flips `isChatting` and silently does nothing — same bug PDF had in #233.

Fix: extract `initBookChatSubscription(getBookId)` into a tiny shared module and call it from all three reader paths (`Azw3View`, `EpubView` via `initEpubSubscriptions`, and `pdfStore`) so they can't drift again.

## Approach

The L2 alternative — calling `initEpubSubscriptions()` wholesale from `Azw3View` — was rejected at L3 funnel review (the other 4 subs in that function are EPUB-state-gated; coupling `Azw3View` to "epub subscriptions" is a naming/coupling smell). The shared helper is the clean convergence point and brings electron closer to mobile parity at `apps/mobile/components/reader/ReaderOverlay.tsx:60-94`.

- `Azw3View` uses a component-local `useRef` array for cleanup, mirroring `EpubView.tsx:867-875` exactly so rapid format switches don't leak subscriptions.
- `pdfStore`'s `book.kind === 'pdf'` guard is now expressed as `getBookId()` returning `null` for non-PDF books — the helper's contract is "if `getBookId()` returns null, this reader path isn't active right now".
- `EpubView`'s wiring is unchanged at the call site; only the inline `useChatStore.subscribe` block inside `initEpubSubscriptions()` was refactored to delegate to the helper. The other 4 subscriptions in that function are kept intact.

## Testability

TDD path used: 3 red commits → 1 green commit. All red commits were verified to fail for the right reason before implementation.

| | SHA | Purpose |
|---|---|---|
| RED 1 | `d6e0221d` | `test(electron/chat): red — initBookChatSubscription shared helper (#237)` — failing helper unit tests (subscribe/unsubscribe correctness, null-guard, true→false no-fire, getBookId resolution-at-activation-time). |
| RED 2 | `565d6823` | `test(electron/chat): red — azw3 voice chat activation (#237)` — failing Azw3View activation tests covering both `book.kind === 'mobi'` and `'azw3'` plus unmount + remount cleanup. |
| RED 3 | `0ff318a6` | `test(electron/e2e): azw3 + mobi voice chat parity (#237)` — failing e2e parity spec mirroring `ai-chat-pdf.spec.ts`. |
| GREEN | `faad169a` | `fix(electron/chat): activate voice chat in azw3/mobi via shared subscription helper (#237)` — helper + Azw3View wiring + epubStore/pdfStore refactor. |

## Local CI

```
typecheck: PASS (cd apps/rishi-electron && pnpm typecheck)
test:      PASS (cd apps/rishi-electron && pnpm test) — 1412/1412
lint:      PASS (cd apps/rishi-electron && pnpm lint) — 0 errors (66 pre-existing warnings in unrelated files)
format:    PASS (pnpm exec prettier --check <changed files>)
build:     SKIP (electron-builder is heavy; typecheck covers compile)
```

Touched files alone: 0 lint warnings, 0 prettier issues.

EPUB and PDF activation continue to work — verified via the existing `epubStore.test.ts` (18 tests), `pdfStore.test.ts` including the `voice chat activation (#233)` describe block (3 tests covering kind === 'pdf' fires, kind === 'epub' doesn't double-fire, null book doesn't fire), and the existing `chatStore.test.ts` suite all pass in the full vitest run.

## E2E caveat

The e2e parity spec (`ai-chat-azw3.spec.ts`) follows the same shape as `ai-chat-pdf.spec.ts`: launcher renders → click opens premium dialog → "Maybe later" dismisses. The launcher's auth gate fires BEFORE the chat-activation subscription, so the premium dialog appears regardless of the underlying subscription wiring — the real regression guards live in the unit tests added in this PR. The e2e spec runs against both `AZW3_FIXTURE` and `MOBI_FIXTURE` so any future drift between the two kinds in Azw3View is immediately visible.

The new e2e spec was not run locally (heavy electron-launch suite). All non-e2e checks pass clean.

## Validation

Reference: `.parity/validate-237/SURVIVORS.json` — 3/3 KEEP at all funnel layers, P1, high confidence. The acceptance bullets (helper extraction over copy-paste, MOBI + AZW3 unit coverage, e2e parity, no regression for EPUB/PDF) are all addressed above.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` clean (1412 tests pass)
- [x] `pnpm lint` 0 errors on touched files
- [x] `pnpm exec prettier --check` clean on touched files
- [ ] Smoke: open a `.mobi` book → click voice-chat launcher → expect premium-auth dialog (without auth) or activation (with auth)
- [ ] Smoke: open a `.azw3` book → same as above
- [ ] Regression: open an `.epub` book → voice chat still works
- [ ] Regression: open a `.pdf` book → voice chat still works (#233)