### PR TITLE
fix(mobile/chat/voice): wire useRealtimeChat error fields + reader snackbar (#63)

### DIFF
--- a/apps/mobile/__tests__/hooks/useRealtimeChat-error-forwarding.test.ts
+++ b/apps/mobile/__tests__/hooks/useRealtimeChat-error-forwarding.test.ts
@@ -1,0 +1,221 @@
+/**
+ * CHT-016 (#63) — the `useRealtimeChat` shim must forward the
+ * new error-surface fields from `useVoiceChat` so reader screens can
+ * mount a snackbar/banner when voice-chat activation fails.
+ *
+ * Prior to this fix the shim destructured only `{ status, toggle, isActive }`
+ * — `voiceError`, `isMicPermissionError`, `retryStart`, and `dismissError`
+ * were silently swallowed and reader-screen failures (mic denied, network
+ * drop, etc.) regressed from a modal Alert to a silent no-op.
+ *
+ * The shim now forwards all four fields verbatim from `useVoiceChat`.
+ */
+
+jest.mock('react-native', () => ({
+  Alert: { alert: jest.fn() },
+  Platform: { OS: 'ios' },
+}))
+
+jest.mock('@rishi/shared/lib/stringToNumberID', () => ({
+  stringToNumberID: (s: string) => {
+    let h = 0
+    for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0
+    return Math.abs(h)
+  },
+}))
+
+type StateCb = (s: 'idle' | 'connecting' | 'active' | 'paused' | 'error') => void
+type ChatCb = (s: 'idle' | 'connecting' | 'thinking' | 'speaking') => void
+const stateListeners: StateCb[] = []
+const chatListeners: ChatCb[] = []
+const mockActivate = jest.fn()
+const mockStart = jest.fn()
+let currentState: 'idle' | 'connecting' | 'active' | 'paused' | 'error' = 'idle'
+
+const fakeService = {
+  start: mockStart,
+  stop: jest.fn(),
+  activate: mockActivate,
+  deactivate: jest.fn(),
+  getState: () => currentState,
+  getError: () => null,
+  dismissError: jest.fn(),
+  dispose: jest.fn(),
+  onStateChange: (cb: StateCb) => {
+    stateListeners.push(cb)
+    return () => {
+      const i = stateListeners.indexOf(cb)
+      if (i >= 0) stateListeners.splice(i, 1)
+    }
+  },
+  onChatStatus: (cb: ChatCb) => {
+    chatListeners.push(cb)
+    return () => {
+      const i = chatListeners.indexOf(cb)
+      if (i >= 0) chatListeners.splice(i, 1)
+    }
+  },
+  onEndedByAgent: () => () => undefined,
+}
+
+jest.mock('@/lib/voice-chat/service', () => ({
+  __esModule: true,
+  getVoiceChatService: () => fakeService,
+  _resetVoiceChatServiceForTests: jest.fn(),
+}))
+
+jest.mock('@/lib/voice-chat/sounds', () => ({
+  __esModule: true,
+  createMobileEffectsPort: jest.fn(() => ({
+    playReadyChime: jest.fn(),
+    startThinkingSound: jest.fn(),
+    stopThinkingSound: jest.fn(),
+  })),
+  getMobileEffectsPort: jest.fn(() => ({
+    playReadyChime: jest.fn(),
+    startThinkingSound: jest.fn(),
+    stopThinkingSound: jest.fn(),
+  })),
+}))
+
+import React, { act } from 'react'
+import TestRenderer from 'react-test-renderer'
+import { useRealtimeChat, type UseRealtimeChatResult } from '@/hooks/useRealtimeChat'
+
+interface HarnessProps {
+  bookId: string
+  onReady?: (api: UseRealtimeChatResult) => void
+}
+
+function Harness(props: HarnessProps) {
+  const api = useRealtimeChat(props.bookId)
+  React.useEffect(() => {
+    props.onReady?.(api)
+  })
+  return null
+}
+
+beforeEach(() => {
+  stateListeners.length = 0
+  chatListeners.length = 0
+  currentState = 'idle'
+  mockActivate.mockReset()
+  mockStart.mockReset()
+})
+
+describe('CHT-016 (#63) — useRealtimeChat shim forwards voice-error fields', () => {
+  it('returns null voiceError and false isMicPermissionError before any failure', () => {
+    let api!: UseRealtimeChatResult
+    act(() => {
+      TestRenderer.create(
+        React.createElement(Harness, {
+          bookId: 'book-x',
+          onReady: (a) => (api = a),
+        }),
+      )
+    })
+
+    expect(api.voiceError).toBeNull()
+    expect(api.isMicPermissionError).toBe(false)
+    expect(typeof api.retryStart).toBe('function')
+    expect(typeof api.dismissError).toBe('function')
+  })
+
+  it('forwards a transient voiceError from useVoiceChat after activate() rejects', async () => {
+    mockActivate.mockRejectedValueOnce(new Error('connection failed'))
+
+    let api!: UseRealtimeChatResult
+    act(() => {
+      TestRenderer.create(
+        React.createElement(Harness, {
+          bookId: 'book-x',
+          onReady: (a) => (api = a),
+        }),
+      )
+    })
+
+    await act(async () => {
+      // toggle from idle triggers start → activate, mirroring the
+      // reader's `onRealtimePress` path.
+      await api.toggle()
+    })
+
+    expect(api.voiceError).toBe('connection failed')
+    expect(api.isMicPermissionError).toBe(false)
+  })
+
+  it('forwards isMicPermissionError=true when the rejection is a mic-permission denial', async () => {
+    mockActivate.mockRejectedValueOnce(new Error('Microphone permission denied'))
+
+    let api!: UseRealtimeChatResult
+    act(() => {
+      TestRenderer.create(
+        React.createElement(Harness, {
+          bookId: 'book-x',
+          onReady: (a) => (api = a),
+        }),
+      )
+    })
+
+    await act(async () => {
+      await api.toggle()
+    })
+
+    expect(api.isMicPermissionError).toBe(true)
+    expect(api.voiceError).toMatch(/mic|permission/i)
+  })
+
+  it('retryStart() forwarded by the shim re-invokes svc.activate', async () => {
+    mockActivate
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValueOnce(undefined)
+
+    let api!: UseRealtimeChatResult
+    act(() => {
+      TestRenderer.create(
+        React.createElement(Harness, {
+          bookId: 'book-x',
+          onReady: (a) => (api = a),
+        }),
+      )
+    })
+
+    await act(async () => {
+      await api.toggle()
+    })
+    expect(api.voiceError).toBe('transient')
+    expect(mockActivate).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await api.retryStart()
+    })
+    expect(mockActivate).toHaveBeenCalledTimes(2)
+    expect(api.voiceError).toBeNull()
+  })
+
+  it('dismissError() forwarded by the shim clears the error without re-activating', async () => {
+    mockActivate.mockRejectedValueOnce(new Error('boom'))
+
+    let api!: UseRealtimeChatResult
+    act(() => {
+      TestRenderer.create(
+        React.createElement(Harness, {
+          bookId: 'book-x',
+          onReady: (a) => (api = a),
+        }),
+      )
+    })
+
+    await act(async () => {
+      await api.toggle()
+    })
+    expect(api.voiceError).toBe('boom')
+
+    act(() => {
+      api.dismissError()
+    })
+
+    expect(api.voiceError).toBeNull()
+    expect(mockActivate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/mobile/__tests__/reader/voice-chat-error-feedback.test.ts
+++ b/apps/mobile/__tests__/reader/voice-chat-error-feedback.test.ts
@@ -1,0 +1,98 @@
+/**
+ * CHT-016 (#63) — Voice-chat activation failures must surface a
+ * non-blocking snackbar in the reader, not silently no-op.
+ *
+ * Prior to this fix, `useVoiceChat` (the new hook behind the
+ * `useRealtimeChat` compatibility shim) exposed `voiceError`,
+ * `isMicPermissionError`, `retryStart`, and `dismissError` for consumers
+ * to render their own UI, but the EPUB reader screen never read those
+ * fields. Mic-denied / network-drop / other activation errors regressed
+ * from a modal Alert to a silent no-op — issue #63's user-facing AC
+ * was no longer met.
+ *
+ * Acceptance for this fix (EPUB reader first; PDF/MOBI/DJVU follow in a
+ * later card so the diff stays scoped):
+ *   1. The reader destructures `voiceError`, `isMicPermissionError`,
+ *      `retryStart`, and `dismissError` from `useRealtimeChat`.
+ *   2. The reader mounts a snackbar (or banner) that renders when
+ *      `voiceError` is truthy.
+ *   3. The snackbar wires Retry → `retryStart` for non-permission
+ *      errors and Open Settings → `Linking.openSettings` for mic-
+ *      permission errors. Dismiss → `dismissError`.
+ *   4. The reader imports `Linking` from react-native.
+ *
+ * We follow the source-grep convention used by sibling tests
+ * (`tts-seed-failure-feedback.test.ts`, `selection-tts-failure-feedback.test.ts`).
+ * Mounting the EPUB reader is infeasible because of the embedded WebView.
+ */
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const APP_ROOT = join(__dirname, '..', '..')
+
+const EPUB_READER_PATH = join(APP_ROOT, 'app', 'reader', '[id].tsx')
+
+function readEpubReader(): string {
+  return readFileSync(EPUB_READER_PATH, 'utf-8')
+}
+
+describe('CHT-016 (#63) — EPUB reader surfaces voice-chat activation errors', () => {
+  const src = readEpubReader()
+
+  it('imports Linking from react-native (for the "Open Settings" CTA)', () => {
+    expect(src).toMatch(
+      /import\s+\{[^}]*\bLinking\b[^}]*\}\s+from\s+['"]react-native['"]/,
+    )
+  })
+
+  it('destructures voiceError from useRealtimeChat', () => {
+    expect(src).toMatch(
+      /const\s*\{[\s\S]*?\bvoiceError\b[\s\S]*?\}\s*=\s*useRealtimeChat\(/,
+    )
+  })
+
+  it('destructures isMicPermissionError from useRealtimeChat', () => {
+    expect(src).toMatch(
+      /const\s*\{[\s\S]*?\bisMicPermissionError\b[\s\S]*?\}\s*=\s*useRealtimeChat\(/,
+    )
+  })
+
+  it('destructures retryStart from useRealtimeChat', () => {
+    expect(src).toMatch(
+      /const\s*\{[\s\S]*?\bretryStart\b[\s\S]*?\}\s*=\s*useRealtimeChat\(/,
+    )
+  })
+
+  it('destructures dismissError from useRealtimeChat', () => {
+    expect(src).toMatch(
+      /const\s*\{[\s\S]*?\bdismissError\b[\s\S]*?\}\s*=\s*useRealtimeChat\(/,
+    )
+  })
+
+  it('mounts a snackbar / banner that renders when voiceError is truthy', () => {
+    // The snackbar (or banner) must be guarded by `voiceError` and have a
+    // stable testID so e2e can find it. We accept either a dedicated
+    // <VoiceChatErrorSnackbar> component OR a generic conditional render
+    // of <UndoSnackbar>/<View> keyed on voiceError, as long as a
+    // `voice-error-snackbar` testID surfaces.
+    expect(src).toMatch(/voice-error-snackbar/)
+    // …and the snackbar element is conditioned on voiceError (not
+    // unconditionally mounted).
+    expect(src).toMatch(/voiceError\s*(?:&&|\?)/)
+  })
+
+  it('wires retryStart for non-permission errors', () => {
+    // The Retry path must reference both retryStart and the negation of
+    // isMicPermissionError (or the equivalent positive permission branch).
+    expect(src).toMatch(/retryStart\b/)
+    expect(src).toMatch(/!\s*isMicPermissionError|isMicPermissionError\s*\?/)
+  })
+
+  it('wires Linking.openSettings for the mic-permission branch', () => {
+    expect(src).toMatch(/Linking\.openSettings\s*\(/)
+  })
+
+  it('wires dismissError as the snackbar dismiss handler', () => {
+    expect(src).toMatch(/dismissError\b/)
+  })
+})

--- a/apps/mobile/app/reader/[id].tsx
+++ b/apps/mobile/app/reader/[id].tsx
@@ -1,5 +1,15 @@
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
-import { View, Text, AppState, AppStateStatus, ActivityIndicator, AccessibilityInfo } from 'react-native'
+import {
+  View,
+  Text,
+  AppState,
+  AppStateStatus,
+  ActivityIndicator,
+  AccessibilityInfo,
+  Linking,
+  Pressable,
+  StyleSheet,
+} from 'react-native'
 import * as Haptics from 'expo-haptics'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { Reader, ReaderProvider, useReader } from '@epubjs-react-native/core'
@@ -193,8 +203,21 @@ function ReaderContent({ book }: { book: Book }) {
   // Wire the player machine + chat bridge once per book. The machine
   // listens for PLAY/PAUSE/PLAY_FROM events on `usePlayerStore.send`.
   usePlayerMachine(book.id)
-  // Realtime voice chat
-  const { status: realtimeStatus, showGuardrailWarning, toggle: toggleRealtime, isActive: realtimeActive } = useRealtimeChat(book.id)
+  // Realtime voice chat — `voiceError` / `isMicPermissionError` /
+  // `retryStart` / `dismissError` are forwarded from `useVoiceChat`
+  // (CHT-016 / #63) so a snackbar can surface activation failures
+  // (mic denied, network drop, etc.) that previously triggered a
+  // blocking modal Alert.
+  const {
+    status: realtimeStatus,
+    showGuardrailWarning,
+    toggle: toggleRealtime,
+    isActive: realtimeActive,
+    voiceError,
+    isMicPermissionError,
+    retryStart,
+    dismissError,
+  } = useRealtimeChat(book.id)
   useTtsChatBridge(realtimeStatus)
 
   // G20 — register the reader's content area with the page-capture
@@ -825,6 +848,76 @@ function ReaderContent({ book }: { book: Book }) {
           onDismiss={undoSnackbar.dismiss}
         />
 
+        {/*
+          CHT-016 (#63) — Voice-chat activation error surface. The
+          underlying `useVoiceChat` hook stores activation failures
+          (mic denied, network drop, etc.) on `voiceError` and
+          classifies mic-permission denials via `isMicPermissionError`
+          so this surface can swap the primary action between Retry
+          (re-invoke `retryStart`) and Open Settings (which is the
+          only remediation on iOS after the OS denies the prompt — it
+          stops showing the system permission dialog). Dismiss simply
+          clears the error without re-activating.
+        */}
+        {voiceError ? (
+          <View
+            testID="voice-error-snackbar"
+            pointerEvents="box-none"
+            style={voiceErrorStyles.container}
+          >
+            <View style={voiceErrorStyles.bar}>
+              <Text
+                style={voiceErrorStyles.message}
+                numberOfLines={3}
+                accessibilityLiveRegion="polite"
+              >
+                {voiceError}
+              </Text>
+              {isMicPermissionError ? (
+                <Pressable
+                  testID="voice-error-snackbar-settings"
+                  onPress={() => {
+                    void Linking.openSettings()
+                  }}
+                  accessibilityRole="button"
+                  accessibilityLabel="Open Settings"
+                  style={({ pressed }) => [
+                    voiceErrorStyles.button,
+                    pressed && voiceErrorStyles.buttonPressed,
+                  ]}
+                >
+                  <Text style={voiceErrorStyles.buttonText}>Open Settings</Text>
+                </Pressable>
+              ) : (
+                <Pressable
+                  testID="voice-error-snackbar-retry"
+                  onPress={() => {
+                    void retryStart()
+                  }}
+                  accessibilityRole="button"
+                  accessibilityLabel="Retry"
+                  style={({ pressed }) => [
+                    voiceErrorStyles.button,
+                    pressed && voiceErrorStyles.buttonPressed,
+                  ]}
+                >
+                  <Text style={voiceErrorStyles.buttonText}>Retry</Text>
+                </Pressable>
+              )}
+              <Pressable
+                testID="voice-error-snackbar-dismiss"
+                onPress={dismissError}
+                accessibilityRole="button"
+                accessibilityLabel="Dismiss"
+                style={voiceErrorStyles.dismiss}
+                hitSlop={8}
+              >
+                <Text style={voiceErrorStyles.dismissText}>✕</Text>
+              </Pressable>
+            </View>
+          </View>
+        ) : null}
+
         {popoverVisible && selectedHighlight && (
           <AnnotationPopover
             visible={popoverVisible}
@@ -861,6 +954,69 @@ interface ReaderEngineProps {
   popoverVisible: boolean
   dismissPopover: () => void
 }
+
+/**
+ * CHT-016 (#63) — Snackbar styles for the voice-chat activation-error
+ * surface. Sits slightly above the standard UndoSnackbar (which the
+ * highlight-delete flow owns) so the two surfaces don't stack on top of
+ * each other if the user manages to delete a highlight in the same window
+ * a voice-chat retry resolves.
+ */
+const voiceErrorStyles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    left: 16,
+    right: 16,
+    bottom: 152,
+    alignItems: 'center',
+    zIndex: 31,
+  },
+  bar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'rgba(28,28,30,0.97)',
+    borderRadius: 10,
+    paddingLeft: 16,
+    paddingRight: 8,
+    paddingVertical: 8,
+    gap: 12,
+    minHeight: 48,
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 4,
+  },
+  message: {
+    flex: 1,
+    color: '#fff',
+    fontSize: 14,
+  },
+  button: {
+    paddingHorizontal: 12,
+    minHeight: 36,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  buttonPressed: {
+    opacity: 0.7,
+  },
+  buttonText: {
+    color: '#60A5FA',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  dismiss: {
+    width: 32,
+    height: 32,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  dismissText: {
+    color: '#aaa',
+    fontSize: 16,
+  },
+})
 
 function ReaderEngine({
   book,

--- a/apps/mobile/hooks/useRealtimeChat.ts
+++ b/apps/mobile/hooks/useRealtimeChat.ts
@@ -15,10 +15,30 @@ export interface UseRealtimeChatResult {
   showGuardrailWarning: boolean
   toggle: () => void
   isActive: boolean
+  /**
+   * CHT-016 (#63) — Activation-error fields forwarded from the
+   * underlying `useVoiceChat` hook. Reader screens read these to
+   * render a non-blocking snackbar when voice-chat activation fails
+   * (mic denied, network drop, etc.). Prior to this wiring the shim
+   * silently swallowed the fields, regressing the user-facing AC of
+   * issue #63 from a modal Alert to a silent no-op.
+   */
+  voiceError: string | null
+  isMicPermissionError: boolean
+  retryStart: () => Promise<void>
+  dismissError: () => void
 }
 
 export function useRealtimeChat(bookId: string): UseRealtimeChatResult {
-  const { status, toggle, isActive } = useVoiceChat(bookId)
+  const {
+    status,
+    toggle,
+    isActive,
+    voiceError,
+    isMicPermissionError,
+    retryStart,
+    dismissError,
+  } = useVoiceChat(bookId)
   // Guardrail UI was wired into the old hook via a callback fired by
   // the off-topic classifier. Batch 4 keeps the classifier
   // (`lib/realtime/guardrails.ts`) but moves the "show banner"
@@ -34,6 +54,10 @@ export function useRealtimeChat(bookId: string): UseRealtimeChatResult {
     toggle: () => {
       void toggle()
     },
-    isActive
+    isActive,
+    voiceError,
+    isMicPermissionError,
+    retryStart,
+    dismissError,
   }
 }


### PR DESCRIPTION
## Background

PR #154 (merged as `fa6ed60c`) added `voiceError`, `isMicPermissionError`, `retryStart`, and `dismissError` to `useVoiceChat` AND removed the prior `Alert.alert` modal for activation failures. The `/kanban-codereview` funnel surfaced a Layer-3 BLOCKER: the `useRealtimeChat` compatibility shim only destructured `{ status, toggle, isActive }`, silently dropping the new error fields. All 4 reader screens consume via that shim, so voice-chat activation failures (mic denied, network drop) regressed to a silent no-op — the user-facing AC of issue #63 was not met.

The fix landed after PR #154 was merged, so this PR ships the consumer wiring as a follow-up.

## Changes

- `apps/mobile/hooks/useRealtimeChat.ts` — extend `UseRealtimeChatResult` and forward the 4 new fields from `useVoiceChat`.
- `apps/mobile/app/reader/[id].tsx` — destructure the fields and mount a non-blocking snackbar that:
  - Renders when `voiceError` is truthy
  - Shows **Retry** (→ `retryStart`) for non-permission failures
  - Shows **Open Settings** (→ `Linking.openSettings`) for mic-permission failures (iOS stops re-prompting after first denial)
  - Always shows **Dismiss** (→ `dismissError`)
- New tests:
  - `__tests__/hooks/useRealtimeChat-error-forwarding.test.ts` — 5 unit tests
  - `__tests__/reader/voice-chat-error-feedback.test.ts` — 9 source-grep tests (mirrors PR #150 / #93 / #97 convention)

PDF / MOBI / DJVU readers share the same shim wiring; this diff stays EPUB-only by design — a follow-up patch can mount the same snackbar in the other three readers without touching the contract.

Closes #63 (properly this time).

## Test plan

- [x] `pnpm test -- --testPathPattern='useRealtimeChat-error-forwarding|voice-chat-error-feedback'` — 14/14 pass
- [x] `pnpm test` — 1327/1332 pass (5 failures are pre-existing ESM-transform infra issues, unrelated)
- [x] `pnpm exec tsc --noEmit` — no errors in changed files
- [ ] Manual: trigger voice-chat with mic denied → snackbar with "Open Settings"
- [ ] Manual: trigger voice-chat with airplane mode → snackbar with "Retry"