### PR TITLE
fix(mobile/chat/conversations): sort embedded books first in NewConversationSheet (#42)

### DIFF
--- a/apps/mobile/__tests__/chat/new-conversation-sheet.test.tsx
+++ b/apps/mobile/__tests__/chat/new-conversation-sheet.test.tsx
@@ -295,6 +295,53 @@ describe('P1-AH — NewConversationSheet replaces Alert button-list', () => {
     expect(rows.length).toBe(14)
   })
 
+  it('sorts embedded (Ready) books first, ahead of Preparing books (#42)', () => {
+    // Interleaved input: pending, ready, pending, ready, pending.
+    // Without sorting, the first rendered row would be `b-pending-1`.
+    mockBooks.push(
+      { id: 'b-pending-1', title: 'Pending 1', format: 'epub', coverPath: null },
+      { id: 'b-ready-1', title: 'Ready 1', format: 'epub', coverPath: null },
+      { id: 'b-pending-2', title: 'Pending 2', format: 'pdf', coverPath: null },
+      { id: 'b-ready-2', title: 'Ready 2', format: 'epub', coverPath: null },
+      { id: 'b-pending-3', title: 'Pending 3', format: 'pdf', coverPath: null },
+    )
+    embeddedIds.add('b-ready-1')
+    embeddedIds.add('b-ready-2')
+
+    const ConversationsScreen = require('@/app/(tabs)/chat').default
+    let tree!: TestRenderer.ReactTestRenderer
+    act(() => {
+      tree = TestRenderer.create(<ConversationsScreen />)
+    })
+
+    act(() => {
+      ;(
+        findByTestID(tree, 'chat-new-conversation-btn')!
+          .props as { onPress: () => void }
+      ).onPress()
+    })
+
+    const rows = findAllByPrefix(tree, 'new-conversation-book-row-')
+    // The first row rendered must correspond to an embedded ("Ready") book.
+    const firstTestId =
+      (rows[0]?.props as { testID?: string } | null)?.testID ?? ''
+    const firstId = firstTestId.replace('new-conversation-book-row-', '')
+    expect(embeddedIds.has(firstId)).toBe(true)
+
+    // And ALL ready rows must come before ANY pending row — i.e. partitioned.
+    const ids = rows.map((r) => {
+      const id = (r.props as { testID?: string } | null)?.testID ?? ''
+      return id.replace('new-conversation-book-row-', '')
+    })
+    const firstPendingIdx = ids.findIndex((id) => !embeddedIds.has(id))
+    const lastReadyIdx = ids.reduce(
+      (acc, id, idx) => (embeddedIds.has(id) ? idx : acc),
+      -1,
+    )
+    expect(firstPendingIdx).toBeGreaterThan(-1)
+    expect(lastReadyIdx).toBeLessThan(firstPendingIdx)
+  })
+
   it('shows embed-status badge per book and routes on tap', () => {
     mockBooks.push(
       { id: 'b-ready', title: 'Ready', format: 'epub', coverPath: null },

--- a/apps/mobile/components/chat/NewConversationSheet.tsx
+++ b/apps/mobile/components/chat/NewConversationSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { FlatList, Text, TouchableOpacity, View } from 'react-native'
 import { Sheet } from '@/components/ui/Sheet'
 import { useTheme } from '@/lib/theme'
@@ -35,6 +35,19 @@ export function NewConversationSheet({
   onSelectBook,
 }: NewConversationSheetProps): React.JSX.Element {
   const { colors, spacing, typography, radius } = useTheme()
+
+  // #42 — Sort embedded ("Ready") books to the top of the list so users
+  // don't have to scroll past "Preparing" titles to find chat-ready ones.
+  // Stable partition: preserves the parent's relative order within each
+  // group (Array.prototype.sort is stable as of ES2019 / Node 12+).
+  const sortedBooks = useMemo(
+    () =>
+      [...books].sort(
+        (a, b) =>
+          Number(isBookEmbedded(b.id)) - Number(isBookEmbedded(a.id)),
+      ),
+    [books, isBookEmbedded],
+  )
 
   const renderItem = useCallback(
     ({ item }: { item: Book }) => {
@@ -153,7 +166,7 @@ export function NewConversationSheet({
       <View testID="new-conversation-sheet" style={{ minHeight: 200 }}>
         <FlatList
           testID="new-conversation-book-list"
-          data={books}
+          data={sortedBooks}
           keyExtractor={(b) => b.id}
           renderItem={renderItem}
           ListEmptyComponent={empty}


### PR DESCRIPTION
Closes #42.

## Summary
NewConversationSheet rendered `books` as-is, so "Preparing" books interleaved with "Ready" ones. Users had to scroll past unprepared titles to find chat-ready books. This sorts embedded (`isBookEmbedded(id) === true`) books to the top of the list.

## Implementation
Added a `useMemo`-derived `sortedBooks` list keyed on `[books, isBookEmbedded]` and fed it to the `FlatList` instead of the raw `books` prop. The sort comparator is a stable partition (`Number(isBookEmbedded(b.id)) - Number(isBookEmbedded(a.id))`) — `Array.prototype.sort` is stable as of ES2019, so the parent's relative order within each group is preserved (no visual churn for users). Skipped the optional "Ready for chat" / "Preparing" section header — the issue marks it optional, and the per-row badge already labels each item, so a header would duplicate that signal without changing the navigation pain point this issue is filed against.

## Testability
TDD — red commit 99016cc6, green commit 2c42f6d1.
Test: `apps/mobile/__tests__/chat/new-conversation-sheet.test.tsx` adds the "sorts embedded books first" assertion (interleaved input, asserts first row is embedded AND all Ready rows precede all Preparing rows).

## Local CI
typecheck: PASS  (cmd: `pnpm exec tsc --noEmit -p apps/mobile/tsconfig.json` — zero errors in changed files; 31 pre-existing errors in unrelated test/lib files were already on `main`)
test:      PASS  (cmd: `pnpm exec jest __tests__/chat/new-conversation-sheet.test.tsx` — 3/3 pass)
lint:      PASS  (cmd: `pnpm exec eslint components/chat/NewConversationSheet.tsx` — exit 0, 0 issues; pre-existing warnings in the test file's jest-mock scaffolding are unchanged from baseline)
format:    SKIP  (no `.prettierrc*` configured in this workspace; the repo style is no-semi/single-quote which doesn't match prettier defaults)
build:     SKIP  (expo builds are heavy)