### PR TITLE
fix(shared/book-import): cleanup bookDir on parse/save failure in picker path (#209)

### DIFF
--- a/apps/mobile/lib/book-import/adapters.ts
+++ b/apps/mobile/lib/book-import/adapters.ts
@@ -135,6 +135,22 @@ export function createMobileFsPort(opts: {
         // best-effort
       }
     },
+
+    async removeBookDir(_path: string): Promise<void> {
+      // #209: the importer hands us the path to `book.<ext>` *inside* the
+      // per-book dir. The dir we created in copyBookToAppData is
+      // `<BOOKS_DIR>/<opts.bookId>`. Delete that (and the file inside)
+      // wholesale rather than fishing the bookId out of the path string —
+      // (bookId, format) is already baked into this port.
+      const bookDir = new Directory(BOOKS_DIR, opts.bookId);
+      try {
+        if (bookDir.exists) {
+          bookDir.delete();
+        }
+      } catch {
+        // best-effort — caller has the original parse / save error.
+      }
+    },
   };
 }
 

--- a/packages/shared/src/book-import/importer.test.ts
+++ b/packages/shared/src/book-import/importer.test.ts
@@ -25,9 +25,18 @@ type TestBookId = string;
 export function makeFs(opts?: {
   copyImpl?: (path: string) => Promise<string>;
   removeImpl?: (path: string) => Promise<void>;
-}): { fs: FsPort; removeCalls: string[]; copyCalls: string[] } {
+  removeBookDirImpl?: (path: string) => Promise<void>;
+  /** When true, the FsPort does NOT define `removeBookDir`. */
+  noRemoveBookDir?: boolean;
+}): {
+  fs: FsPort;
+  removeCalls: string[];
+  copyCalls: string[];
+  removeBookDirCalls: string[];
+} {
   const removeCalls: string[] = [];
   const copyCalls: string[] = [];
+  const removeBookDirCalls: string[] = [];
   const fs: FsPort = {
     copyBookToAppData: vi.fn(async (path: string) => {
       copyCalls.push(path);
@@ -40,7 +49,13 @@ export function makeFs(opts?: {
       if (opts?.removeImpl) return opts.removeImpl(path);
     }),
   };
-  return { fs, removeCalls, copyCalls };
+  if (!opts?.noRemoveBookDir) {
+    fs.removeBookDir = vi.fn(async (path: string) => {
+      removeBookDirCalls.push(path);
+      if (opts?.removeBookDirImpl) return opts.removeBookDirImpl(path);
+    });
+  }
+  return { fs, removeCalls, copyCalls, removeBookDirCalls };
 }
 
 export function makeDbForImport(opts?: {
@@ -179,8 +194,8 @@ describe("runImport — copy failure", () => {
   });
 });
 
-describe("runImport — parse failure rolls back the copy", () => {
-  it("removes the copied file and returns stage: parse", async () => {
+describe("runImport — parse failure rolls back the copy (#209)", () => {
+  it("removes the bookDir when removeBookDir is defined", async () => {
     const failingFormats = {
       getBookData: vi.fn(async () => {
         throw new Error("bad zip");
@@ -189,7 +204,7 @@ describe("runImport — parse failure rolls back the copy", () => {
       getMobiData: vi.fn(),
       getAzw3Data: vi.fn(),
     };
-    const { fs, removeCalls } = makeFs();
+    const { fs, removeCalls, removeBookDirCalls } = makeFs();
     const { db, savedBooks } = makeDbForImport();
     const events: ImportProgressEvent<TestBookId>[] = [];
 
@@ -201,7 +216,10 @@ describe("runImport — parse failure rolls back the copy", () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.stage).toBe("parse");
-    expect(removeCalls).toEqual(["/userData/broken.epub"]);
+    // Prefer removeBookDir over removeFile so the orphan per-book dir
+    // (the partition mobile owns) is torn down, not just the file inside it.
+    expect(removeBookDirCalls).toEqual(["/userData/broken.epub"]);
+    expect(removeCalls).toEqual([]);
     expect(savedBooks).toEqual([]);
     expect(events.map((e) => e.kind)).toEqual([
       "copying",
@@ -209,12 +227,67 @@ describe("runImport — parse failure rolls back the copy", () => {
       "failed",
     ]);
   });
+
+  it("falls back to removeFile when removeBookDir is NOT defined (electron shape)", async () => {
+    const failingFormats = {
+      getBookData: vi.fn(async () => {
+        throw new Error("bad zip");
+      }),
+      getPdfData: vi.fn(),
+      getMobiData: vi.fn(),
+      getAzw3Data: vi.fn(),
+    };
+    const { fs, removeCalls, removeBookDirCalls } = makeFs({
+      noRemoveBookDir: true,
+    });
+    const events: ImportProgressEvent<TestBookId>[] = [];
+
+    const result = await runImport(
+      makeImporterDeps({ formats: failingFormats, fs }),
+      "/Downloads/broken.epub",
+      (e) => events.push(e),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(removeCalls).toEqual(["/userData/broken.epub"]);
+    expect(removeBookDirCalls).toEqual([]);
+  });
+
+  it("still returns the parse error when cleanup itself throws", async () => {
+    const failingFormats = {
+      getBookData: vi.fn(async () => {
+        throw new Error("bad zip");
+      }),
+      getPdfData: vi.fn(),
+      getMobiData: vi.fn(),
+      getAzw3Data: vi.fn(),
+    };
+    const { fs } = makeFs({
+      removeBookDirImpl: async () => {
+        throw new Error("rm failed");
+      },
+    });
+    const events: ImportProgressEvent<TestBookId>[] = [];
+
+    const result = await runImport(
+      makeImporterDeps({ formats: failingFormats, fs }),
+      "/Downloads/broken.epub",
+      (e) => events.push(e),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.stage).toBe("parse");
+      // The cleanup branch must NOT swallow / replace the original error.
+      expect(result.error).toBe("bad zip");
+    }
+  });
 });
 
-describe("runImport — save failure does NOT roll back copy", () => {
-  it("returns stage: save and leaves the copied file on disk", async () => {
+describe("runImport — save failure rolls back the copy (#209)", () => {
+  it("removes the bookDir when DB save throws", async () => {
     const { formats } = makeFormats();
-    const { fs, removeCalls } = makeFs();
+    const { fs, removeCalls, removeBookDirCalls } = makeFs();
     const { db } = makeDbForImport({ failOn: "saveBook" });
     const events: ImportProgressEvent<TestBookId>[] = [];
 
@@ -226,6 +299,7 @@ describe("runImport — save failure does NOT roll back copy", () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.stage).toBe("save");
+    expect(removeBookDirCalls).toEqual(["/userData/book.epub"]);
     expect(removeCalls).toEqual([]);
     expect(events.map((e) => e.kind)).toEqual([
       "copying",
@@ -233,6 +307,49 @@ describe("runImport — save failure does NOT roll back copy", () => {
       "saving",
       "failed",
     ]);
+  });
+
+  it("falls back to removeFile when removeBookDir is NOT defined", async () => {
+    const { formats } = makeFormats();
+    const { fs, removeCalls, removeBookDirCalls } = makeFs({
+      noRemoveBookDir: true,
+    });
+    const { db } = makeDbForImport({ failOn: "saveBook" });
+    const events: ImportProgressEvent<TestBookId>[] = [];
+
+    const result = await runImport(
+      makeImporterDeps({ formats, fs, db }),
+      "/Downloads/book.epub",
+      (e) => events.push(e),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(removeCalls).toEqual(["/userData/book.epub"]);
+    expect(removeBookDirCalls).toEqual([]);
+  });
+
+  it("still returns the save error when cleanup itself throws", async () => {
+    const { formats } = makeFormats();
+    const { fs } = makeFs({
+      removeBookDirImpl: async () => {
+        throw new Error("rm failed");
+      },
+    });
+    const { db } = makeDbForImport({ failOn: "saveBook" });
+    const events: ImportProgressEvent<TestBookId>[] = [];
+
+    const result = await runImport(
+      makeImporterDeps({ formats, fs, db }),
+      "/Downloads/book.epub",
+      (e) => events.push(e),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.stage).toBe("save");
+      // The cleanup branch must NOT swallow / replace the original error.
+      expect(result.error).toBe("saveBook failed");
+    }
   });
 });
 

--- a/packages/shared/src/book-import/importer.ts
+++ b/packages/shared/src/book-import/importer.ts
@@ -60,6 +60,29 @@ function messageOf(err: unknown, fallback: string): string {
 }
 
 /**
+ * Best-effort cleanup of the per-book directory (or just the file, when the
+ * platform stores books flat). See `FsPort.removeBookDir` for the contract.
+ *
+ * Issue #209: failures here MUST NOT replace the original parse / save error
+ * — the caller has already classified the failure stage and we want the
+ * original message to surface unchanged.
+ */
+async function rollbackCopy(
+  fs: FsPort,
+  bookPath: string,
+): Promise<void> {
+  try {
+    if (fs.removeBookDir) {
+      await fs.removeBookDir(bookPath);
+    } else {
+      await fs.removeFile(bookPath);
+    }
+  } catch {
+    /* swallow */
+  }
+}
+
+/**
  * Best-effort cover extraction + R2 upload. Failures emit upload-failed
  * but never block the result. Runs asynchronously (microtask) so `done`
  * lands first.
@@ -110,8 +133,8 @@ function runPostSave<BookId, Book, BookInsertable>(
 
 /**
  * Single-file import pipeline. Sequential stages with per-stage timeouts.
- * Returns a discriminated ImportResult. Rolls back the copy on parse failure;
- * leaves the copied file on save failure (caller can retry).
+ * Returns a discriminated ImportResult. Rolls back the copied book (file +
+ * per-book dir on mobile) on parse OR save failure — see #209.
  */
 export async function runImport<BookId, Book, BookInsertable>(
   deps: ImporterDeps<BookId, Book, BookInsertable>,
@@ -171,11 +194,10 @@ export async function runImport<BookId, Book, BookInsertable>(
   } catch (err) {
     const error = messageOf(err, "Parse failed");
     emit({ kind: "failed", filePath, stage: "parse", error });
-    try {
-      await deps.fs.removeFile(bookPath);
-    } catch {
-      /* swallow */
-    }
+    // #209: clean up the orphan per-book dir on mobile (or just the copied
+    // file on electron). Best-effort — failures here do not replace the
+    // parse error.
+    await rollbackCopy(deps.fs, bookPath);
     return { ok: false, filePath, stage: "parse", error };
   }
 
@@ -193,6 +215,10 @@ export async function runImport<BookId, Book, BookInsertable>(
   } catch (err) {
     const error = messageOf(err, "Save failed");
     emit({ kind: "failed", filePath, stage: "save", error });
+    // #209: mirror the parse-fail cleanup — the DB insert never persisted a
+    // row, so leaving the copied file (and on mobile, the per-book dir)
+    // around is a pure leak. Best-effort.
+    await rollbackCopy(deps.fs, bookPath);
     return { ok: false, filePath, stage: "save", error };
   }
 

--- a/packages/shared/src/book-import/types.ts
+++ b/packages/shared/src/book-import/types.ts
@@ -127,6 +127,21 @@ export interface DbPort<BookId, Book, BookInsertable> {
 export interface FsPort {
   copyBookToAppData(filePath: string): Promise<string>;
   removeFile(path: string): Promise<void>;
+  /**
+   * Remove the per-book directory that contains `bookPath` (issue #209).
+   *
+   * Mobile mints `books/<bookId>/book.<ext>` and the orphan directory leaks
+   * on parse / save failure if only the file is removed. Implementations
+   * that own a per-book directory should delete the whole dir here;
+   * implementations that don't (electron writes a flat
+   * `userData/<filename>`) can omit this and the importer falls back to
+   * `removeFile`.
+   *
+   * Best-effort: implementations MUST NOT throw on a missing dir, and the
+   * importer treats any rejection as non-fatal (the original parse / save
+   * error is the one propagated to the caller).
+   */
+  removeBookDir?(bookPath: string): Promise<void>;
 }
 
 /** R2 upload port. */


### PR DESCRIPTION
Closes #209.

## Summary
The picker-path importer in `packages/shared/src/book-import/importer.ts` did not remove the bookDir on parse-fail or save-fail, leaving orphan directories on disk. PR #207 fixed the mobile-side path (copy-throw cleanup in `createMobileFsPort.copyBookToAppData`) but missed the shared package partition — the two later failure surfaces still leaked.

## Implementation
- Added an optional `FsPort.removeBookDir(bookPath)` so platforms owning a per-book directory (mobile) can tear down the whole dir, while electron (flat `userData/<filename>`) can omit it and the importer falls back to `removeFile`.
- Routed both the parse-fail and save-fail branches through a new `rollbackCopy()` helper that prefers `removeBookDir` when defined. The helper swallows cleanup failures so the original parse/save `error` message (and emitted `failed` event) survives unchanged — verified by dedicated regression tests.
- Implemented `removeBookDir` on `createMobileFsPort` (deletes `books/<bookId>/`, using the bookId already baked into the port — no path parsing).

## Testability
TDD — red commit fb6a69aa, green commit 32d2d9ce.

Six new tests in `packages/shared/src/book-import/importer.test.ts`:
- parse-fail prefers `removeBookDir` over `removeFile`
- parse-fail falls back to `removeFile` (electron shape)
- parse-fail preserves the original error when cleanup throws
- save-fail removes the bookDir (new contract — supersedes the old "leaves the copied file on save failure" test)
- save-fail falls back to `removeFile`
- save-fail preserves the original error when cleanup throws

## Local CI
typecheck: PASS  (cmd: `pnpm typecheck` in `packages/shared`)
test:      PASS  (cmd: `pnpm test` in `packages/shared` — 510/510 tests across 36 files)
lint:      PASS  (cmd: `pnpm exec eslint apps/mobile/lib/book-import/adapters.ts` — packages/shared has no eslint config)
format:    SKIP  (no prettier config in repo)
build:     SKIP  (heavy; tsc --noEmit already covers it)