### PR TITLE
fix(mobile/chat/detail): clear PulsingDot interval on unmount (#59)

### DIFF
--- a/apps/mobile/__tests__/chat/pulsing-dot-interval-leak.test.tsx
+++ b/apps/mobile/__tests__/chat/pulsing-dot-interval-leak.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * CHT-010 / Issue #59 — PulsingDot interval leak.
+ *
+ * Bug: the PulsingDot effect (in apps/mobile/app/chat/[bookId].tsx) used to
+ * `return () => clearInterval(interval)` from INSIDE its outer `setTimeout`
+ * callback. That cleanup function was returned to the timeout callback (which
+ * discards return values), NOT to React. Consequently, React's `useEffect`
+ * cleanup only cleared the timeout — never the interval — so the interval
+ * kept firing after the component unmounted, leaking timers and triggering
+ * `setOpacity` updates on a torn-down tree.
+ *
+ * This test guards the fix: after mounting PulsingDot, advancing fake timers
+ * past `delay` so the interval is created, and unmounting, EVERY id returned
+ * by `setInterval` for the duration of the mount MUST have been passed to
+ * `clearInterval`.
+ */
+
+jest.mock('react-native', () => {
+  const React = require('react')
+  const mk = (name: string) =>
+    React.forwardRef((p: any, r: unknown) =>
+      React.createElement(name, { ...p, ref: r }, p.children),
+    )
+  return {
+    View: mk('View'),
+    Text: mk('Text'),
+    Pressable: mk('Pressable'),
+    TouchableOpacity: mk('TouchableOpacity'),
+    Image: mk('Image'),
+    TextInput: mk('TextInput'),
+    ActivityIndicator: mk('ActivityIndicator'),
+    KeyboardAvoidingView: mk('KeyboardAvoidingView'),
+    ScrollView: mk('ScrollView'),
+    FlatList: mk('FlatList'),
+    Alert: { alert: jest.fn() },
+    StyleSheet: {
+      create: (s: Record<string, unknown>) => s,
+      hairlineWidth: 0.5,
+    },
+    Platform: {
+      OS: 'ios',
+      select: <T,>(spec: Record<string, T>): T | undefined =>
+        spec.ios ?? spec.default,
+    },
+    useColorScheme: () => 'light',
+  }
+})
+
+// Reanimated mock — PulsingDot itself does not use Reanimated APIs, but the
+// host module (`[bookId].tsx`) imports `Animated, { FadeIn, FadeOut }` at
+// top-level, so the mock must exist for the file to load.
+jest.mock('react-native-reanimated', () => {
+  const React = require('react')
+  const View = React.forwardRef((p: any, r: unknown) =>
+    React.createElement('Animated.View', { ...p, ref: r }, p.children),
+  )
+  return {
+    __esModule: true,
+    default: { View, createAnimatedComponent: (c: unknown) => c },
+    View,
+    FadeIn: { duration: () => ({ withInitialValues: () => ({}) }) },
+    FadeOut: { duration: () => ({}) },
+    SlideInLeft: { duration: () => ({}) },
+    SlideInRight: { duration: () => ({}) },
+  }
+})
+
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react')
+  return {
+    SafeAreaView: (p: any) =>
+      React.createElement('SafeAreaView', p, p.children),
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  }
+})
+
+// The chat-detail module pulls in a heavy graph (expo-router, storage,
+// hooks, etc.) that the test does not exercise. We only import the
+// `PulsingDot` named export, but ts-jest still evaluates the whole module
+// during `require`, so the surrounding singletons need stubs.
+jest.mock('expo-router', () => {
+  const React = require('react')
+  return {
+    useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+    useLocalSearchParams: () => ({}),
+    useFocusEffect: (cb: () => void) => {
+      React.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [cb])
+    },
+  }
+})
+
+jest.mock('@/components/ui/icon-symbol', () => {
+  const React = require('react')
+  return {
+    IconSymbol: (p: any) =>
+      React.createElement('IconSymbol', { testID: `icon-${p.name}`, ...p }),
+  }
+})
+jest.mock('@/components/auth/useRequireAuth', () => ({
+  useRequireAuth: () => (action: () => void) => action(),
+}))
+jest.mock('@/lib/stores/authStore', () => ({
+  __esModule: true,
+  useAuthStore: <T,>(selector: (s: { isAuthenticated: boolean }) => T) =>
+    selector({ isAuthenticated: true }),
+}))
+jest.mock('@/lib/conversation-storage', () => ({
+  getConversationsForBook: () => [],
+  getMessages: () => [],
+  addMessage: jest.fn(),
+  createConversation: (bookId: string) => ({
+    id: `nc-${bookId}`,
+    bookId,
+    title: 't',
+    createdAt: 0,
+    updatedAt: 0,
+  }),
+}))
+jest.mock('@/lib/book-storage', () => ({
+  getBookById: () => null,
+  getBookForReading: jest.fn(async () => null),
+}))
+jest.mock('@/lib/rag/vector-store', () => ({
+  isBookEmbedded: () => true,
+  searchSimilarChunks: jest.fn(),
+}))
+jest.mock('@/lib/rag/pipeline', () => ({
+  embedBook: jest.fn(async () => undefined),
+}))
+jest.mock('@/hooks/useEmbeddingModel', () => ({
+  useEmbeddingModel: () => ({ isReady: true, downloadProgress: 1 }),
+}))
+jest.mock('@/hooks/useRAGQuery', () => ({
+  useRAGQuery: () => ({ askQuestion: jest.fn(), isLoading: false }),
+}))
+jest.mock('@/hooks/useVoiceInput', () => ({
+  useVoiceInput: () => ({
+    isRecording: false,
+    isTranscribing: false,
+    error: null,
+    permissionDenied: false,
+    startRecording: jest.fn(),
+    stopAndTranscribe: jest.fn(),
+  }),
+}))
+jest.mock('@/components/ChatMessage', () => {
+  const React = require('react')
+  return {
+    ChatMessage: (p: any) =>
+      React.createElement('ChatMessage', { testID: p.testID }),
+  }
+})
+jest.mock('@/components/ChatInput', () => {
+  const React = require('react')
+  return {
+    ChatInput: (p: any) => React.createElement('ChatInput', p),
+  }
+})
+jest.mock('@/components/ModelDownloadCard', () => {
+  const React = require('react')
+  return { ModelDownloadCard: () => React.createElement('ModelDownloadCard') }
+})
+jest.mock('@/components/EmbeddingProgress', () => {
+  const React = require('react')
+  return { EmbeddingProgress: () => React.createElement('EmbeddingProgress') }
+})
+
+import React, { act } from 'react'
+import TestRenderer from 'react-test-renderer'
+
+describe('PulsingDot interval leak (#59)', () => {
+  let intervalSpy: jest.SpyInstance
+  let clearIntervalSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    intervalSpy = jest.spyOn(global, 'setInterval')
+    clearIntervalSpy = jest.spyOn(global, 'clearInterval')
+  })
+
+  afterEach(() => {
+    intervalSpy.mockRestore()
+    clearIntervalSpy.mockRestore()
+    jest.useRealTimers()
+  })
+
+  it('clears its interval on unmount (single mount)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { PulsingDot } = require('@/app/chat/[bookId]')
+    let tree!: TestRenderer.ReactTestRenderer
+    act(() => {
+      tree = TestRenderer.create(<PulsingDot delay={0} />)
+    })
+
+    // Run the outer setTimeout(..., delay) so the interval is created.
+    act(() => {
+      jest.advanceTimersByTime(50)
+    })
+
+    const intervalIdsBefore = intervalSpy.mock.results
+      .filter((r) => r.type === 'return')
+      .map((r) => r.value as ReturnType<typeof setInterval>)
+    expect(intervalIdsBefore.length).toBeGreaterThan(0)
+
+    act(() => {
+      tree.unmount()
+    })
+
+    const clearedIds = clearIntervalSpy.mock.calls.map(
+      (call) => call[0] as ReturnType<typeof setInterval>,
+    )
+    for (const id of intervalIdsBefore) {
+      expect(clearedIds).toContain(id)
+    }
+  })
+
+  it('does not leak intervals across repeated mount/unmount cycles', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { PulsingDot } = require('@/app/chat/[bookId]')
+    for (let i = 0; i < 5; i++) {
+      let tree!: TestRenderer.ReactTestRenderer
+      act(() => {
+        tree = TestRenderer.create(<PulsingDot delay={0} />)
+      })
+      act(() => {
+        jest.advanceTimersByTime(50)
+      })
+      act(() => {
+        tree.unmount()
+      })
+    }
+
+    const createdIds = intervalSpy.mock.results
+      .filter((r) => r.type === 'return')
+      .map((r) => r.value as ReturnType<typeof setInterval>)
+    const clearedIds = clearIntervalSpy.mock.calls.map(
+      (call) => call[0] as ReturnType<typeof setInterval>,
+    )
+    // Every interval created during the test MUST be in clearedIds —
+    // otherwise we have leaked timers that will keep firing on torn-down
+    // components.
+    expect(createdIds.length).toBeGreaterThan(0)
+    for (const id of createdIds) {
+      expect(clearedIds).toContain(id)
+    }
+  })
+})

--- a/apps/mobile/app/chat/[bookId].tsx
+++ b/apps/mobile/app/chat/[bookId].tsx
@@ -697,7 +697,7 @@ function TypingIndicator() {
   )
 }
 
-function PulsingDot({ delay }: { delay: number }) {
+export function PulsingDot({ delay }: { delay: number }) {
   const [opacity, setOpacity] = useState(0.3)
 
   useEffect(() => {

--- a/apps/mobile/app/chat/[bookId].tsx
+++ b/apps/mobile/app/chat/[bookId].tsx
@@ -702,6 +702,12 @@ export function PulsingDot({ delay }: { delay: number }) {
 
   useEffect(() => {
     let mounted = true
+    // #59 — Hoist the interval handle out of the inner `setTimeout`
+    // callback so the outer effect cleanup can actually clear it.
+    // Previously `return () => clearInterval(interval)` was returned
+    // from the timeout callback (which discards return values), leaving
+    // the interval firing forever on torn-down components.
+    let interval: ReturnType<typeof setInterval> | null = null
     const cycle = () => {
       if (!mounted) return
       setOpacity(1)
@@ -713,13 +719,16 @@ export function PulsingDot({ delay }: { delay: number }) {
 
     const timeout = setTimeout(() => {
       cycle()
-      const interval = setInterval(cycle, 600)
-      return () => clearInterval(interval)
+      interval = setInterval(cycle, 600)
     }, delay)
 
     return () => {
       mounted = false
       clearTimeout(timeout)
+      if (interval !== null) {
+        clearInterval(interval)
+        interval = null
+      }
     }
   }, [delay])
 


### PR DESCRIPTION
Closes #59.

## Summary
PulsingDot's `useEffect` returned its `clearInterval` cleanup from inside the inner `setTimeout` callback, which discards return values. So the outer effect cleanup only ever cleared the timeout — never the interval. After unmount the interval kept firing and called `setOpacity` on a torn-down tree, leaking timers across every appearance of the typing indicator.

Chose the **`useRef`-style hoist** (here a `let` inside the effect closure — same lifetime semantics as a `useRef` for an effect-scoped handle) over a Reanimated `withRepeat(withSequence(...))` rewrite because it is the minimal root-cause fix that keeps the diff inside the PulsingDot area. Issue #68 owns nearby code in the same file, so we deliberately limited scope.

## Implementation
- Hoist the `setInterval` handle to an effect-scoped `let interval` initialized to `null`.
- The deferred `setInterval` (created inside the `setTimeout` callback at `delay` ms) now assigns to that handle.
- The outer cleanup clears the timeout AND `clearInterval(interval)` when it is non-null, then nulls it.
- The `mounted` flag remains so the inner cycle no-ops if either timer fires after unmount but before the cleanup ran (e.g., during the unmount itself).
- Added a named `export function PulsingDot` so the Jest test can render it in isolation. Default export is unchanged.

## Testability
TDD — red commit `9e88fc07`, green commit `ca66e921`.

The test (`apps/mobile/__tests__/chat/pulsing-dot-interval-leak.test.tsx`) mounts `PulsingDot`, lets the deferred `setInterval` fire under fake timers, unmounts, and asserts every id returned by `setInterval` is passed to `clearInterval`. Also runs five mount/unmount cycles to guard against per-cycle leaks. Both cases were red before the fix and green after.

## Local CI
typecheck: PASS (cmd: `node_modules/.bin/tsc --noEmit -p tsconfig.json` — 0 errors in `app/chat/[bookId].tsx` or the new test; pre-existing errors in `packages/shared/src/voice-chat/*`, `__tests__/*` etc. unrelated)
test:      PASS (cmd: `node_modules/.bin/jest __tests__/chat/` — 17 suites / 45 tests)
lint:      PASS (cmd: `pnpm run lint` — 0 errors; 20 pre-existing warnings, none on changed files)
format:    SKIP (no prettier config)
build:     SKIP (heavy)