### PR TITLE
fix(electron/reader): re-fire BOOK_OPENED when fresh book CFI arrives (#226)

### DIFF
--- a/apps/rishi-electron/src/renderer/src/components/epub/EpubView.tsx
+++ b/apps/rishi-electron/src/renderer/src/components/epub/EpubView.tsx
@@ -86,6 +86,7 @@ import { useBookSyncId } from '@/hooks/reader/useBookSyncId'
 import { useReaderMenuSync } from '@/hooks/reader/useReaderMenuSync'
 import { useCommonMenuHandlers } from '@/hooks/reader/useCommonMenuHandlers'
 import { usePageRequestSubscription } from '@/hooks/reader/usePageRequestSubscription'
+import { useEpubNavHistoryLifecycle } from '@/hooks/reader/useEpubNavHistoryLifecycle'
 import { useSelectionStore } from '@/stores/selectionStore'
 import { useUndoableHighlightShortcut } from '@/hooks/useUndoableHighlightShortcut'
 import { findParagraphForCfi } from '@/modules/cfi-to-paragraph'
@@ -967,17 +968,11 @@ export default function EpubView({ book }: { book: Book }): React.JSX.Element {
 
   const setParagraphRendition = useEpubStore((s) => s.setParagraphRendition)
 
-  // Navigation history: lifecycle (BOOK_OPENED / BOOK_CLOSED)
-  useEffect(() => {
-    if (!currentLocation) return
-    navigationHistoryActor.send({
-      type: 'BOOK_OPENED',
-      bookId: String(book.id),
-      initialPosition: { kind: 'epub', cfi: currentLocation }
-    })
-    return () => navigationHistoryActor.send({ type: 'BOOK_CLOSED' })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [book.id])
+  // Navigation history: lifecycle (BOOK_OPENED / BOOK_CLOSED).
+  // Extracted to a hook so the ref-guarded re-fire on first-CFI-arrival
+  // (the fix for #226 — freshly-imported books mount with location = '')
+  // can be unit-tested without booting the whole reader.
+  useEpubNavHistoryLifecycle({ bookId: String(book.id), currentLocation })
 
   // Navigation history: PAGE_VISITED on every location change
   useEffect(() => {

--- a/apps/rishi-electron/src/renderer/src/hooks/reader/__tests__/useEpubNavHistoryLifecycle.test.ts
+++ b/apps/rishi-electron/src/renderer/src/hooks/reader/__tests__/useEpubNavHistoryLifecycle.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+// The lifecycle hook is created in the green-phase commit. Build the specifier
+// from parts so vite's import-analysis can't statically resolve it at transform
+// time — until the hook exists this dynamic import resolves to a
+// module-not-found rejection, which is the expected red-phase failure mode.
+type LifecycleHook = (args: { bookId: string; currentLocation: string }) => void
+
+const HOOK_PATH = '@/hooks/' + 'reader/useEpubNavHistoryLifecycle'
+
+async function loadHook(): Promise<LifecycleHook> {
+  const mod = (await import(/* @vite-ignore */ HOOK_PATH)) as {
+    useEpubNavHistoryLifecycle: LifecycleHook
+  }
+  return mod.useEpubNavHistoryLifecycle
+}
+
+// Stub the actor so we can observe send() calls without booting xstate.
+const sendMock = vi.fn()
+vi.mock('@/machines/navigationHistory/navigationHistoryActor', () => ({
+  navigationHistoryActor: {
+    send: (event: unknown) => sendMock(event)
+  }
+}))
+
+beforeEach(() => {
+  sendMock.mockReset()
+})
+
+describe('useEpubNavHistoryLifecycle — #226 (freshly-imported books)', () => {
+  it('does not dispatch BOOK_OPENED while currentLocation is empty (fresh import, pre-CFI)', async () => {
+    const useEpubNavHistoryLifecycle = await loadHook()
+    renderHook(() => useEpubNavHistoryLifecycle({ bookId: 'b-1', currentLocation: '' }))
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('dispatches BOOK_OPENED once the first real CFI arrives from epubjs', async () => {
+    const useEpubNavHistoryLifecycle = await loadHook()
+    const { rerender } = renderHook(
+      ({ loc }: { loc: string }) =>
+        useEpubNavHistoryLifecycle({ bookId: 'b-1', currentLocation: loc }),
+      { initialProps: { loc: '' } }
+    )
+    expect(sendMock).not.toHaveBeenCalled()
+
+    rerender({ loc: 'epubcfi(/6/4!/4/2/2)' })
+
+    expect(sendMock).toHaveBeenCalledTimes(1)
+    expect(sendMock).toHaveBeenCalledWith({
+      type: 'BOOK_OPENED',
+      bookId: 'b-1',
+      initialPosition: { kind: 'epub', cfi: 'epubcfi(/6/4!/4/2/2)' }
+    })
+  })
+
+  it('does not re-dispatch BOOK_OPENED on subsequent CFI changes for the same book', async () => {
+    const useEpubNavHistoryLifecycle = await loadHook()
+    const { rerender } = renderHook(
+      ({ loc }: { loc: string }) =>
+        useEpubNavHistoryLifecycle({ bookId: 'b-1', currentLocation: loc }),
+      { initialProps: { loc: '' } }
+    )
+    rerender({ loc: 'epubcfi(/6/4!/4/2/2)' })
+    sendMock.mockClear()
+
+    // User pages forward — currentLocation changes again.
+    rerender({ loc: 'epubcfi(/6/4!/4/4/2)' })
+    rerender({ loc: 'epubcfi(/6/6!/4/2/2)' })
+
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('dispatches BOOK_CLOSED on unmount when BOOK_OPENED had fired', async () => {
+    const useEpubNavHistoryLifecycle = await loadHook()
+    const { rerender, unmount } = renderHook(
+      ({ loc }: { loc: string }) =>
+        useEpubNavHistoryLifecycle({ bookId: 'b-1', currentLocation: loc }),
+      { initialProps: { loc: '' } }
+    )
+    rerender({ loc: 'epubcfi(/6/4!/4/2/2)' })
+    sendMock.mockClear()
+
+    unmount()
+
+    expect(sendMock).toHaveBeenCalledWith({ type: 'BOOK_CLOSED' })
+  })
+
+  it('does not dispatch BOOK_CLOSED on unmount when BOOK_OPENED never fired (fresh import, no CFI)', async () => {
+    const useEpubNavHistoryLifecycle = await loadHook()
+    const { unmount } = renderHook(() =>
+      useEpubNavHistoryLifecycle({ bookId: 'b-1', currentLocation: '' })
+    )
+    expect(sendMock).not.toHaveBeenCalled()
+
+    unmount()
+
+    // Sending BOOK_CLOSED to an inactive machine is a no-op functionally,
+    // but firing it when no BOOK_OPENED preceded it would be sloppy. Assert
+    // the hook is well-behaved: no spurious BOOK_CLOSED.
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('resumes existing book: dispatches BOOK_OPENED on first render with a CFI already present', async () => {
+    const useEpubNavHistoryLifecycle = await loadHook()
+    renderHook(() =>
+      useEpubNavHistoryLifecycle({ bookId: 'b-1', currentLocation: 'epubcfi(/6/8!/4/2/2)' })
+    )
+    expect(sendMock).toHaveBeenCalledTimes(1)
+    expect(sendMock).toHaveBeenCalledWith({
+      type: 'BOOK_OPENED',
+      bookId: 'b-1',
+      initialPosition: { kind: 'epub', cfi: 'epubcfi(/6/8!/4/2/2)' }
+    })
+  })
+
+  it('switching to a different bookId fires BOOK_CLOSED then BOOK_OPENED with the new initial CFI', async () => {
+    const useEpubNavHistoryLifecycle = await loadHook()
+    const { rerender } = renderHook(
+      ({ id, loc }: { id: string; loc: string }) =>
+        useEpubNavHistoryLifecycle({ bookId: id, currentLocation: loc }),
+      { initialProps: { id: 'b-1', loc: 'epubcfi(/6/4!/4/2/2)' } }
+    )
+    sendMock.mockClear()
+
+    rerender({ id: 'b-2', loc: 'epubcfi(/6/2!/4/2/2)' })
+
+    // Order matters: close the previous book before opening the new one.
+    expect(sendMock).toHaveBeenNthCalledWith(1, { type: 'BOOK_CLOSED' })
+    expect(sendMock).toHaveBeenNthCalledWith(2, {
+      type: 'BOOK_OPENED',
+      bookId: 'b-2',
+      initialPosition: { kind: 'epub', cfi: 'epubcfi(/6/2!/4/2/2)' }
+    })
+  })
+})

--- a/apps/rishi-electron/src/renderer/src/hooks/reader/useEpubNavHistoryLifecycle.ts
+++ b/apps/rishi-electron/src/renderer/src/hooks/reader/useEpubNavHistoryLifecycle.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from 'react'
+import { navigationHistoryActor } from '@/machines/navigationHistory/navigationHistoryActor'
+
+/**
+ * Drives the BOOK_OPENED / BOOK_CLOSED lifecycle of the navigation-history
+ * state machine for the EPUB reader.
+ *
+ * Why this exists (#226):
+ *   `book.location` is initialised as `''` for freshly-imported books
+ *   (see `main/ipc/formats.ts:129`). PR #222 swapped `||` → `??` on
+ *   EpubView's `useState` initialiser, so on first open the EPUB reader
+ *   mounts with `currentLocation === ''` until epubjs fires its first
+ *   `locationChanged` and seeds a real CFI.
+ *
+ *   The old inline effect had deps `[book.id]` and early-returned when
+ *   `!currentLocation`, so for fresh imports it never dispatched
+ *   `BOOK_OPENED`. The navigation-history machine therefore stayed in
+ *   `inactive` for the entire reader session — the back/forward pill
+ *   was silently disabled until the user closed and reopened the book.
+ *
+ *   The fix re-fires `BOOK_OPENED` once a real CFI arrives. Naively
+ *   adding `currentLocation` to the deps array would re-fire on every
+ *   page turn, which re-runs `hydrateOnOpen`
+ *   (navigationHistoryMachine.ts:27) and resets the stack to empty.
+ *   We therefore split the lifecycle into two effects:
+ *
+ *     1. BOOK_OPENED runs whenever `bookId` or `currentLocation` change,
+ *        guarded by a ref so it dispatches at most once per bookId —
+ *        the first time we observe a non-empty CFI.
+ *     2. BOOK_CLOSED runs only on unmount or genuine bookId change
+ *        (deps `[bookId]`), and only if BOOK_OPENED actually fired for
+ *        that bookId, so we don't emit spurious BOOK_CLOSED events for
+ *        fresh imports that close before epubjs ever reports a CFI.
+ */
+export function useEpubNavHistoryLifecycle({
+  bookId,
+  currentLocation
+}: {
+  bookId: string
+  currentLocation: string
+}): void {
+  // Tracks which bookId we have already announced via BOOK_OPENED so
+  // mid-session CFI changes (page turns, TTS-driven relocateds) do not
+  // re-fire BOOK_OPENED and clobber the navigation-history stack.
+  const openedForBookIdRef = useRef<string | null>(null)
+
+  // Effect 1: BOOK_OPENED. Re-runs on every CFI change so we can catch
+  // the first non-empty CFI for freshly-imported books, but the ref
+  // guard ensures we dispatch exactly once per bookId.
+  useEffect(() => {
+    if (!currentLocation) return
+    if (openedForBookIdRef.current === bookId) return
+
+    openedForBookIdRef.current = bookId
+    navigationHistoryActor.send({
+      type: 'BOOK_OPENED',
+      bookId,
+      initialPosition: { kind: 'epub', cfi: currentLocation }
+    })
+  }, [bookId, currentLocation])
+
+  // Effect 2: BOOK_CLOSED on unmount or bookId change. Suppressed when
+  // BOOK_OPENED was never dispatched for the closing bookId (fresh
+  // import that closed before the first CFI arrived).
+  useEffect(() => {
+    return () => {
+      if (openedForBookIdRef.current === bookId) {
+        navigationHistoryActor.send({ type: 'BOOK_CLOSED' })
+        openedForBookIdRef.current = null
+      }
+    }
+  }, [bookId])
+}


### PR DESCRIPTION
Closes #226.

## Summary
PR #222 swapped `||` → `??` on `EpubView.tsx:112`, but `book.location` is `''` (empty string, not nullish) for freshly-imported books (`main/ipc/formats.ts:129`). The `[book.id]`-keyed lifecycle effect early-returned on `!currentLocation` and did not re-fire when epubjs later seeded a real CFI via `locationChanged`, so `navigationHistoryMachine` stayed in `inactive` for the whole reader session and the back/forward pill was silently disabled until the user closed and reopened the book.

This PR re-fires `BOOK_OPENED` once epubjs writes a real CFI back to `book.location` (around `EpubView.tsx:1078`), so the navigation-history pill works immediately on freshly-imported books — without re-firing on every subsequent page turn (which would clobber the back-stack via `hydrateOnOpen`).

## Implementation
Extracted the EPUB BOOK_OPENED / BOOK_CLOSED lifecycle into a new `useEpubNavHistoryLifecycle` hook so the guard is unit-testable without booting the whole reader. The hook splits the lifecycle into two effects: BOOK_OPENED depends on `[bookId, currentLocation]` and is ref-guarded so it fires at most once per `bookId` (the first time we observe a non-empty CFI); BOOK_CLOSED depends on `[bookId]` and is suppressed when BOOK_OPENED never fired. This removes the previous `eslint-disable react-hooks/exhaustive-deps` — the new dep arrays are honestly exhaustive.

Option A from the issue body, with the obvious naive-version pitfall (per-page-turn `hydrateOnOpen` reset) called out and avoided.

## Testability
TDD — red commit b7d0cee3, green commit 0fc80c84. New test file at `apps/rishi-electron/src/renderer/src/hooks/reader/__tests__/useEpubNavHistoryLifecycle.test.ts` covers: fresh-import no-CFI no-dispatch; first-CFI-arrival exactly one dispatch; subsequent CFI changes no re-dispatch; unmount semantics for both opened and never-opened bookIds; resume case; bookId switch fires close-then-open in order.

## Local CI
typecheck: PASS  (cmd: `pnpm typecheck` — 0 errors)
test:      PASS  (cmd: `pnpm test` — 1425 passed across 158 files)
lint:      PASS  (cmd: `pnpm lint` — 0 errors, 66 pre-existing warnings, none from this PR)
format:    SKIP  (no prettier config in electron)
build:     SKIP  (heavy)