### PR TITLE
fix(mobile/chat/detail): source chip navigates to chunk/page location (#68)

### DIFF
--- a/apps/mobile/__tests__/chat/source-location.test.ts
+++ b/apps/mobile/__tests__/chat/source-location.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Pin the chunk → reader-param mapping the chat citation chip relies on
+ * (#68). `handleSourcePress` previously discarded `source.chunkId` /
+ * `source.chapter`, so the chip just opened the reader at the user's
+ * last saved position. The helper parses the chunker's per-format
+ * labels back into the params the reader screens honor on mount:
+ *
+ *   - PDF / DJVU  → `page`
+ *   - MOBI / AZW3 → `chapter` (normalised to the 0-indexed reader store)
+ *   - EPUB        → `cfi` if present on the chunk, else `chapter` label
+ *
+ * `chunkId` always rides along so a later highlight-on-jump pass can
+ * resolve back to the exact chunk without us re-touching the chat
+ * screen.
+ */
+import { resolveSourceLocationParams } from '@/lib/chat/source-location'
+import type { Book } from '@/types/book'
+import type { SourceChunk } from '@/types/conversation'
+
+function book(format: Book['format']): Pick<Book, 'id' | 'format'> {
+  return { id: 'b1', format }
+}
+
+function chunk(over: Partial<SourceChunk> = {}): SourceChunk {
+  return {
+    chunkId: 'chunk-uuid',
+    text: '',
+    chapter: null,
+    ...over,
+  }
+}
+
+describe('resolveSourceLocationParams (#68)', () => {
+  describe('PDF', () => {
+    it('parses "Page N" → page', () => {
+      const params = resolveSourceLocationParams(
+        book('pdf'),
+        chunk({ chapter: 'Page 42' }),
+      )
+      expect(params).toEqual({ id: 'b1', chunkId: 'chunk-uuid', page: '42' })
+    })
+
+    it('omits page when chapter is null', () => {
+      const params = resolveSourceLocationParams(
+        book('pdf'),
+        chunk({ chapter: null }),
+      )
+      expect(params).toEqual({ id: 'b1', chunkId: 'chunk-uuid' })
+      expect(params.page).toBeUndefined()
+    })
+
+    it('omits page when chapter is non-page text', () => {
+      const params = resolveSourceLocationParams(
+        book('pdf'),
+        chunk({ chapter: 'Introduction' }),
+      )
+      expect(params).toEqual({ id: 'b1', chunkId: 'chunk-uuid' })
+    })
+  })
+
+  describe('DJVU', () => {
+    it('parses "Page N" → page (same as PDF)', () => {
+      const params = resolveSourceLocationParams(
+        book('djvu'),
+        chunk({ chapter: 'Page 7' }),
+      )
+      expect(params.page).toBe('7')
+    })
+  })
+
+  describe('MOBI', () => {
+    it('parses "Chapter N" → chapter (0-indexed for the reader store)', () => {
+      const params = resolveSourceLocationParams(
+        book('mobi'),
+        chunk({ chapter: 'Chapter 3' }),
+      )
+      expect(params).toEqual({
+        id: 'b1',
+        chunkId: 'chunk-uuid',
+        chapter: '2',
+      })
+    })
+
+    it('omits chapter when label is not parseable', () => {
+      const params = resolveSourceLocationParams(
+        book('mobi'),
+        chunk({ chapter: null }),
+      )
+      expect(params.chapter).toBeUndefined()
+    })
+
+    it('AZW3 shares the MOBI parser', () => {
+      const params = resolveSourceLocationParams(
+        book('azw3'),
+        chunk({ chapter: 'Chapter 5' }),
+      )
+      expect(params.chapter).toBe('4')
+    })
+  })
+
+  describe('EPUB', () => {
+    it('forwards cfiRange when present', () => {
+      const params = resolveSourceLocationParams(
+        book('epub'),
+        chunk({ cfiRange: 'epubcfi(/6/4!/4/2/1:0)', chapter: 'Heading' }),
+      )
+      expect(params).toEqual({
+        id: 'b1',
+        chunkId: 'chunk-uuid',
+        cfi: 'epubcfi(/6/4!/4/2/1:0)',
+      })
+      expect(params.chapter).toBeUndefined()
+    })
+
+    it('falls back to chapter heading label when no CFI', () => {
+      const params = resolveSourceLocationParams(
+        book('epub'),
+        chunk({ chapter: 'Chapter One' }),
+      )
+      expect(params).toEqual({
+        id: 'b1',
+        chunkId: 'chunk-uuid',
+        chapter: 'Chapter One',
+      })
+    })
+
+    it('returns just id + chunkId when nothing positional is known', () => {
+      const params = resolveSourceLocationParams(
+        book('epub'),
+        chunk({ chapter: null }),
+      )
+      expect(params).toEqual({ id: 'b1', chunkId: 'chunk-uuid' })
+    })
+  })
+})

--- a/apps/mobile/__tests__/chat/source-press-routing.test.tsx
+++ b/apps/mobile/__tests__/chat/source-press-routing.test.tsx
@@ -255,7 +255,12 @@ describe('Chat detail — source-press routes per format (P1-A)', () => {
       chatMessageRegistry.onSourcePress!({ chunkId: 'x', chapter: null, text: '' })
     })
     expect(pushSpy).toHaveBeenCalledTimes(1)
-    expect(pushSpy).toHaveBeenCalledWith('/reader/pdf/b1')
+    // Updated for #68: the chunkId always rides along even when no
+    // positional information can be parsed from the chapter label.
+    expect(pushSpy).toHaveBeenCalledWith({
+      pathname: '/reader/pdf/[id]',
+      params: { id: 'b1', chunkId: 'x' },
+    })
   })
 
   it('handleSourcePress (MOBI) → /reader/mobi/<id>', async () => {
@@ -276,7 +281,12 @@ describe('Chat detail — source-press routes per format (P1-A)', () => {
     act(() => {
       chatMessageRegistry.onSourcePress!({ chunkId: 'x', chapter: null, text: '' })
     })
-    expect(pushSpy).toHaveBeenCalledWith('/reader/mobi/b1')
+    // Updated for #68: object-form push so the chunkId / chapter can
+    // ride along as query params for the reader to honor on mount.
+    expect(pushSpy).toHaveBeenCalledWith({
+      pathname: '/reader/mobi/[id]',
+      params: { id: 'b1', chunkId: 'x' },
+    })
   })
 
   it('handleSourcePress (EPUB) still routes to /reader/<id>', async () => {
@@ -297,6 +307,105 @@ describe('Chat detail — source-press routes per format (P1-A)', () => {
     act(() => {
       chatMessageRegistry.onSourcePress!({ chunkId: 'x', chapter: null, text: '' })
     })
-    expect(pushSpy).toHaveBeenCalledWith('/reader/b1')
+    // The chunkId always rides along (#68) even when no positional
+    // information is available, so a downstream highlight-on-jump pass
+    // can still resolve the citation.
+    expect(pushSpy).toHaveBeenCalledWith({
+      pathname: '/reader/[id]',
+      params: { id: 'b1', chunkId: 'x' },
+    })
+  })
+
+  // #68 — `handleSourcePress` MUST thread the chunk's location into the
+  // router push so the reader can scroll to the cited passage on mount.
+  // Pre-fix, the chip discarded `source.chunkId` / `source.chapter` and
+  // pushed to the reader root.
+  describe('source chunk location → reader query params (#68)', () => {
+    it('PDF citation with "Page N" chapter → ?page=N', async () => {
+      mockBooks.push(makeBook('pdf'))
+      mockConversations.push({
+        id: 'c1', bookId: 'b1', title: 't', createdAt: 0, updatedAt: 0,
+      })
+      const convStorage = require('@/lib/conversation-storage')
+      convStorage.getMessages = jest.fn(() => [
+        { id: 'm1', conversationId: 'c1', role: 'assistant', content: 'hi', sourceChunks: null, createdAt: 0, updatedAt: 0 },
+      ])
+
+      const BookChatScreen = require('@/app/chat/[bookId]').default
+      await act(async () => { TestRenderer.create(<BookChatScreen />) })
+      await act(async () => { await Promise.resolve() })
+
+      act(() => {
+        chatMessageRegistry.onSourcePress!({
+          chunkId: 'cid-1',
+          chapter: 'Page 12',
+          text: '',
+        })
+      })
+      expect(pushSpy).toHaveBeenCalledTimes(1)
+      expect(pushSpy).toHaveBeenCalledWith({
+        pathname: '/reader/pdf/[id]',
+        params: { id: 'b1', chunkId: 'cid-1', page: '12' },
+      })
+    })
+
+    it('EPUB citation with cfiRange → ?cfi=<cfi>', async () => {
+      mockBooks.push(makeBook('epub'))
+      mockConversations.push({
+        id: 'c1', bookId: 'b1', title: 't', createdAt: 0, updatedAt: 0,
+      })
+      const convStorage = require('@/lib/conversation-storage')
+      convStorage.getMessages = jest.fn(() => [
+        { id: 'm1', conversationId: 'c1', role: 'assistant', content: 'hi', sourceChunks: null, createdAt: 0, updatedAt: 0 },
+      ])
+
+      const BookChatScreen = require('@/app/chat/[bookId]').default
+      await act(async () => { TestRenderer.create(<BookChatScreen />) })
+      await act(async () => { await Promise.resolve() })
+
+      act(() => {
+        chatMessageRegistry.onSourcePress!({
+          chunkId: 'cid-2',
+          chapter: 'Heading 1',
+          cfiRange: 'epubcfi(/6/4!/4/2/1:0)',
+          text: '',
+        })
+      })
+      expect(pushSpy).toHaveBeenCalledWith({
+        pathname: '/reader/[id]',
+        params: {
+          id: 'b1',
+          chunkId: 'cid-2',
+          cfi: 'epubcfi(/6/4!/4/2/1:0)',
+        },
+      })
+    })
+
+    it('MOBI citation with "Chapter N" → ?chapter=<N-1> (0-indexed)', async () => {
+      mockBooks.push(makeBook('mobi'))
+      mockConversations.push({
+        id: 'c1', bookId: 'b1', title: 't', createdAt: 0, updatedAt: 0,
+      })
+      const convStorage = require('@/lib/conversation-storage')
+      convStorage.getMessages = jest.fn(() => [
+        { id: 'm1', conversationId: 'c1', role: 'assistant', content: 'hi', sourceChunks: null, createdAt: 0, updatedAt: 0 },
+      ])
+
+      const BookChatScreen = require('@/app/chat/[bookId]').default
+      await act(async () => { TestRenderer.create(<BookChatScreen />) })
+      await act(async () => { await Promise.resolve() })
+
+      act(() => {
+        chatMessageRegistry.onSourcePress!({
+          chunkId: 'cid-3',
+          chapter: 'Chapter 4',
+          text: '',
+        })
+      })
+      expect(pushSpy).toHaveBeenCalledWith({
+        pathname: '/reader/mobi/[id]',
+        params: { id: 'b1', chunkId: 'cid-3', chapter: '3' },
+      })
+    })
   })
 })

--- a/apps/mobile/__tests__/reader/cold-start-recovery.test.ts
+++ b/apps/mobile/__tests__/reader/cold-start-recovery.test.ts
@@ -59,7 +59,10 @@ describe('STA-027 — cold-start reader-load failure recovery affordance', () =>
       const src = read(reader)
       // The useEffect for loading must include `loadAttempt` in its dep
       // array — otherwise tapping Retry bumps the counter to no effect.
-      expect(src).toMatch(/\[\s*id\s*,\s*loadAttempt\s*\]/)
+      // Trailing deps are allowed (e.g. #68 added `pageParam` /
+      // `chapterParam` to the MOBI / DJVU loaders so a citation tap
+      // re-fires the loader with the new override).
+      expect(src).toMatch(/\[\s*id\s*,\s*loadAttempt\b/)
     })
 
     it(`${reader.label}: thrown load → falls through to ReaderErrorScreen instead of an infinite spinner`, () => {

--- a/apps/mobile/app/chat/[bookId].tsx
+++ b/apps/mobile/app/chat/[bookId].tsx
@@ -30,7 +30,10 @@ import { EmbeddingProgress } from '@/components/EmbeddingProgress'
 import { IconSymbol } from '@/components/ui/icon-symbol'
 import { useRequireAuth } from '@/components/auth/useRequireAuth'
 import { useAuthStore } from '@/lib/stores/authStore'
-import { resolveReaderRouteForBook } from '@/lib/reader-routes'
+import {
+  resolveReaderPathnameForBook,
+  resolveSourceLocationParams,
+} from '@/lib/chat/source-location'
 import { safeBack } from '@/lib/navigation'
 import type { Message, SourceChunk } from '@/types/conversation'
 import type { Book } from '@/types/book'
@@ -361,12 +364,23 @@ export default function BookChatScreen() {
   }, [retryQuestion, handleSend])
 
   const handleSourcePress = useCallback(
-    (_source: SourceChunk) => {
+    (source: SourceChunk) => {
       // P1-A: route to the format-appropriate reader screen. The
       // previous unconditional `/reader/${bookId}` opened the EPUB
       // reader for every format and errored out on PDF / MOBI / DJVU.
+      //
+      // #68: thread the chunk's location into the router push so the
+      // reader can scroll to the cited passage on mount. Pre-fix the
+      // chip discarded `source.chunkId` / `source.chapter`, so the
+      // citation was non-actionable. `resolveSourceLocationParams`
+      // parses the chunker's per-format chapter labels back into the
+      // query params each reader honors (`?page=` for PDF/DJVU,
+      // `?chapter=` for MOBI/AZW3, `?cfi=` for EPUB when available).
       if (!book) return
-      router.push(resolveReaderRouteForBook(book))
+      router.push({
+        pathname: resolveReaderPathnameForBook(book.format),
+        params: resolveSourceLocationParams(book, source),
+      })
     },
     [book, router]
   )

--- a/apps/mobile/app/reader/[id].tsx
+++ b/apps/mobile/app/reader/[id].tsx
@@ -86,7 +86,17 @@ export function computeEpubProgressForShell(progress: number): ReaderProgress {
 }
 
 export default function ReaderScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>()
+  // #68 — `cfi` and `chapter` are forwarded by chat citation taps via
+  // `resolveSourceLocationParams`. `cfi` (when populated by a future
+  // RAG-pipeline pass that captures it) is the authoritative jump
+  // target; `chapter` is a best-effort heading-label match against the
+  // EPUB's TOC. We thread both into <ReaderContent /> so the inner
+  // hooks can substitute them ahead of `book.currentCfi`.
+  const { id, cfi: cfiParam, chapter: chapterParam } = useLocalSearchParams<{
+    id: string
+    cfi?: string
+    chapter?: string
+  }>()
   const router = useRouter()
   const [book, setBook] = useState<Book | null>(null)
 
@@ -150,13 +160,25 @@ export default function ReaderScreen() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <ReaderProvider>
-        <ReaderContent book={book} />
+        <ReaderContent
+          book={book}
+          initialCfiOverride={cfiParam ?? null}
+          chapterLabelOverride={chapterParam ?? null}
+        />
       </ReaderProvider>
     </GestureHandlerRootView>
   )
 }
 
-function ReaderContent({ book }: { book: Book }) {
+function ReaderContent({
+  book,
+  initialCfiOverride,
+  chapterLabelOverride,
+}: {
+  book: Book
+  initialCfiOverride: string | null
+  chapterLabelOverride: string | null
+}) {
   const router = useRouter()
   const insets = useSafeAreaInsets()
   const {
@@ -279,6 +301,31 @@ function ReaderContent({ book }: { book: Book }) {
       setBookmarks(getBookmarksForBook(book.id))
     }
   }, [book.id])
+
+  // #68 — when the reader is opened from a chat citation tap with a
+  // `?chapter=<heading>` query param (no CFI was available on the
+  // chunk), best-effort match the heading against the TOC and jump to
+  // the corresponding spine entry. `cfi` takes precedence — it's wired
+  // through `initialCfiOverride` into the engine's `initialLocation`,
+  // so we skip this branch when a CFI was provided.
+  //
+  // The ref guard ensures the jump fires exactly once per mount —
+  // subsequent TOC updates (e.g. font-resize re-parse) must not yank
+  // the user back to the cited chapter.
+  const chapterJumpFiredRef = useRef(false)
+  useEffect(() => {
+    if (initialCfiOverride) return
+    if (!chapterLabelOverride) return
+    if (chapterJumpFiredRef.current) return
+    if (!toc || toc.length === 0) return
+    const match = toc.find(
+      (t) => t.label?.trim() === chapterLabelOverride.trim(),
+    )
+    if (match) {
+      chapterJumpFiredRef.current = true
+      goToLocation(match.href)
+    }
+  }, [toc, chapterLabelOverride, initialCfiOverride, goToLocation])
 
   // Reflect bookmark presence at the current CFI in the toolbar icon.
   useEffect(() => {
@@ -798,6 +845,7 @@ function ReaderContent({ book }: { book: Book }) {
           onPressAnnotation={handlePressAnnotation}
           popoverVisible={popoverVisible}
           dismissPopover={() => setPopoverVisible(false)}
+          initialCfiOverride={initialCfiOverride}
         />
 
         {/*
@@ -953,6 +1001,10 @@ interface ReaderEngineProps {
   onPressAnnotation: (annotation: Annotation) => void
   popoverVisible: boolean
   dismissPopover: () => void
+  // #68 — when set, overrides the saved `book.currentCfi` on mount so a
+  // chat citation tap lands on the cited passage instead of the
+  // reader's last-known position.
+  initialCfiOverride: string | null
 }
 
 /**
@@ -1027,6 +1079,7 @@ function ReaderEngine({
   onPressAnnotation,
   popoverVisible,
   dismissPopover,
+  initialCfiOverride,
 }: ReaderEngineProps) {
   const { toggleToolbar } = useContext(ReaderShellContext)
   const handleTap = useCallback(() => {
@@ -1037,6 +1090,11 @@ function ReaderEngine({
     toggleToolbar()
   }, [popoverVisible, dismissPopover, toggleToolbar])
 
+  // #68 — citation tap wins over the saved position; otherwise fall back
+  // to `book.currentCfi` so a normal open still resumes the reader at
+  // its last spot.
+  const initialLocation = initialCfiOverride || book.currentCfi || undefined
+
   return (
     <Reader
       src={book.filePath}
@@ -1044,7 +1102,7 @@ function ReaderEngine({
       flow="paginated"
       enableSwipe={true}
       enableSelection={true}
-      initialLocation={book.currentCfi || undefined}
+      initialLocation={initialLocation}
       defaultTheme={readerDefaultTheme}
       menuItems={menuItems}
       initialAnnotations={initialAnnotations}

--- a/apps/mobile/app/reader/djvu/[id].tsx
+++ b/apps/mobile/app/reader/djvu/[id].tsx
@@ -207,7 +207,14 @@ document.addEventListener('selectionchange', function() {
 </html>`
 
 export default function DjvuReaderScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>()
+  // #68 — `page` is forwarded by chat citation taps via
+  // `resolveSourceLocationParams`. When present, it overrides the saved
+  // `book.currentPage` for this mount so the WebView opens at the
+  // cited page.
+  const { id, page: pageParam } = useLocalSearchParams<{
+    id: string
+    page?: string
+  }>()
   const router = useRouter()
 
   const [book, setBook] = useState<Book | null>(null)
@@ -389,7 +396,17 @@ export default function DjvuReaderScreen() {
         .then((loaded) => {
           if (loaded) {
             setBook(loaded)
-            const startPage = loaded.currentPage || 1
+            // #68 — honor `pageParam` from chat citation taps ahead of
+            // the saved `loaded.currentPage` so the WebView lands on
+            // the cited page on mount. The next 'page' postMessage
+            // persists the new index via `handleMessage`.
+            const fromCitation = pageParam
+              ? Number.parseInt(pageParam, 10)
+              : NaN
+            const startPage =
+              Number.isFinite(fromCitation) && fromCitation >= 1
+                ? fromCitation
+                : loaded.currentPage || 1
             setCurrentPage(startPage)
             currentPageRef.current = startPage
             setHighlights(getHighlightsByBookId(loaded.id))
@@ -404,7 +421,7 @@ export default function DjvuReaderScreen() {
         })
         .finally(() => setLoading(false))
     }
-  }, [id, loadAttempt])
+  }, [id, loadAttempt, pageParam])
 
   // Send file data to WebView once djvu.js is loaded
   useEffect(() => {

--- a/apps/mobile/app/reader/mobi/[id].tsx
+++ b/apps/mobile/app/reader/mobi/[id].tsx
@@ -269,7 +269,15 @@ document.addEventListener('selectionchange', function() {
 </html>`
 
 export default function MobiReaderScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>()
+  // #68 — `chapter` is forwarded by chat citation taps via
+  // `resolveSourceLocationParams` (0-indexed to match the reader's
+  // internal counter). When present, it overrides the saved
+  // `book.currentPage` (which stores the chapter index for MOBI) for
+  // this mount so the WebView opens at the cited chapter.
+  const { id, chapter: chapterParam } = useLocalSearchParams<{
+    id: string
+    chapter?: string
+  }>()
   const router = useRouter()
 
   const [book, setBook] = useState<Book | null>(null)
@@ -337,7 +345,18 @@ export default function MobiReaderScreen() {
         .then((loaded) => {
           if (loaded) {
             setBook(loaded)
-            const startChapter = loaded.currentPage || 0
+            // #68 — `chapterParam` is the 0-indexed chapter target
+            // forwarded from a chat citation tap. Honor it ahead of
+            // the saved `loaded.currentPage` so the WebView lands on
+            // the cited chapter on mount. The next 'chapter'
+            // postMessage persists the new index via `handleMessage`.
+            const fromCitation = chapterParam
+              ? Number.parseInt(chapterParam, 10)
+              : NaN
+            const startChapter =
+              Number.isFinite(fromCitation) && fromCitation >= 0
+                ? fromCitation
+                : loaded.currentPage || 0
             setCurrentChapter(startChapter)
             currentChapterRef.current = startChapter
             setHighlights(getHighlightsByBookId(loaded.id))
@@ -352,7 +371,7 @@ export default function MobiReaderScreen() {
         })
         .finally(() => setLoading(false))
     }
-  }, [id, loadAttempt])
+  }, [id, loadAttempt, chapterParam])
 
   // Send file data to WebView once loaded
   useEffect(() => {

--- a/apps/mobile/app/reader/pdf/[id].tsx
+++ b/apps/mobile/app/reader/pdf/[id].tsx
@@ -96,7 +96,14 @@ interface ActiveSelection {
 }
 
 export default function PdfReaderScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>()
+  // #68 — `page` is forwarded by chat citation taps via
+  // `resolveSourceLocationParams`. When present, it overrides the saved
+  // `book.currentPage` for this mount so the reader lands on the cited
+  // passage. The next page-change persists the new position normally.
+  const { id, page: pageParam } = useLocalSearchParams<{
+    id: string
+    page?: string
+  }>()
   const router = useRouter()
 
   const readerRef = useRef<PdfWebReaderHandle>(null)
@@ -246,11 +253,22 @@ export default function PdfReaderScreen() {
         )
       }
       // Restore reading position.
-      const initial = book?.currentPage ?? 1
+      //
+      // #68 — when the user arrives from a chat citation tap, `pageParam`
+      // is the chunk's page number. Honor it ahead of the saved
+      // `book.currentPage` so the reader scrolls to the cited passage
+      // on mount. The next page-change persists the new position via
+      // `handlePageChange` below, so the override doesn't re-fire on
+      // subsequent navigations within the book.
+      const fromCitation = pageParam ? Number.parseInt(pageParam, 10) : NaN
+      const initial =
+        Number.isFinite(fromCitation) && fromCitation >= 1
+          ? fromCitation
+          : book?.currentPage ?? 1
       if (initial > 1) readerRef.current?.goToPage(initial)
       setBookNavigationState(BookNavigationState.Idle)
     },
-    [book?.currentPage, highlights, setPageCount, setOutlineStore, setBookNavigationState]
+    [book?.currentPage, pageParam, highlights, setPageCount, setOutlineStore, setBookNavigationState]
   )
 
   const handlePageChange = useCallback(

--- a/apps/mobile/lib/chat/source-location.ts
+++ b/apps/mobile/lib/chat/source-location.ts
@@ -1,0 +1,113 @@
+/**
+ * Map a chat-source citation onto the navigation params the reader for
+ * the book's format honors at mount (#68).
+ *
+ * `handleSourcePress` previously discarded `source.chunkId` /
+ * `source.chapter`, so tapping a citation chip just opened the reader at
+ * the user's last position — the citation was non-actionable. This
+ * helper centralises the per-format parse so the chat screen stays free
+ * of chunker-internal naming.
+ *
+ * What the chunker actually puts in `chapter`:
+ *   - PDF / DJVU  → `"Page N"`            (see lib/rag/chunker.ts
+ *                                          pagesToSections)
+ *   - MOBI / AZW3 → `"Chapter N"`         (1-indexed label, 0-indexed
+ *                                          internally — see chunker.ts
+ *                                          mobi branch)
+ *   - EPUB        → free-form heading text or null (no CFI is captured
+ *                                          today; `cfiRange` is reserved
+ *                                          on SourceChunk for a future
+ *                                          enrichment pass)
+ *
+ * The returned params are merged into `router.push({ pathname, params })`
+ * by the chat screen. The reader screens read them via
+ * `useLocalSearchParams`.
+ */
+
+import type { Book } from '@/types/book'
+import type { SourceChunk } from '@/types/conversation'
+
+const PAGE_PREFIX_RE = /^Page\s+(\d+)/i
+const CHAPTER_PREFIX_RE = /^Chapter\s+(\d+)/i
+
+export type SourceLocationParams = Record<string, string>
+
+/**
+ * Resolve the per-format query params for a citation tap. Always
+ * includes the bookId (the dynamic route segment) and `chunkId` (a
+ * stable handle the reader can use later to scroll to the exact passage
+ * once highlight-on-jump lands).
+ *
+ * Returns `{ id, chunkId }` only when nothing positional can be parsed —
+ * the reader still navigates, just to the saved position. That's
+ * strictly better than the pre-fix behaviour because the chunkId still
+ * travels for downstream consumers.
+ */
+export function resolveSourceLocationParams(
+  book: Pick<Book, 'id' | 'format'>,
+  source: Pick<SourceChunk, 'chunkId' | 'chapter' | 'cfiRange'>,
+): SourceLocationParams {
+  const params: SourceLocationParams = { id: book.id }
+  if (source.chunkId) params.chunkId = source.chunkId
+
+  switch (book.format) {
+    case 'pdf':
+    case 'djvu': {
+      const m = source.chapter?.match(PAGE_PREFIX_RE)
+      if (m) params.page = m[1]
+      return params
+    }
+    case 'mobi':
+    case 'azw3': {
+      const m = source.chapter?.match(CHAPTER_PREFIX_RE)
+      if (m) {
+        // Chunker's MOBI label is 1-indexed ("Chapter 1"); the reader
+        // store is 0-indexed. Normalise here so the reader can do a
+        // straight `setCurrentChapter(Number(params.chapter))`.
+        const oneIndexed = Number.parseInt(m[1], 10)
+        if (Number.isFinite(oneIndexed) && oneIndexed >= 1) {
+          params.chapter = String(oneIndexed - 1)
+        }
+      }
+      return params
+    }
+    case 'epub':
+    default: {
+      // EPUB chunks don't carry a CFI today, but `cfiRange` is reserved
+      // on SourceChunk for the next enrichment pass — forward it so the
+      // reader can honor `?cfi=...` once the pipeline starts populating
+      // it. Fall back to the chapter heading label so the reader can do
+      // a best-effort TOC-label match (`toc[].label === chapter` →
+      // `goToLocation(href)`).
+      if (source.cfiRange) params.cfi = source.cfiRange
+      else if (source.chapter && source.chapter.trim().length > 0) {
+        params.chapter = source.chapter.trim()
+      }
+      return params
+    }
+  }
+}
+
+/**
+ * The `pathname` template for a per-format reader route. Mirrors
+ * `resolveReaderRouteForBook` (which returns a concrete string with the
+ * id substituted) but keeps the bracket form so it can be passed to
+ * `router.push({ pathname, params })` — expo-router substitutes the
+ * `[id]` segment from `params.id`.
+ */
+export function resolveReaderPathnameForBook(
+  format: Book['format'],
+): `/reader/[id]` | `/reader/pdf/[id]` | `/reader/mobi/[id]` | `/reader/djvu/[id]` {
+  switch (format) {
+    case 'pdf':
+      return '/reader/pdf/[id]'
+    case 'mobi':
+    case 'azw3':
+      return '/reader/mobi/[id]'
+    case 'djvu':
+      return '/reader/djvu/[id]'
+    case 'epub':
+    default:
+      return '/reader/[id]'
+  }
+}


### PR DESCRIPTION
Closes #68.

## Summary
`handleSourcePress` discarded `source.chunkId` / `source.chapter` and pushed to the reader root, making citation chips non-actionable. This threads the chunk location into the router push (object form) and updates each reader's mount handler to honor the new param.

## Implementation
A new helper, `apps/mobile/lib/chat/source-location.ts`, parses the chunker's per-format chapter labels into the query params each reader honors:

- PDF / DJVU → `?page=N` (from `chapter = "Page N"` emitted by `pagesToSections` in `lib/rag/chunker.ts`)
- MOBI / AZW3 → `?chapter=N` (0-indexed for the reader store, parsed from `chapter = "Chapter N"`)
- EPUB → `?cfi=<cfi>` when the chunk carries one, otherwise `?chapter=<heading>` for best-effort TOC-label match via `goToLocation(href)`
- `chunkId` always rides along so a future highlight-on-jump pass can resolve to the exact chunk without re-touching the chat screen

The chat screen now imports `resolveReaderPathnameForBook` + `resolveSourceLocationParams` and uses the expo-router object form (`router.push({ pathname, params })`). The four reader screens (`apps/mobile/app/reader/{[id],pdf/[id],mobi/[id],djvu/[id]}.tsx`) read the new params via `useLocalSearchParams` and substitute them ahead of the saved `book.currentCfi` / `book.currentPage` on first mount only — subsequent page-turns persist normally.

The EPUB reader threads `initialCfiOverride` through `ReaderEngine` to override epubjs's `initialLocation`, plus a one-shot effect (guarded by a ref) jumps to the matching TOC entry when only a chapter label is available.

## Coordination
PR #244 (for #59) touches the same file (`apps/mobile/app/chat/[bookId].tsx`) at different lines (~700-732, PulsingDot). This PR touches only the `handleSourcePress` block (~lines 363-385) and the import block. Either can land first; the second will need a trivial rebase.

## Testability
TDD — red commit `a48877e4`, green commit `08819bed`. Two new tests:
- `__tests__/chat/source-location.test.ts` — pure parser unit (11 cases across PDF / DJVU / MOBI / AZW3 / EPUB)
- `__tests__/chat/source-press-routing.test.tsx` — extended with three integration tests asserting `router.push` is called with the expected object form for PDF / EPUB / MOBI citation taps. The three pre-existing assertions were updated to the new object form.
- `__tests__/reader/cold-start-recovery.test.ts` — regex loosened to allow trailing deps so the MOBI / DJVU loader effects can include `chapterParam` / `pageParam`.

## Local CI
typecheck: PASS  (cmd: `pnpm exec tsc --noEmit -p tsconfig.json` — 133 pre-existing errors in unrelated files; 0 in changed files; identical count before and after the green commit)
test:      PASS  (cmd: `pnpm exec jest __tests__/chat/ __tests__/reader/` — 104/104 across 21 suites)
lint:      PASS  (cmd: `pnpm run lint` — 0 errors, only pre-existing warnings; none from changed files)
format:    SKIP  (no prettier config)
build:     SKIP  (heavy)