### PR TITLE
fix(mobile/reader/pdf): theme .page-wrapper bg in Dark/Sepia (#231)

### DIFF
--- a/apps/mobile/__tests__/components/reader/pdf-page-wrapper-theme.test.ts
+++ b/apps/mobile/__tests__/components/reader/pdf-page-wrapper-theme.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Issue #231 — PR #230 (issue #47) themed the WebView body background but
+ * the PDF reader's inline `<style>` block in `webview-template.ts`
+ * hardcodes `.page-wrapper { background: #fff }`. In Dark / Sepia themes
+ * the body re-themes, but the white rectangle behind each PDF page stays
+ * bright white — a jarring contrast against the dark surround.
+ *
+ * Acceptance:
+ *   - Each ReaderTheme yields injected CSS that includes a `.page-wrapper`
+ *     rule whose background matches the active theme's `background`.
+ *   - Light theme behaviour stays visually identical (still resolves to
+ *     the theme's `#FFFFFF`).
+ *   - The PDF webview template no longer hardcodes a static
+ *     `background: #fff` on `.page-wrapper` — the injected CSS must win.
+ *
+ * Source-grep is the established pattern for the PDF WebView template
+ * (see `pdf-webview-bridge.test.ts`) — instantiating the HTML/JS inside
+ * Jest would require a real DOM + pdfjs runtime. Pinning the hardcoded
+ * literal at the source level is the cheapest way to catch a regression
+ * that re-introduces the white rectangle.
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+import { READER_THEMES } from '../../../constants/reader-themes'
+import type { ThemeName } from '../../../types/book'
+
+const MOBILE_ROOT = join(__dirname, '..', '..', '..')
+
+const THEME_NAMES: ThemeName[] = ['white', 'dark', 'yellow']
+
+describe('Issue #231 — PDF .page-wrapper background follows the active theme', () => {
+  describe('shared reader-theme CSS helper', () => {
+    let buildReaderThemeCss: (theme: (typeof READER_THEMES)[ThemeName]) => string
+
+    beforeAll(async () => {
+      const mod = await import('../../../lib/reader-theme-css')
+      buildReaderThemeCss = mod.buildReaderThemeCss
+    })
+
+    it.each(THEME_NAMES)(
+      'emits a .page-wrapper rule using the %s theme background',
+      (name) => {
+        const theme = READER_THEMES[name]
+        const css = buildReaderThemeCss(theme)
+        // Must mention `.page-wrapper` as a selector and carry the
+        // theme's background literal somewhere in the same stylesheet —
+        // proving that a theme toggle visibly re-paints the wrapper.
+        expect(css).toMatch(/\.page-wrapper\b/)
+        // The same generated CSS must reference the theme's background
+        // colour. We deliberately use a substring assertion (not a
+        // strict-equality regex) so the helper is free to render the
+        // rule with !important, additional declarations, or surrounding
+        // whitespace — the contract is "wrapper uses the theme colour",
+        // not a particular formatter style.
+        const wrapperRule = css
+          .split('\n')
+          .find((line) => /\.page-wrapper\b/.test(line))
+        expect(wrapperRule).toBeDefined()
+        expect(wrapperRule).toContain(theme.background)
+      },
+    )
+
+    it('does not leak the light background into the dark stylesheet', () => {
+      const dark = buildReaderThemeCss(READER_THEMES.dark)
+      // The pre-fix template used `#fff` as the static wrapper colour;
+      // pin that it no longer appears in the dark stylesheet so a future
+      // refactor can't quietly re-introduce the bright rectangle.
+      expect(dark).not.toMatch(/#fff\b/i)
+      expect(dark).not.toMatch(/#ffffff\b/i)
+    })
+  })
+
+  describe('PDF webview template', () => {
+    const TEMPLATE_PATH = join(
+      MOBILE_ROOT,
+      'components',
+      'pdf',
+      'webview-template.ts',
+    )
+    const src = readFileSync(TEMPLATE_PATH, 'utf-8')
+
+    it('does not hardcode a static background:#fff on .page-wrapper', () => {
+      // The bug: an inline `<style>` rule like
+      //   `.page-wrapper { ...; background: #fff; ... }`
+      // wins over the injected stylesheet whenever the latter omits the
+      // selector. Strip whitespace before matching so a reformatter
+      // (single-line vs. multi-line declaration block) can't sneak the
+      // hardcoded literal back in.
+      const stripped = src.replace(/\s+/g, ' ')
+      // Match any `.page-wrapper { ... background: #fff ... }` declaration
+      // block — `[^}]*` keeps the assertion inside a single rule body.
+      const offendingRule = /\.page-wrapper\s*\{[^}]*background\s*:\s*#fff\b[^}]*\}/i
+      expect(stripped).not.toMatch(offendingRule)
+    })
+  })
+})

--- a/apps/mobile/components/pdf/webview-template.ts
+++ b/apps/mobile/components/pdf/webview-template.ts
@@ -30,8 +30,13 @@ export const PDF_READER_HTML = `<!DOCTYPE html>
     -webkit-user-select: text; -webkit-touch-callout: default; }
   #status { padding: 12px; font-size: 13px; }
   #pages { padding: 8px 0 64px 0; }
+  /* Issue #231 — wrapper background is themed at runtime via
+     buildReaderThemeCss / buildReaderThemeInjection. Leaving a static
+     #fff here reintroduces the bright rectangle in Dark/Sepia mode
+     because the inline rule would shadow the injected one on the
+     initial load. */
   .page-wrapper { position: relative; margin: 8px auto;
-    background: #fff; box-shadow: 0 1px 6px rgba(0,0,0,0.6); }
+    box-shadow: 0 1px 6px rgba(0,0,0,0.6); }
   .page-canvas { display: block; width: 100%; height: auto; }
   .text-layer { position: absolute; inset: 0; line-height: 1;
     overflow: hidden; pointer-events: auto; }

--- a/apps/mobile/lib/reader-theme-css.ts
+++ b/apps/mobile/lib/reader-theme-css.ts
@@ -63,6 +63,16 @@ export function buildReaderThemeCss(theme: ReaderTheme): string {
     `html, body { background: ${bg} !important; color: ${fg} !important; }`,
     // pdfjs viewer chrome — keep page chrome consistent with body.
     `#viewerContainer, .pdfViewer { background: ${bg} !important; }`,
+    // Issue #231 — the custom PDF WebView template (components/pdf/
+    // webview-template.ts) renders each pdfjs page inside a
+    // `.page-wrapper` div. Its inline stylesheet previously hardcoded
+    // `background: #fff`, leaving a bright rectangle around every page
+    // in Dark / Sepia mode. Routing the wrapper background through the
+    // active theme keeps the page surround consistent with the body.
+    // pdfjs paints the actual page content onto a canvas, so the
+    // wrapper colour only shows in the gutters and before-render
+    // moments — exactly the surface that needs to follow the theme.
+    `.page-wrapper { background: ${bg} !important; }`,
     // MOBI parser content wrapper.
     `#content, #content * { color: ${fg} !important; }`,
     `#content a { color: ${fg} !important; }`,


### PR DESCRIPTION
Closes #231.

## Summary
PR #230 themed the body background but the PDF reader's `webview-template.ts` hardcoded `.page-wrapper { background: #fff }`, leaving a bright white rectangle around each PDF page in Dark/Sepia modes. This routes the wrapper bg through `buildReaderThemeCss` so it follows the active theme.

## Implementation
Two minimal edits in series:

1. `apps/mobile/lib/reader-theme-css.ts` — `buildReaderThemeCss` now emits an extra `.page-wrapper { background: <theme.background> !important; }` rule. Reusing `theme.background` (rather than introducing a new surface token) keeps the wrapper consistent with the body for every theme — exactly what the issue's acceptance criteria call for (blends with the dark body in Dark mode, sepia-tinted in Sepia, unchanged white in Light).
2. `apps/mobile/components/pdf/webview-template.ts` — the inline `<style>` block no longer hardcodes `background: #fff` on `.page-wrapper`. The injected stylesheet wins via `!important` regardless, but stripping the literal also means the initial load (before the first `injectJavaScript` round-trip) inherits the body colour instead of flashing white. pdfjs renders the actual page CONTENT to a canvas, so the wrapper colour only shows in the gutters and before-render moments — exactly the surface that needs to follow the theme.

## Testability
TDD — red commit 1c3b88d3, green commit 2993a007.

New `__tests__/components/reader/pdf-page-wrapper-theme.test.ts` covers:
- For each `ThemeName` (`white`/`dark`/`yellow`), the CSS produced by `buildReaderThemeCss` contains a `.page-wrapper` rule whose declaration block embeds the theme's `background` literal.
- The dark stylesheet must not contain `#fff` / `#ffffff` (regression pin against re-introducing the hardcoded literal).
- The PDF webview template source no longer contains a `.page-wrapper { ... background: #fff ... }` declaration block (whitespace-insensitive match).

All existing tests in `webview-theme-injection.test.ts` (PR #230) still pass.

## Local CI
```
typecheck: PASS  (cmd: ./node_modules/.bin/tsc --noEmit -p tsconfig.json) — 0 errors in changed files; pre-existing errors in packages/shared/voice-chat & unrelated test files predate this branch
test:      PASS  (cmd: ./node_modules/.bin/jest __tests__/components/reader/ __tests__/pdf/pdf-webview-bridge.test.ts) — 28 suites, 243 tests
lint:      PASS  (cmd: pnpm run lint) — 0 errors, 20 pre-existing warnings (none in changed files)
format:    SKIP  (no prettier config)
build:     SKIP  (heavy)
```